### PR TITLE
Fix workflow_call failure due to reserved GITHUB_TOKEN secret name

### DIFF
--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -35,9 +35,6 @@ on:
         required: false
         type: string
         default: ''
-    secrets:
-      GITHUB_TOKEN:
-        required: false
 permissions:
   contents: read
 jobs:
@@ -100,7 +97,7 @@ jobs:
       - name: Checkout dependencies
         env:
           PR_BODY: ${{ env.PR_BODY }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN != '' && secrets.GITHUB_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           python tools/scripts/get_pr_checkout.py \
             --always-clone-repos 'ansible/django-ansible-base' \

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -107,5 +107,3 @@ jobs:
       pr_base: ${{ github.event.pull_request.base.ref }}
       pr_head_repo: ${{ github.event.pull_request.head.repo.full_name }}
       pr_body: ${{ github.event.pull_request.body }}
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

- **What is being changed?** Removing the explicit `GITHUB_TOKEN` secret declaration from the `dev-environment.yml` reusable workflow and the corresponding secret pass-through in `sanity.yml`. Using `github.token` directly instead.
- **Why is this change needed?** GitHub Actions reserves the name `GITHUB_TOKEN` for system use. Declaring it as a `workflow_call` secret causes the workflow to fail with: *"secret name `GITHUB_TOKEN` within `workflow_call` can not be used since it would collide with system reserved name"*
- **How does this change address the issue?** `github.token` is automatically available in reusable workflows without needing to be explicitly passed as a secret, so the declaration and pass-through are unnecessary.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Development environment change

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites
A pull request against this repository to trigger the Sanity workflow.

### Steps to Test
1. Open this PR and observe the CI workflow runs
2. Verify the `Dev environment tests` job is triggered without the reserved name error
3. Confirm `get_pr_checkout.py` still has access to a valid token via the `GH_TOKEN` env var

### Expected Results
The `Dev environment tests` workflow starts and runs without the `GITHUB_TOKEN` collision error.

## Additional Context

### Required Actions
No external actions needed.

### Screenshots/Logs
N/A — the fix addresses a GitHub Actions validation error that occurs before any steps execute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reusable workflow no longer accepts a forwarded repository token; callers no longer pass that token.
  * Call sites now provide only the pull-request body input to the reusable workflow.
  * Result: more consistent token usage across workflows and reduced exposure of repository token configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->