### PR TITLE
[AAP-72146] Remove personal keycloak image references and fix ruff errors

### DIFF
--- a/aap_gateway_api/models/route.py
+++ b/aap_gateway_api/models/route.py
@@ -42,7 +42,9 @@ class Route(UniqueNamedCommonModel, AuditableModel):
     http_port = models.ForeignKey(
         HTTPPort, related_name="routes", blank=False, on_delete=models.CASCADE, help_text=_("The port on the gateway to listen to traffic on.")
     )
-    service_cluster = models.ForeignKey(ServiceCluster, related_name="routes", on_delete=models.CASCADE, help_text=_("The Ansible service to route traffic to."))
+    service_cluster = models.ForeignKey(
+        ServiceCluster, related_name="routes", on_delete=models.CASCADE, help_text=_("The Ansible service to route traffic to.")
+    )
 
     service_port = models.IntegerField(
         blank=False, validators=[MaxValueValidator(65535), MinValueValidator(1)], help_text=_("The port on the service cluster to route traffic to.")

--- a/aap_gateway_api/tests/views/api/v1/app_urls/test_app_url_data.py
+++ b/aap_gateway_api/tests/views/api/v1/app_urls/test_app_url_data.py
@@ -7,7 +7,6 @@ from rest_framework.test import APIClient
 from aap_gateway_api.models import Organization, User
 
 
-
 def mk_app(
     name="Test OAuth2 Application",
     description="Created for testing app_url API endpoint.",

--- a/tools/configs/container-startup.yml
+++ b/tools/configs/container-startup.yml
@@ -26,9 +26,6 @@ redis_tls_enabled: True
 ### Sidecars (uncomment to enable):
 # haproxy_enabled: True
 # keycloak_enabled: True
-# Uncomment this if enabling keycloak on macOS M1 or later
-# keycloak_image: quay.io/rh_ee_dtoirov/m1/keycloak
-# keycloak_image: quay.io/rh_ee_dtoirov/m1/keycloak
 # ldap_enabled: True
 # tacacs_enabled: True
 # radius_enabled: True


### PR DESCRIPTION
## Description

- **What is being changed?** Removes three commented-out lines from `tools/configs/container-startup.yml` that referenced a personal `quay.io/rh_ee_dtoirov/m1/keycloak` image (one comment and two duplicate image overrides).
- **Why is this change needed?** Personal registry references should not live in the shared example configuration; they are developer-specific and can confuse other contributors.
- **How does this change address the issue?** The lines are simply deleted, keeping the keycloak sidecar section clean and vendor-neutral.

## Type of Change
- [x] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites
- A local development environment with container-startup support.

### Steps to Test
1. Review `tools/configs/container-startup.yml` and confirm the personal `quay.io/rh_ee_dtoirov/m1/keycloak` references are gone.
2. Run the container startup process with keycloak disabled (default) — verify no errors.
3. Optionally enable keycloak and confirm it still uses the default upstream image.

### Expected Results
- The config file no longer contains any personal registry references.
- Container startup behavior is unchanged (the removed lines were commented out).

## Additional Context
No external actions required — this is a cosmetic cleanup of commented-out lines.