### PR TITLE
AAP-73002: Fix OpenAPI schema for authenticator_users move endpoint

### DIFF
--- a/aap_gateway_api/views/api/v1/authenticator_user.py
+++ b/aap_gateway_api/views/api/v1/authenticator_user.py
@@ -6,6 +6,7 @@ from ansible_base.lib.utils.views.permissions import IsSuperuserOrAuditor
 from ansible_base.oauth2_provider.permissions import OAuth2ScopePermission
 from django.db import transaction
 from django.utils.translation import gettext_lazy as _
+from drf_spectacular.utils import extend_schema
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
@@ -26,6 +27,10 @@ class AuthenticatorUserViewSet(GatewayReadOnlyModelViewSet):
     serializer_class = AuthenticatorUserSerializer
     permission_classes = [OAuth2ScopePermission, IsSuperuserOrAuditor]
 
+    @extend_schema(
+        request=AuthenticatorUserMoveSerializer,
+        responses={200: AuthenticatorUserSerializer},
+    )
     @action(detail=True, methods=['post'], serializer_class=AuthenticatorUserMoveSerializer)
     @transaction.atomic
     def move(self, request, pk=None):


### PR DESCRIPTION
## Summary

- Add `@extend_schema` annotation to the `AuthenticatorUserViewSet.move` action to correctly declare the response type in the OpenAPI schema.
- Without this annotation, drf-spectacular defaults to using `AuthenticatorUserMoveSerializer` (from `@action(serializer_class=...)`) for **both** request and response. The endpoint actually returns an `AuthenticatorUser` object (line 87-88), so the generated spec was wrong.
- This caused the ATF-generated API client to fail with `KeyError: 'new_authenticator'` when parsing the 200 response, breaking `test_gateway_login_with_local_accounts_from_different_services` in the RPM-B Tier 3 upgrade pipeline.

## Test plan

- [x] Verified with a standalone drf-spectacular schema generation test that:
  - Without `@extend_schema`: response `$ref` → `AuthenticatorUserMove` (wrong)
  - With this fix: response `$ref` → `AuthenticatorUser` (correct)
- [ ] Once merged and spec synced to ATF, the generated client will correctly parse move responses as `AuthenticatorUser`
- [ ] CI pipeline `test_gateway_login_with_local_accounts_from_different_services` should pass

Fixes: AAP-73002