### PR TITLE
AAP-68344 hub large file upload test

### DIFF
--- a/aap_gateway_api/defaults.py
+++ b/aap_gateway_api/defaults.py
@@ -118,9 +118,10 @@ DYNAMIC_PREFERENCES = {
 # This is used to make API HTTP requests from the gateway to the services that
 # are configured to run behind it for operations like syncing and migration.
 ENVOY_HOSTNAME = "localhost"
-# Since envoy buffer limits are "soft limits", this needs to be comfortably higher than GRPC_SERVER_MAX_RECEIVE_MESSAGE_LENGTH;
+# Envoy buffer limits are "soft limits". Set to 250 MiB to support large container image uploads.
+# Must be comfortably higher than GRPC_SERVER_MAX_RECEIVE_MESSAGE_LENGTH.
 # how much higher depends on network throughput, 3 MiB higher is the absolute minimum I could set without error 413s.
-ENVOY_PER_CONNECTION_BUFFER_LIMIT_BYTES = 2**20 * 25
+ENVOY_PER_CONNECTION_BUFFER_LIMIT_BYTES = 262144000  # 250 MiB
 ENVOY_VERIFY_HTTPS_CERTIFICATES = True
 
 # Set to desired external URL (load balancer, proxy, etc.)

--- a/aap_gateway_api/registered_preferences.py
+++ b/aap_gateway_api/registered_preferences.py
@@ -146,7 +146,7 @@ register(
 register(
     section="proxy",
     preference_name="idle_timeout",
-    default=600,
+    default=15,
     required=True,
     preference_type="int",
     help_text=_(

--- a/aap_gateway_api/registered_preferences.py
+++ b/aap_gateway_api/registered_preferences.py
@@ -146,7 +146,7 @@ register(
 register(
     section="proxy",
     preference_name="idle_timeout",
-    default=15,
+    default=600,
     required=True,
     preference_type="int",
     help_text=_(


### PR DESCRIPTION
## Description

  Increase `ENVOY_PER_CONNECTION_BUFFER_LIMIT_BYTES` from 25 MiB (default) to 250 MiB to support container image uploads >4GB.

  **What is being changed?**
  - `ENVOY_PER_CONNECTION_BUFFER_LIMIT_BYTES` increased from default `2**20 * 25` (25 MiB) to `262144000` (250 MiB)
  - Updated comments to clarify buffer limit requirements and network throughput considerations

  **Why is this change needed?**
  Container image uploads to Hub were failing with HTTP 413 errors when OCI distribution PATCH requests contained chunks that exceeded envoy's per-connection buffer limit. This prevented users from uploading large container images (>4GB).

  **How does this change address the issue?**
  Envoy's per-connection buffer limit is a "soft limit" that buffers request data before proxying. The default 25 MiB was insufficient for large chunked uploads. Increasing to 250 MiB allows the buffer to accommodate larger chunks while still being well above the GRPC_SERVER_MAX_RECEIVE_MESSAGE_LENGTH requirement.

  ## Type of Change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] Configuration change

  ## Self-Review Checklist
  - [x] I have performed a self-review of my code
  - [x] I have added relevant comments to complex code sections
  - [x] I have considered the security impact of these changes
  - [x] I have considered performance implications
  - [x] I have thought about error handling and edge cases
  - [x] I have tested the changes in my local environment

  ## Testing Instructions

  ### Prerequisites
  - AAP containerized installer environment with Hub configured
  - Access to push large container images (>4GB)

  ### Steps to Test
  1. Deploy Gateway with the updated `ENVOY_PER_CONNECTION_BUFFER_LIMIT_BYTES` setting
  2. Push a container image >4GB to the Hub registry
  3. Verify upload completes successfully without 413 errors

  ### Expected Results
  - Large container image uploads complete successfully
  - No HTTP 413 (Request Entity Too Large) errors in envoy logs
  - Container image is accessible after push

  ### Related Changes
  This PR also includes an earlier commit (25d23ac) that increased `proxy_idle_timeout` from 15s to 600s, which works in conjunction with the buffer limit increase to support long-running
   large uploads.

  **Resolves:** AAP-68344