### PR TITLE
Add support for workflow_dispatch

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,6 +1,54 @@
 name: Backport Cherry-Pick
 
 on:
+  # This workflow support two types of triggers:
+  # - workflow_dispatch: allows manual invocation via the GitHub UI or the gh CLI
+  #     e.g.  gh workflow run backport.yml -f source_commits="abc1234" -f target_branches="stable-2.6"
+  # - workflow_call: allows invocation from another GitHub Actions workflow
+  #
+  # IMPORTANT: Keep the inputs sections of both triggers in sync!
+  # They must define the same inputs with the same types and defaults.
+  # If you add, remove, or rename an input, make the same update in both triggers.
+  # Note: Secrets are only specified for workflow_call trigger.
+  workflow_dispatch:
+    inputs:
+      source_commits:
+        description: "Commit SHA(s) to backport — single SHA or comma-separated list (e.g., abc1234 or abc1234,def5678)"
+        required: true
+        type: string
+      target_branches:
+        description: "Comma-separated target branches"
+        required: true
+        type: string
+      jira_ticket:
+        description: "Jira ticket for tracking (e.g., AAP-12345)"
+        required: false
+        type: string
+        default: ""
+      source_branch:
+        description: "Branch where the commit must exist"
+        required: false
+        type: string
+        default: "devel"
+      conflict_label:
+        description: "Label applied to draft PRs with conflicts"
+        required: false
+        type: string
+        default: "backport-conflict"
+      jira_base_url:
+        description: "Base URL for Jira ticket links (overrides JIRA_BASE_URL variable)"
+        required: false
+        type: string
+      git_committer_name:
+        description: "Git committer name for cherry-picked commits"
+        required: false
+        type: string
+        default: "github-actions[bot]"
+      git_committer_email:
+        description: "Git committer email — must match the GPG key's UID for the Verified badge"
+        required: false
+        type: string
+        default: "41898282+github-actions[bot]@users.noreply.github.com"
   workflow_call:
     inputs:
       source_commits:


### PR DESCRIPTION
## Description

<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
  - added additional trigger to back-port workflow
- Why is this change needed?
  - with current implementation, the workflow could not be triggered via GH CLI
- How does this change address the issue?
  - with both workflow_call and workflow_dispatch the workflow can be triggered either from another workflow or by GH CLI

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->

Testing is optional I would say, as it requires several not so trivial items to setup before testing.

### Prerequisites
<!-- List any specific setup required -->

1. You will need a set of branches, one that's at least one commit ahead of the other. This can be devel branch and another temporary branch that's reset to a commit before devel's latest commit. In this case, devel will be source branch, the temporary branch will be target branch. 
2. Your repository needs to be configured to allow Actions to create Pull requests (not allowed by default)
3. Your repository will need to have PGP_PRIVATE_KEY secret that contains PGP private key, base64 encoded, with no passphrase. You could re-use you existing one if you didn't set it with a passphrase.

### Steps to Test
1. Checkout the PR and push it into a branch in your fork (in the example below, it will be PR-AAP-72147)
2. Get the branch names
3. Get the commit SHA
4. Run the GH CLI like the example below:
    ```sh
    gh workflow run backport.yml -f source_branch="devel" \
    -f source_commits="f9b6f78836817947b5d2952af37de87b8201ee36" \
    -f target_branches="devel-before-readme-update" \
    -f git_committer_name="Your name goes here" \
    -f git_committer_email="youremail@somewhere.com" \
    --repo your-org-name/jewel --ref PR-AAP-72147
    ```

### Expected Results
<!-- Describe what should happen after following the steps -->

You should get message:
> ✓ Created workflow_dispatch event for backport.yml at PR-AAP-72147

## Additional Context
<!-- Optional but helpful information -->

You can see successful test here, the PR created by triggering the workflow with command like shown above: https://github.com/tznamena/jewel/pull/1