### PR TITLE
Use BOT PAT with fall back to github token

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,3 +1,10 @@
+# Authentication: This workflow needs write access to push branches, create PRs, and manage labels.
+# By default it uses the built-in GITHUB_TOKEN (requires org/repo settings to grant write permissions).
+# If the organization restricts the default token to read-only, pass a bot PAT via the
+# BACKPORT_BOT_PAT secret — the workflow falls back to GITHUB_TOKEN when the PAT is not provided.
+# The PAT needs fine-grained permissions: Contents (read/write), Pull requests (read/write),
+# and Issues (read/write).
+
 name: Backport Cherry-Pick
 
 on:
@@ -92,6 +99,9 @@ on:
       GPG_PRIVATE_KEY:
         description: "Base64-encoded armored GPG private key for commit signing (no passphrase)"
         required: true
+      BACKPORT_BOT_PAT:
+        description: "Bot PAT for pushing branches and creating PRs (falls back to GITHUB_TOKEN if not set)"
+        required: false
 
 jobs:
   backport:
@@ -105,6 +115,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Use bot PAT for checkout so git push uses its credentials; fall back to default token
+          token: ${{ secrets.BACKPORT_BOT_PAT || github.token }}
 
       - name: Import GPG signing key
         env:
@@ -222,7 +234,8 @@ jobs:
 
       - name: Process backports
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Use bot PAT for gh CLI (push, PR create, labels); fall back to default token
+          GH_TOKEN: ${{ secrets.BACKPORT_BOT_PAT || github.token }}
           SHA_SHORT: ${{ steps.validate.outputs.sha_short }}
           FULL_SHA_LIST: ${{ steps.validate.outputs.full_sha_list }}
           COMMIT_COUNT: ${{ steps.validate.outputs.commit_count }}


### PR DESCRIPTION
## Description

<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
  - use token provided by BACKPORT_BOT_PAT secret or fall back to using github.token
- Why is this change needed?
  - in some repositories the standard github token will not be allowed to create branches and open PRs
- How does this change address the issue?
  - by accepting the token from a secret the workflow can work in both situations

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [x] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->

Testing of this will be possible only after it is merged because testing in a fork always has usable `github.token`. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Backport workflow now accepts an optional bot personal access token (PAT) to enable write operations when available.
  * When provided, the bot PAT is preferred for repository checkout and CLI operations so backport pushes, pull requests, and label updates run with appropriate write permissions; otherwise the workflow falls back to the default token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->