### PR TITLE
[AAP-73441] Add auto-close PR workflow for protected branches

### DIFF
--- a/.github/workflows/auto-close-pr.yml
+++ b/.github/workflows/auto-close-pr.yml
@@ -1,0 +1,45 @@
+---
+name: Auto-Close PR
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  auto-close:
+    if: vars.AUTO_CLOSE_PR_BRANCHES != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR targets a protected branch
+        id: check
+        env:
+          PROTECTED_BRANCHES: ${{ vars.AUTO_CLOSE_PR_BRANCHES }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+        run: |
+          for branch in $PROTECTED_BRANCHES; do
+            if [ "$branch" = "$PR_BASE" ]; then
+              echo "match=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+          echo "match=false" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on PR
+        if: steps.check.outputs.match == 'true' && vars.AUTO_CLOSE_PR_MESSAGE != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MESSAGE: ${{ vars.AUTO_CLOSE_PR_MESSAGE }}
+        run: gh pr comment "$PR_NUMBER" --body "$MESSAGE"
+
+      - name: Close PR
+        if: steps.check.outputs.match == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr close "$PR_NUMBER"


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that auto-closes PRs opened against configurable protected branches
- Controlled via two repository variables: `AUTO_CLOSE_PR_BRANCHES` (space-separated branch list) and `AUTO_CLOSE_PR_MESSAGE` (optional comment before closing)
- When `AUTO_CLOSE_PR_BRANCHES` is empty or unset the workflow is a no-op, so jewel is unaffected while aap-gateway can set `devel` to block direct PRs

## Test plan
- [ ] Verify workflow is skipped when `AUTO_CLOSE_PR_BRANCHES` is not set
- [ ] Set `AUTO_CLOSE_PR_BRANCHES=devel` and open a PR against devel — confirm it is closed
- [ ] Set `AUTO_CLOSE_PR_MESSAGE` and verify the comment appears before close
- [ ] Open a PR against a non-protected branch — confirm it is left open

🤖 Generated with [Claude Code](https://claude.com/claude-code)