### PR TITLE
[AAP-72446] [devel backport] CVE-2026-6266: Enforce email change policy and restrict reverse-sync

### DIFF
--- a/aap_gateway_api/management/commands/detect_changed_emails.py
+++ b/aap_gateway_api/management/commands/detect_changed_emails.py
@@ -10,6 +10,7 @@ With --audit, performs a full security analysis including authenticator
 linkage checks, duplicate detection, and high-risk scoring.
 """
 
+import logging
 from collections import defaultdict
 
 from ansible_base.activitystream.models import Entry
@@ -18,6 +19,8 @@ from ansible_base.authentication.models import AuthenticatorUser
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand
+
+logger = logging.getLogger(__name__)
 
 User = get_user_model()
 
@@ -133,6 +136,7 @@ class Command(BaseCommand):
             plugin = get_authenticator_plugin(au.provider.type)
             auth_type = plugin.type
         except Exception:
+            logger.debug("Could not classify authenticator %s (type=%s), defaulting to 'unknown'", au.provider.name, au.provider.type)
             auth_type = "unknown"
         return "local" if auth_type == "local" else "external"
 

--- a/aap_gateway_api/management/commands/detect_changed_emails.py
+++ b/aap_gateway_api/management/commands/detect_changed_emails.py
@@ -1,16 +1,13 @@
 """
-Email Hijack Detection Command for AAP Gateway
+Detect Changed Emails Command for AAP Gateway
 
-Usage: python manage.py detect_email_hijack
+Usage:
+    aap-gateway-manage detect_changed_emails
+    aap-gateway-manage detect_changed_emails --audit
 
-Detects potential email hijacking by analyzing:
-  1. Activity stream for email changes
-  2. Users with both local and external authenticators
-  3. AuthenticatorUser.email vs User.email mismatches
-  4. Duplicate emails across users
-  5. Email changes made by non-superuser actors
-  6. Email changes where the new email matched another user
-  7. High-risk combo: email changed + dual authenticators
+Default mode shows email changes from the activity stream.
+With --audit, performs a full security analysis including authenticator
+linkage checks, duplicate detection, and high-risk scoring.
 """
 
 from collections import defaultdict
@@ -25,11 +22,18 @@ from django.core.management.base import BaseCommand
 User = get_user_model()
 
 SEPARATOR = "=" * 90
-SUB_SEPARATOR = "-" * 90
 
 
 class Command(BaseCommand):
-    help = "Detect potential email hijacking by scanning the activity stream and authenticator linkages."
+    help = "Detect email changes from the activity stream. Use --audit for full security analysis."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--audit',
+            action='store_true',
+            dest='audit',
+            help='Run full security audit: authenticator linkage, duplicates, and high-risk scoring.',
+        )
 
     def header(self, title):
         self.stdout.write(f"\n{SEPARATOR}")
@@ -37,23 +41,20 @@ class Command(BaseCommand):
         self.stdout.write(SEPARATOR)
 
     def handle(self, *args, **options):
+        audit = options['audit']
         email_changes = self._check_activity_stream()
-        dual_auth_users = self._check_dual_authenticators(
-            email_changes,
-        )
+
+        if not audit:
+            self._print_summary_basic(email_changes)
+            return
+
+        dual_auth_users = self._check_dual_authenticators(email_changes)
         mismatches = self._check_email_mismatches()
         duplicates = self._check_duplicate_emails()
-        non_super = self._check_non_superuser_changes(
-            email_changes,
-        )
-        suspicious = self._check_email_matches_other_user(
-            email_changes,
-        )
-        high_risk = self._check_high_risk_combo(
-            email_changes,
-            dual_auth_users,
-        )
-        self._print_summary(
+        non_super = self._check_non_superuser_changes(email_changes)
+        suspicious = self._check_email_matches_other_user(email_changes)
+        high_risk = self._check_high_risk_combo(email_changes, dual_auth_users)
+        self._print_summary_full(
             email_changes,
             dual_auth_users,
             mismatches,
@@ -64,10 +65,10 @@ class Command(BaseCommand):
         )
 
     # -----------------------------------------------------------------
-    # 1. Activity stream email changes
+    # Activity stream email changes (always shown)
     # -----------------------------------------------------------------
     def _check_activity_stream(self):
-        self.header("1. ACTIVITY STREAM: ALL EMAIL CHANGES ON USER OBJECTS")
+        self.header("EMAIL CHANGES IN ACTIVITY STREAM")
         user_ct = ContentType.objects.get_for_model(User)
         entries = (
             Entry.objects.filter(
@@ -81,7 +82,7 @@ class Command(BaseCommand):
 
         records = []
         if not entries.exists():
-            self.stdout.write("\n  No email changes found in the activity stream.")
+            self.stdout.write("\n  No email changes found in the activity stream.\n")
             return records
 
         self.stdout.write(f"\n  Found {entries.count()} email change(s):\n")
@@ -124,20 +125,15 @@ class Command(BaseCommand):
         return records
 
     # -----------------------------------------------------------------
-    # 2. Users with both local and external authenticators
+    # Audit-only checks below
     # -----------------------------------------------------------------
     def _check_dual_authenticators(self, email_changes):
-        self.header("2. USERS WITH LOCAL + EXTERNAL AUTHENTICATORS")
+        self.header("USERS WITH LOCAL + EXTERNAL AUTHENTICATORS")
         users_with_auth = defaultdict(lambda: {"local": [], "external": []})
-        auth_users = AuthenticatorUser.objects.select_related(
-            "user",
-            "provider",
-        ).all()
+        auth_users = AuthenticatorUser.objects.select_related("user", "provider").all()
         for au in auth_users:
             try:
-                plugin = get_authenticator_plugin(
-                    au.provider.type,
-                )
+                plugin = get_authenticator_plugin(au.provider.type)
                 auth_type = plugin.type
             except Exception:
                 auth_type = "unknown"
@@ -179,17 +175,11 @@ class Command(BaseCommand):
 
         return dual
 
-    # -----------------------------------------------------------------
-    # 3. AuthenticatorUser.email vs User.email mismatches
-    # -----------------------------------------------------------------
     def _check_email_mismatches(self):
-        self.header("3. AUTHENTICATOR EMAIL vs USER EMAIL MISMATCHES")
+        self.header("AUTHENTICATOR EMAIL vs USER EMAIL MISMATCHES")
         mismatches = []
         qs = (
-            AuthenticatorUser.objects.select_related(
-                "user",
-                "provider",
-            )
+            AuthenticatorUser.objects.select_related("user", "provider")
             .exclude(email__isnull=True)
             .exclude(email="")
         )
@@ -210,16 +200,11 @@ class Command(BaseCommand):
 
         return mismatches
 
-    # -----------------------------------------------------------------
-    # 4. Duplicate emails across users
-    # -----------------------------------------------------------------
     def _check_duplicate_emails(self):
-        self.header("4. DUPLICATE EMAILS ACROSS USERS")
+        self.header("DUPLICATE EMAILS ACROSS USERS")
 
         email_to_users = defaultdict(list)
-        qs = User.all_objects.exclude(
-            email__isnull=True,
-        ).exclude(email="")
+        qs = User.all_objects.exclude(email__isnull=True).exclude(email="")
         for u in qs:
             email_to_users[u.email.lower()].append(u)
 
@@ -238,11 +223,8 @@ class Command(BaseCommand):
 
         return dupes
 
-    # -----------------------------------------------------------------
-    # 5. Email changes by non-superuser actors
-    # -----------------------------------------------------------------
     def _check_non_superuser_changes(self, email_changes):
-        self.header("5. EMAIL CHANGES BY NON-SUPERUSER ACTORS")
+        self.header("EMAIL CHANGES BY NON-SUPERUSER ACTORS")
         non_super = [r for r in email_changes if r["actor_is_super"] is False]
 
         if not non_super:
@@ -260,11 +242,8 @@ class Command(BaseCommand):
 
         return non_super
 
-    # -----------------------------------------------------------------
-    # 6. Email changed to match another user
-    # -----------------------------------------------------------------
     def _check_email_matches_other_user(self, email_changes):
-        self.header("6. EMAIL CHANGES THAT MATCHED ANOTHER EXISTING USER'S EMAIL")
+        self.header("EMAIL CHANGES THAT MATCHED ANOTHER EXISTING USER'S EMAIL")
         suspicious = []
         for r in email_changes:
             if not r["new_email"]:
@@ -291,15 +270,8 @@ class Command(BaseCommand):
 
         return suspicious
 
-    # -----------------------------------------------------------------
-    # 7. High-risk: email changed + dual authenticators
-    # -----------------------------------------------------------------
-    def _check_high_risk_combo(
-        self,
-        email_changes,
-        dual_auth_users,
-    ):
-        self.header("7. HIGH-RISK: EMAIL CHANGED + LOCAL+EXTERNAL AUTHENTICATORS")
+    def _check_high_risk_combo(self, email_changes, dual_auth_users):
+        self.header("HIGH-RISK: EMAIL CHANGED + LOCAL+EXTERNAL AUTHENTICATORS")
         high_risk = [r for r in email_changes if r["target_user"] and r["target_user"].pk in dual_auth_users]
 
         if not high_risk:
@@ -323,9 +295,17 @@ class Command(BaseCommand):
         return high_risk
 
     # -----------------------------------------------------------------
-    # Summary
+    # Summaries
     # -----------------------------------------------------------------
-    def _print_summary(
+    def _print_summary_basic(self, email_changes):
+        self.stdout.write(f"  Total email changes found: {len(email_changes)}")
+        non_super = [r for r in email_changes if r["actor_is_super"] is False]
+        if non_super:
+            self.stdout.write(f"  Of which {len(non_super)} were by non-superuser actors.")
+            self.stdout.write("\n  Run with --audit for full security analysis.")
+        self.stdout.write(f"\n{SEPARATOR}\n")
+
+    def _print_summary_full(
         self,
         email_changes,
         dual_auth_users,
@@ -335,7 +315,7 @@ class Command(BaseCommand):
         suspicious,
         high_risk,
     ):
-        self.header("SUMMARY")
+        self.header("AUDIT SUMMARY")
         self.stdout.write(f"\n  Total email changes in activity stream:      {len(email_changes)}")
         self.stdout.write(f"  Users with local + external auth:             {len(dual_auth_users)}")
         self.stdout.write(f"  AuthUser vs User email mismatches:            {len(mismatches)}")

--- a/aap_gateway_api/management/commands/detect_changed_emails.py
+++ b/aap_gateway_api/management/commands/detect_changed_emails.py
@@ -127,28 +127,41 @@ class Command(BaseCommand):
     # -----------------------------------------------------------------
     # Audit-only checks below
     # -----------------------------------------------------------------
+    @staticmethod
+    def _classify_authenticator(au):
+        try:
+            plugin = get_authenticator_plugin(au.provider.type)
+            auth_type = plugin.type
+        except Exception:
+            auth_type = "unknown"
+        return "local" if auth_type == "local" else "external"
+
+    @staticmethod
+    def _build_auth_map():
+        users_with_auth = defaultdict(lambda: {"local": [], "external": []})
+        for au in AuthenticatorUser.objects.select_related("user", "provider").all():
+            bucket = Command._classify_authenticator(au)
+            users_with_auth[au.user_id][bucket].append({"name": au.provider.name, "type": au.provider.type, "uid": au.uid, "email": au.email})
+        return {uid: data for uid, data in users_with_auth.items() if data["local"] and data["external"]}
+
+    def _print_dual_user(self, user_id, data, changed_pks):
+        try:
+            u = User.all_objects.get(pk=user_id)
+            uname, uemail = u.username, u.email
+        except User.DoesNotExist:
+            uname, uemail = f"[DELETED pk={user_id}]", "N/A"
+
+        flag = " *** EMAIL WAS CHANGED ***" if user_id in changed_pks else ""
+        self.stdout.write(f"  User: {uname} (pk={user_id}, email={uemail}){flag}")
+        for a in data["local"]:
+            self.stdout.write(f"    [LOCAL]    {a['name']} | uid={a['uid']} | auth_email={a['email']}")
+        for a in data["external"]:
+            self.stdout.write(f"    [EXTERNAL] {a['name']} ({a['type']}) | uid={a['uid']} | auth_email={a['email']}")
+        self.stdout.write("")
+
     def _check_dual_authenticators(self, email_changes):
         self.header("USERS WITH LOCAL + EXTERNAL AUTHENTICATORS")
-        users_with_auth = defaultdict(lambda: {"local": [], "external": []})
-        auth_users = AuthenticatorUser.objects.select_related("user", "provider").all()
-        for au in auth_users:
-            try:
-                plugin = get_authenticator_plugin(au.provider.type)
-                auth_type = plugin.type
-            except Exception:
-                auth_type = "unknown"
-
-            bucket = "local" if auth_type == "local" else "external"
-            users_with_auth[au.user_id][bucket].append(
-                {
-                    "name": au.provider.name,
-                    "type": au.provider.type,
-                    "uid": au.uid,
-                    "email": au.email,
-                }
-            )
-
-        dual = {uid: data for uid, data in users_with_auth.items() if data["local"] and data["external"]}
+        dual = self._build_auth_map()
 
         if not dual:
             self.stdout.write("\n  No users found with both local and external authenticators.")
@@ -157,32 +170,14 @@ class Command(BaseCommand):
         self.stdout.write(f"\n  Found {len(dual)} user(s) with both local and external authenticators:\n")
         changed_pks = {r["target_user"].pk for r in email_changes if r["target_user"]}
         for user_id, data in dual.items():
-            try:
-                u = User.all_objects.get(pk=user_id)
-                uname = u.username
-                uemail = u.email
-            except User.DoesNotExist:
-                uname = f"[DELETED pk={user_id}]"
-                uemail = "N/A"
-
-            flag = " *** EMAIL WAS CHANGED ***" if user_id in changed_pks else ""
-            self.stdout.write(f"  User: {uname} (pk={user_id}, email={uemail}){flag}")
-            for a in data["local"]:
-                self.stdout.write(f"    [LOCAL]    {a['name']} | uid={a['uid']} | auth_email={a['email']}")
-            for a in data["external"]:
-                self.stdout.write(f"    [EXTERNAL] {a['name']} ({a['type']}) | uid={a['uid']} | auth_email={a['email']}")
-            self.stdout.write("")
+            self._print_dual_user(user_id, data, changed_pks)
 
         return dual
 
     def _check_email_mismatches(self):
         self.header("AUTHENTICATOR EMAIL vs USER EMAIL MISMATCHES")
         mismatches = []
-        qs = (
-            AuthenticatorUser.objects.select_related("user", "provider")
-            .exclude(email__isnull=True)
-            .exclude(email="")
-        )
+        qs = AuthenticatorUser.objects.select_related("user", "provider").exclude(email__isnull=True).exclude(email="")
         for au in qs:
             if au.user.email and au.email and au.email.lower() != au.user.email.lower():
                 mismatches.append(au)

--- a/aap_gateway_api/management/commands/detect_email_hijack.py
+++ b/aap_gateway_api/management/commands/detect_email_hijack.py
@@ -1,0 +1,353 @@
+"""
+Email Hijack Detection Command for AAP Gateway
+
+Usage: python manage.py detect_email_hijack
+
+Detects potential email hijacking by analyzing:
+  1. Activity stream for email changes
+  2. Users with both local and external authenticators
+  3. AuthenticatorUser.email vs User.email mismatches
+  4. Duplicate emails across users
+  5. Email changes made by non-superuser actors
+  6. Email changes where the new email matched another user
+  7. High-risk combo: email changed + dual authenticators
+"""
+
+from collections import defaultdict
+
+from ansible_base.activitystream.models import Entry
+from ansible_base.authentication.authenticator_plugins.utils import get_authenticator_plugin
+from ansible_base.authentication.models import AuthenticatorUser
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.core.management.base import BaseCommand
+
+User = get_user_model()
+
+SEPARATOR = "=" * 90
+SUB_SEPARATOR = "-" * 90
+
+
+class Command(BaseCommand):
+    help = "Detect potential email hijacking by scanning the activity stream and authenticator linkages."
+
+    def header(self, title):
+        self.stdout.write(f"\n{SEPARATOR}")
+        self.stdout.write(f"  {title}")
+        self.stdout.write(SEPARATOR)
+
+    def handle(self, *args, **options):
+        email_changes = self._check_activity_stream()
+        dual_auth_users = self._check_dual_authenticators(
+            email_changes,
+        )
+        mismatches = self._check_email_mismatches()
+        duplicates = self._check_duplicate_emails()
+        non_super = self._check_non_superuser_changes(
+            email_changes,
+        )
+        suspicious = self._check_email_matches_other_user(
+            email_changes,
+        )
+        high_risk = self._check_high_risk_combo(
+            email_changes,
+            dual_auth_users,
+        )
+        self._print_summary(
+            email_changes,
+            dual_auth_users,
+            mismatches,
+            duplicates,
+            non_super,
+            suspicious,
+            high_risk,
+        )
+
+    # -----------------------------------------------------------------
+    # 1. Activity stream email changes
+    # -----------------------------------------------------------------
+    def _check_activity_stream(self):
+        self.header("1. ACTIVITY STREAM: ALL EMAIL CHANGES ON USER OBJECTS")
+        user_ct = ContentType.objects.get_for_model(User)
+        entries = (
+            Entry.objects.filter(
+                content_type=user_ct,
+                operation="update",
+                changes__changed_fields__has_key="email",
+            )
+            .select_related("created_by")
+            .order_by("created")
+        )
+
+        records = []
+        if not entries.exists():
+            self.stdout.write("\n  No email changes found in the activity stream.")
+            return records
+
+        self.stdout.write(f"\n  Found {entries.count()} email change(s):\n")
+        for entry in entries:
+            old_email, new_email = entry.changes["changed_fields"]["email"]
+            actor = entry.created_by
+            actor_name = actor.username if actor else "SYSTEM/UNKNOWN"
+            actor_is_super = actor.is_superuser if actor else None
+
+            try:
+                target = User.all_objects.get(pk=entry.object_id)
+                target_name = target.username
+            except User.DoesNotExist:
+                target = None
+                target_name = f"[DELETED user pk={entry.object_id}]"
+
+            record = {
+                "entry": entry,
+                "old_email": old_email,
+                "new_email": new_email,
+                "actor": actor,
+                "actor_name": actor_name,
+                "actor_is_super": actor_is_super,
+                "target_user": target,
+                "target_name": target_name,
+                "timestamp": entry.created,
+            }
+            records.append(record)
+
+            is_self = actor and target and actor.pk == target.pk
+            flag = " [SELF-EDIT]" if is_self else ""
+            if actor_is_super is False:
+                flag += " [NON-SUPERUSER ACTOR]"
+
+            self.stdout.write(f"  [{entry.created}] {actor_name} changed {target_name}'s email{flag}")
+            self.stdout.write(f"    Old: {old_email or '(empty)'}")
+            self.stdout.write(f"    New: {new_email or '(empty)'}")
+            self.stdout.write("")
+
+        return records
+
+    # -----------------------------------------------------------------
+    # 2. Users with both local and external authenticators
+    # -----------------------------------------------------------------
+    def _check_dual_authenticators(self, email_changes):
+        self.header("2. USERS WITH LOCAL + EXTERNAL AUTHENTICATORS")
+        users_with_auth = defaultdict(lambda: {"local": [], "external": []})
+        auth_users = AuthenticatorUser.objects.select_related(
+            "user",
+            "provider",
+        ).all()
+        for au in auth_users:
+            try:
+                plugin = get_authenticator_plugin(
+                    au.provider.type,
+                )
+                auth_type = plugin.type
+            except Exception:
+                auth_type = "unknown"
+
+            bucket = "local" if auth_type == "local" else "external"
+            users_with_auth[au.user_id][bucket].append(
+                {
+                    "name": au.provider.name,
+                    "type": au.provider.type,
+                    "uid": au.uid,
+                    "email": au.email,
+                }
+            )
+
+        dual = {uid: data for uid, data in users_with_auth.items() if data["local"] and data["external"]}
+
+        if not dual:
+            self.stdout.write("\n  No users found with both local and external authenticators.")
+            return dual
+
+        self.stdout.write(f"\n  Found {len(dual)} user(s) with both local and external authenticators:\n")
+        changed_pks = {r["target_user"].pk for r in email_changes if r["target_user"]}
+        for user_id, data in dual.items():
+            try:
+                u = User.all_objects.get(pk=user_id)
+                uname = u.username
+                uemail = u.email
+            except User.DoesNotExist:
+                uname = f"[DELETED pk={user_id}]"
+                uemail = "N/A"
+
+            flag = " *** EMAIL WAS CHANGED ***" if user_id in changed_pks else ""
+            self.stdout.write(f"  User: {uname} (pk={user_id}, email={uemail}){flag}")
+            for a in data["local"]:
+                self.stdout.write(f"    [LOCAL]    {a['name']} | uid={a['uid']} | auth_email={a['email']}")
+            for a in data["external"]:
+                self.stdout.write(f"    [EXTERNAL] {a['name']} ({a['type']}) | uid={a['uid']} | auth_email={a['email']}")
+            self.stdout.write("")
+
+        return dual
+
+    # -----------------------------------------------------------------
+    # 3. AuthenticatorUser.email vs User.email mismatches
+    # -----------------------------------------------------------------
+    def _check_email_mismatches(self):
+        self.header("3. AUTHENTICATOR EMAIL vs USER EMAIL MISMATCHES")
+        mismatches = []
+        qs = (
+            AuthenticatorUser.objects.select_related(
+                "user",
+                "provider",
+            )
+            .exclude(email__isnull=True)
+            .exclude(email="")
+        )
+        for au in qs:
+            if au.user.email and au.email and au.email.lower() != au.user.email.lower():
+                mismatches.append(au)
+
+        if not mismatches:
+            self.stdout.write("\n  No mismatches found between AuthenticatorUser.email and User.email.")
+            return mismatches
+
+        self.stdout.write(f"\n  Found {len(mismatches)} mismatch(es):\n")
+        for au in mismatches:
+            self.stdout.write(f"  User: {au.user.username} (pk={au.user.pk})")
+            self.stdout.write(f"    User.email:              {au.user.email}")
+            self.stdout.write(f"    AuthenticatorUser.email:  {au.email}  (authenticator: {au.provider.name})")
+            self.stdout.write("")
+
+        return mismatches
+
+    # -----------------------------------------------------------------
+    # 4. Duplicate emails across users
+    # -----------------------------------------------------------------
+    def _check_duplicate_emails(self):
+        self.header("4. DUPLICATE EMAILS ACROSS USERS")
+
+        email_to_users = defaultdict(list)
+        qs = User.all_objects.exclude(
+            email__isnull=True,
+        ).exclude(email="")
+        for u in qs:
+            email_to_users[u.email.lower()].append(u)
+
+        dupes = {email: users for email, users in email_to_users.items() if len(users) > 1}
+
+        if not dupes:
+            self.stdout.write("\n  No duplicate emails found across users.")
+            return dupes
+
+        self.stdout.write(f"\n  Found {len(dupes)} email(s) shared by multiple users:\n")
+        for email, users in dupes.items():
+            self.stdout.write(f"  Email: {email}")
+            for u in users:
+                self.stdout.write(f"    - {u.username} (pk={u.pk}, is_superuser={u.is_superuser})")
+            self.stdout.write("")
+
+        return dupes
+
+    # -----------------------------------------------------------------
+    # 5. Email changes by non-superuser actors
+    # -----------------------------------------------------------------
+    def _check_non_superuser_changes(self, email_changes):
+        self.header("5. EMAIL CHANGES BY NON-SUPERUSER ACTORS")
+        non_super = [r for r in email_changes if r["actor_is_super"] is False]
+
+        if not non_super:
+            self.stdout.write("\n  No email changes by non-superuser actors found.")
+            return non_super
+
+        self.stdout.write(f"\n  Found {len(non_super)} email change(s) by non-superuser actors:\n")
+        for r in non_super:
+            is_self = r["actor"] and r["target_user"] and r["actor"].pk == r["target_user"].pk
+            edit_type = "SELF-EDIT" if is_self else "EDITED ANOTHER USER"
+            self.stdout.write(f"  [{r['timestamp']}] Actor: {r['actor_name']} ({edit_type})")
+            self.stdout.write(f"    Target: {r['target_name']}")
+            self.stdout.write(f"    {r['old_email'] or '(empty)'} -> {r['new_email'] or '(empty)'}")
+            self.stdout.write("")
+
+        return non_super
+
+    # -----------------------------------------------------------------
+    # 6. Email changed to match another user
+    # -----------------------------------------------------------------
+    def _check_email_matches_other_user(self, email_changes):
+        self.header("6. EMAIL CHANGES THAT MATCHED ANOTHER EXISTING USER'S EMAIL")
+        suspicious = []
+        for r in email_changes:
+            if not r["new_email"]:
+                continue
+            others = User.all_objects.filter(
+                email__iexact=r["new_email"],
+            ).exclude(pk=r["entry"].object_id)
+            if others.exists():
+                suspicious.append((r, list(others)))
+
+        if not suspicious:
+            self.stdout.write("\n  No email changes resulted in a match with another user's current email.")
+            self.stdout.write("  (Note: checks current state; the match may have existed only at the time of change.)")
+            return suspicious
+
+        self.stdout.write(f"\n  Found {len(suspicious)} suspicious match(es):\n")
+        for r, matched_users in suspicious:
+            self.stdout.write(f"  [{r['timestamp']}] {r['actor_name']} changed {r['target_name']}'s email")
+            self.stdout.write(f"    New email: {r['new_email']}")
+            self.stdout.write("    MATCHES these other users:")
+            for mu in matched_users:
+                self.stdout.write(f"      - {mu.username} (pk={mu.pk})")
+            self.stdout.write("")
+
+        return suspicious
+
+    # -----------------------------------------------------------------
+    # 7. High-risk: email changed + dual authenticators
+    # -----------------------------------------------------------------
+    def _check_high_risk_combo(
+        self,
+        email_changes,
+        dual_auth_users,
+    ):
+        self.header("7. HIGH-RISK: EMAIL CHANGED + LOCAL+EXTERNAL AUTHENTICATORS")
+        high_risk = [r for r in email_changes if r["target_user"] and r["target_user"].pk in dual_auth_users]
+
+        if not high_risk:
+            self.stdout.write("\n  No high-risk combinations found.")
+            return high_risk
+
+        self.stdout.write(f"\n  Found {len(high_risk)} high-risk user(s):\n")
+        for r in high_risk:
+            uid = r["target_user"].pk
+            data = dual_auth_users[uid]
+            self.stdout.write(f"  [{r['timestamp']}] {r['target_name']} (pk={uid})")
+            self.stdout.write(f"    Email changed: {r['old_email'] or '(empty)'} -> {r['new_email'] or '(empty)'}")
+            self.stdout.write(f"    Changed by: {r['actor_name']} (superuser={r['actor_is_super']})")
+            self.stdout.write("    Authenticators:")
+            for a in data["local"]:
+                self.stdout.write(f"      [LOCAL]    {a['name']} | uid={a['uid']}")
+            for a in data["external"]:
+                self.stdout.write(f"      [EXTERNAL] {a['name']} | uid={a['uid']}")
+            self.stdout.write("")
+
+        return high_risk
+
+    # -----------------------------------------------------------------
+    # Summary
+    # -----------------------------------------------------------------
+    def _print_summary(
+        self,
+        email_changes,
+        dual_auth_users,
+        mismatches,
+        duplicates,
+        non_super,
+        suspicious,
+        high_risk,
+    ):
+        self.header("SUMMARY")
+        self.stdout.write(f"\n  Total email changes in activity stream:      {len(email_changes)}")
+        self.stdout.write(f"  Users with local + external auth:             {len(dual_auth_users)}")
+        self.stdout.write(f"  AuthUser vs User email mismatches:            {len(mismatches)}")
+        self.stdout.write(f"  Duplicate emails across users:                {len(duplicates)}")
+        self.stdout.write(f"  Email changes by non-superusers:              {len(non_super)}")
+        self.stdout.write(f"  Email changes matching another user:          {len(suspicious)}")
+        self.stdout.write(f"  High-risk (changed email + dual auth):        {len(high_risk)}")
+        self.stdout.write("")
+
+        if any([non_super, suspicious, high_risk]):
+            self.stdout.write("  *** POTENTIAL ISSUES DETECTED - REVIEW FLAGGED ITEMS ABOVE ***")
+        else:
+            self.stdout.write("  No obvious indicators of email hijacking detected.")
+
+        self.stdout.write(f"\n{SEPARATOR}\n")

--- a/aap_gateway_api/models/user.py
+++ b/aap_gateway_api/models/user.py
@@ -45,6 +45,7 @@ def password_is_usable(password):
 class User(AbstractDABUser, CommonModel, AuditableModel):
     # Enable audit log for this model
     audit_log_enabled = True
+    EMAIL_ENFORCEMENT_VIA_SERIALIZER = True
 
     ignore_relations = [
         'groups',  # not using the auth app stuff, see Team model

--- a/aap_gateway_api/models/user.py
+++ b/aap_gateway_api/models/user.py
@@ -45,6 +45,14 @@ def password_is_usable(password):
 class User(AbstractDABUser, CommonModel, AuditableModel):
     # Enable audit log for this model
     audit_log_enabled = True
+
+    # Gateway enforces email-change policy in its own serializer
+    # (_validate_email_change) and in GetOrCreateProcessor for
+    # reverse-sync.  The ORM-level pre_save signal must be
+    # disabled because Gateway's SSO authentication pipeline
+    # updates user emails via direct ORM saves where CRUM has no
+    # requesting user set (mid-authentication), which would
+    # conflict with the signal's permission checks.
     EMAIL_ENFORCEMENT_VIA_SERIALIZER = True
 
     ignore_relations = [

--- a/aap_gateway_api/resource_api.py
+++ b/aap_gateway_api/resource_api.py
@@ -37,6 +37,9 @@ def _get_gateway_serializer_map():
     return _GATEWAY_SERIALIZER_MAP
 
 
+_SENSITIVE_FIELDS = frozenset({'email', 'is_superuser', 'is_staff'})
+
+
 class _SyncRequest:
     """Minimal request-like object that carries just enough
     context for Gateway serializers during resource-registry
@@ -47,6 +50,9 @@ class _SyncRequest:
         self.method = 'PATCH'
         self.data = {}
 
+    def __getattr__(self, name):
+        return None
+
 
 class GetOrCreateProcessor(ResourceTypeProcessor):
     def _validate_via_gateway_serializer(self, validated_data):
@@ -55,9 +61,8 @@ class GetOrCreateProcessor(ResourceTypeProcessor):
         reverse-sync payloads (email restrictions, field
         permissions, etc.).
 
-        Fields that fail validation are silently stripped from
-        validated_data and logged so the rest of the sync still
-        succeeds.
+        Fields that fail validation are stripped (with a warning
+        log) so the rest of the sync still succeeds.
         """
         if self.instance.pk is None:
             return
@@ -83,20 +88,35 @@ class GetOrCreateProcessor(ResourceTypeProcessor):
                 return
         except Exception:
             logger.exception(
-                "Unexpected error validating resource-registry payload for %s pk=%s; allowing update to proceed unfiltered.",
+                "Unexpected error validating resource-registry payload for %s pk=%s; stripping sensitive fields.",
                 self.instance.__class__.__name__,
                 self.instance.pk,
             )
+            for field in _SENSITIVE_FIELDS:
+                validated_data.pop(field, None)
+            return
+
+        if 'non_field_errors' in ser.errors:
+            logger.error(
+                "Cross-field validation failed for %s (pk=%s) via resource registry.  Requesting user: %s.  Errors: %s.  Clearing validated_data.",
+                self.instance.__class__.__name__,
+                self.instance.pk,
+                user,
+                ser.errors['non_field_errors'],
+            )
+            validated_data.clear()
             return
 
         for field_name, errors in ser.errors.items():
             if field_name in validated_data:
-                logger.warning(
-                    "Blocked field '%s' on %s (pk=%s) via resource registry.  Requesting user: %s.  Errors: %s",
+                log_fn = logger.error if field_name in _SENSITIVE_FIELDS else logger.warning
+                log_fn(
+                    "Blocked field '%s' on %s (pk=%s) via resource registry.  Requesting user: %s.  Attempted value: %r.  Errors: %s",
                     field_name,
                     self.instance.__class__.__name__,
                     self.instance.pk,
                     user,
+                    validated_data[field_name],
                     errors,
                 )
                 del validated_data[field_name]
@@ -107,17 +127,13 @@ class GetOrCreateProcessor(ResourceTypeProcessor):
         validated_data.
 
         If ``is_new`` is True (POST) this tries to find an
-        existing object by unique fields; if found it updates,
-        otherwise creates.
+        existing object by unique fields; if found it updates
+        (with validation), otherwise creates via
+        ``update_or_create`` without Gateway serializer
+        validation (new objects have no prior state to protect).
 
-        If ``is_new`` is False (PUT/PATCH) it sets the fields
-        directly.
-
-        In both update paths the data is first validated through
-        the Gateway's own serializer so that all business rules
-        (email restrictions, field permissions, etc.) are
-        enforced even though the request arrived via the resource
-        registry rather than the normal API.
+        If ``is_new`` is False (PUT/PATCH) it validates through
+        the Gateway serializer then sets the fields directly.
         """
         if is_new:
             lookup_fields = get_model_lookup_keys(self.instance.__class__)

--- a/aap_gateway_api/resource_api.py
+++ b/aap_gateway_api/resource_api.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 from typing import Optional
 
 from ansible_base.feature_flags.models import AAPFlag
@@ -6,6 +7,7 @@ from ansible_base.rbac.models import DABPermission, RoleDefinition
 from ansible_base.resource_registry.registry import ParentResource, ResourceConfig, ServiceAPIConfig, SharedResource
 from ansible_base.resource_registry.shared_types import FeatureFlagType, OrganizationType, RoleDefinitionType, TeamType, UserType
 from ansible_base.resource_registry.utils.resource_type_processor import ResourceTypeProcessor
+from crum import get_current_user
 from django.db.models import Model
 from rest_framework import serializers
 from rest_framework.serializers import ValidationError
@@ -13,33 +15,133 @@ from rest_framework.serializers import ValidationError
 from aap_gateway_api import models
 from aap_gateway_api.utils.models import get_model_lookup_keys
 
+logger = logging.getLogger('aap.gateway.resource_api')
+
+_GATEWAY_SERIALIZER_MAP = None
+
+
+def _get_gateway_serializer_map():
+    """Lazy-load the model → serializer mapping to avoid
+    circular imports at module level."""
+    global _GATEWAY_SERIALIZER_MAP
+    if _GATEWAY_SERIALIZER_MAP is None:
+        from aap_gateway_api.serializers.organization import OrganizationSerializer
+        from aap_gateway_api.serializers.team import TeamSerializer
+        from aap_gateway_api.serializers.user import UserSerializer
+
+        _GATEWAY_SERIALIZER_MAP = {
+            models.User: UserSerializer,
+            models.Organization: OrganizationSerializer,
+            models.Team: TeamSerializer,
+        }
+    return _GATEWAY_SERIALIZER_MAP
+
+
+class _SyncRequest:
+    """Minimal request-like object that carries just enough
+    context for Gateway serializers during resource-registry
+    operations."""
+
+    def __init__(self, user):
+        self.user = user
+        self.method = 'PATCH'
+        self.data = {}
+
 
 class GetOrCreateProcessor(ResourceTypeProcessor):
+    def _validate_via_gateway_serializer(self, validated_data):
+        """Run validated_data through the Gateway serializer for
+        this model so that *all* its validation rules apply to
+        reverse-sync payloads (email restrictions, field
+        permissions, etc.).
+
+        Fields that fail validation are silently stripped from
+        validated_data and logged so the rest of the sync still
+        succeeds.
+        """
+        if self.instance.pk is None:
+            return
+
+        try:
+            ser_cls = _get_gateway_serializer_map().get(self.instance.__class__)
+            if ser_cls is None:
+                return
+
+            user = get_current_user()
+            request = _SyncRequest(user) if user else None
+
+            ser = ser_cls(
+                instance=self.instance,
+                data=validated_data,
+                partial=True,
+                context={
+                    'request': request,
+                    'view': None,
+                },
+            )
+            if ser.is_valid():
+                return
+        except Exception:
+            logger.exception(
+                "Unexpected error validating resource-registry payload for %s pk=%s; allowing update to proceed unfiltered.",
+                self.instance.__class__.__name__,
+                self.instance.pk,
+            )
+            return
+
+        for field_name, errors in ser.errors.items():
+            if field_name in validated_data:
+                logger.warning(
+                    "Blocked field '%s' on %s (pk=%s) via resource registry.  Requesting user: %s.  Errors: %s",
+                    field_name,
+                    self.instance.__class__.__name__,
+                    self.instance.pk,
+                    user,
+                    errors,
+                )
+                del validated_data[field_name]
+
     def save(self, validated_data, is_new=False):
         """
-        Save the resource instance using the provided validated_data.
-        If `is_new` is True (i.e: for POST requests), this method tries to find an existing object using the model's unique fields.
-        If found, it updates the existing objects. If not, it creates a new one.
-        If `is_new` is False (i.e: for PUT/ PATCH requests), this method sets the fields in validated_data accordingly.
-        """
+        Save the resource instance using the provided
+        validated_data.
 
+        If ``is_new`` is True (POST) this tries to find an
+        existing object by unique fields; if found it updates,
+        otherwise creates.
+
+        If ``is_new`` is False (PUT/PATCH) it sets the fields
+        directly.
+
+        In both update paths the data is first validated through
+        the Gateway's own serializer so that all business rules
+        (email restrictions, field permissions, etc.) are
+        enforced even though the request arrived via the resource
+        registry rather than the normal API.
+        """
         if is_new:
-            # find the fields of this model that can be used to find an existing instance
             lookup_fields = get_model_lookup_keys(self.instance.__class__)
 
-            # get the look up fields kwargs that are present in the validated_data without modifying the input data
             validated_data = copy.deepcopy(validated_data)
             lookup_kwargs = {k: validated_data.pop(k) for k in lookup_fields if k in validated_data}
 
-            # we use update_or_create to ensure idempotency for repeated POSTS
-            # this is to support cases where multiple services might make simultaneous requests to create a shared resource.
-            # If a resource is being created locally in a service and the resource already exists on Gateway, the local resource
-            # should be linked to the resource in Gateway
-            self.instance, changed = self.instance.__class__.objects.update_or_create(**lookup_kwargs, defaults=validated_data)
-            # At this point, changed = True if a new object was created, False if the object existed.
-            # Now check if any of the object fields were updated.
-            changed = changed or any(not hasattr(self.instance, k) or getattr(self.instance, k) != val for k, val in validated_data.items())
-            return (changed, self.instance)
+            existing = self.instance.__class__.objects.filter(**lookup_kwargs).first()
+            if existing:
+                self.instance = existing
+                self._validate_via_gateway_serializer(validated_data)
+                changed = any(not hasattr(self.instance, k) or getattr(self.instance, k) != val for k, val in validated_data.items())
+                for k, val in validated_data.items():
+                    setattr(self.instance, k, val)
+                self.instance.save()
+                return (changed, self.instance)
+            else:
+                self.instance, _ = self.instance.__class__.objects.update_or_create(
+                    **lookup_kwargs,
+                    defaults=validated_data,
+                )
+                return (True, self.instance)
+
+        self._validate_via_gateway_serializer(validated_data)
 
         changed_fields = []
         for k, val in validated_data.items():

--- a/aap_gateway_api/serializers/user.py
+++ b/aap_gateway_api/serializers/user.py
@@ -438,16 +438,19 @@ class UserSerializer(CommonUserSerializer):
         Perform cross-field validation for authenticators and authenticator_uid.
 
         This method:
-        1. Validates email changes are authorized.
-        2. Handles partial updates for authenticator_uid.
-        3. Validates authenticator and UID combinations:
+        1. Delegates to DAB's CommonUserSerializer.validate() for system user
+           protection and email change authorization.
+        2. Validates email changes are authorized (local enforcement).
+        3. Handles partial updates for authenticator_uid.
+        4. Validates authenticator and UID combinations:
            - Ensures UID is present when adding/modifying authenticators.
            - Checks for UID conflicts across authenticators.
            - Validates new authenticators for conflicts.
-        4. Ensures authenticator_uid is empty when removing all authenticators.
+        5. Ensures authenticator_uid is empty when removing all authenticators.
 
         Raises ValidationError if any validation fails.
         """
+        data = super().validate(data)
         self._validate_email_change(data)
 
         authenticators = data.get('authenticators')

--- a/aap_gateway_api/serializers/user.py
+++ b/aap_gateway_api/serializers/user.py
@@ -430,6 +430,9 @@ class UserSerializer(CommonUserSerializer):
             return
 
         requesting_user = self._get_requesting_user()
+        if requesting_user is None:
+            return
+
         if not can_change_user(requesting_user, self.instance, can_self_edit=False):
             raise ValidationError({'email': [_("You do not have permission to change the %(field)s field.") % {'field': 'email'}]})
 

--- a/aap_gateway_api/serializers/user.py
+++ b/aap_gateway_api/serializers/user.py
@@ -416,38 +416,29 @@ class UserSerializer(CommonUserSerializer):
         if errors:
             raise serializers.ValidationError(errors)
 
-    def _validate_identity_fields(self, data):
-        """Prevent unauthorized changes to username and email.
+    def _validate_email_change(self, data):
+        """Prevent unauthorized changes to email.
 
         Delegates to DAB's can_change_user with can_self_edit=False so that
         only superusers and org admins (who administer ALL of the target
-        user's organizations) may change username or email.
+        user's organizations) may change email.
         """
         if self.instance is None:
             return
 
-        identity_fields = {
-            'username': self.instance.username,
-            'email': self.instance.email,
-        }
-        identity_errors_if_not_allowed = {}
-        for field, current_value in identity_fields.items():
-            if field in data and data[field] != current_value:
-                identity_errors_if_not_allowed[field] = [_("You do not have permission to change the %(field)s field.") % {'field': field}]
-
-        if not identity_errors_if_not_allowed:
+        if 'email' not in data or data['email'] == self.instance.email:
             return
 
         requesting_user = self._get_requesting_user()
         if not can_change_user(requesting_user, self.instance, can_self_edit=False):
-            raise ValidationError(identity_errors_if_not_allowed)
+            raise ValidationError({'email': [_("You do not have permission to change the %(field)s field.") % {'field': 'email'}]})
 
     def validate(self, data):
         """
         Perform cross-field validation for authenticators and authenticator_uid.
 
         This method:
-        1. Validates identity field changes (username/email) are authorized.
+        1. Validates email changes are authorized.
         2. Handles partial updates for authenticator_uid.
         3. Validates authenticator and UID combinations:
            - Ensures UID is present when adding/modifying authenticators.
@@ -457,7 +448,7 @@ class UserSerializer(CommonUserSerializer):
 
         Raises ValidationError if any validation fails.
         """
-        self._validate_identity_fields(data)
+        self._validate_email_change(data)
 
         authenticators = data.get('authenticators')
         authenticator_uid = data.get('authenticator_uid')

--- a/aap_gateway_api/serializers/user.py
+++ b/aap_gateway_api/serializers/user.py
@@ -7,6 +7,7 @@ from ansible_base.authentication.utils.user import can_user_change_password
 from ansible_base.lib.serializers.common import CommonUserSerializer
 from ansible_base.lib.utils.encryption import ENCRYPTED_STRING
 from ansible_base.lib.utils.response import get_relative_url
+from ansible_base.rbac.policies import can_change_user
 from crum import get_current_user
 from django.contrib.auth import update_session_auth_hash
 from django.core.exceptions import ValidationError as DjangoValidationError
@@ -171,11 +172,15 @@ class UserSerializer(CommonUserSerializer):
         AuthenticatorUser.objects.create(uid=uid, user=user_instance, provider=authenticator, email=email)
         return authenticator
 
-    def is_superuser_making_request(self) -> bool:
+    def _get_requesting_user(self):
         request = self.context.get('request', None)
-        if request and hasattr(request, 'user') and request.user.is_superuser:
-            return True
-        return False
+        if request and hasattr(request, 'user'):
+            return request.user
+        return None
+
+    def is_superuser_making_request(self) -> bool:
+        user = self._get_requesting_user()
+        return user is not None and user.is_superuser
 
     def validate_password(self, value: str) -> str:
         if not value or value in [ENCRYPTED_STRING, PASSWORD_DISABLED]:
@@ -411,20 +416,46 @@ class UserSerializer(CommonUserSerializer):
         if errors:
             raise serializers.ValidationError(errors)
 
+    def _validate_identity_fields(self, data):
+        """Prevent unauthorized changes to username and email.
+
+        Delegates to DAB's can_change_user with can_self_edit=False so that
+        only superusers and org admins (who administer ALL of the target
+        user's organizations) may change username or email.
+        """
+        if self.instance is None:
+            return
+
+        identity_fields = {
+            'username': self.instance.username,
+            'email': self.instance.email,
+        }
+        identity_errors_if_not_allowed = {}
+        for field, current_value in identity_fields.items():
+            if field in data and data[field] != current_value:
+                identity_errors_if_not_allowed[field] = [_("You do not have permission to change the %(field)s field.") % {'field': field}]
+
+        requesting_user = self._get_requesting_user()
+        if not can_change_user(requesting_user, self.instance, can_self_edit=False):
+            raise ValidationError(identity_errors_if_not_allowed)
+
     def validate(self, data):
         """
         Perform cross-field validation for authenticators and authenticator_uid.
 
         This method:
-        1. Handles partial updates for authenticator_uid.
-        2. Validates authenticator and UID combinations:
+        1. Validates identity field changes (username/email) are authorized.
+        2. Handles partial updates for authenticator_uid.
+        3. Validates authenticator and UID combinations:
            - Ensures UID is present when adding/modifying authenticators.
            - Checks for UID conflicts across authenticators.
            - Validates new authenticators for conflicts.
-        3. Ensures authenticator_uid is empty when removing all authenticators.
+        4. Ensures authenticator_uid is empty when removing all authenticators.
 
         Raises ValidationError if any validation fails.
         """
+        self._validate_identity_fields(data)
+
         authenticators = data.get('authenticators')
         authenticator_uid = data.get('authenticator_uid')
 

--- a/aap_gateway_api/serializers/user.py
+++ b/aap_gateway_api/serializers/user.py
@@ -435,6 +435,9 @@ class UserSerializer(CommonUserSerializer):
             if field in data and data[field] != current_value:
                 identity_errors_if_not_allowed[field] = [_("You do not have permission to change the %(field)s field.") % {'field': field}]
 
+        if not identity_errors_if_not_allowed:
+            return
+
         requesting_user = self._get_requesting_user()
         if not can_change_user(requesting_user, self.instance, can_self_edit=False):
             raise ValidationError(identity_errors_if_not_allowed)

--- a/aap_gateway_api/serializers/user.py
+++ b/aap_gateway_api/serializers/user.py
@@ -431,6 +431,7 @@ class UserSerializer(CommonUserSerializer):
 
         requesting_user = self._get_requesting_user()
         if requesting_user is None:
+            logger.debug("Skipping email change authorization: no requesting user in context (system sync path)")
             return
 
         if not can_change_user(requesting_user, self.instance, can_self_edit=False):
@@ -442,8 +443,9 @@ class UserSerializer(CommonUserSerializer):
 
         This method:
         1. Delegates to DAB's CommonUserSerializer.validate() for system user
-           protection and email change authorization.
-        2. Validates email changes are authorized (local enforcement).
+           protection and email change authorization (first line of defense).
+        2. Applies Gateway-local email policy via _validate_email_change as
+           a second line of defense (defense-in-depth).
         3. Handles partial updates for authenticator_uid.
         4. Validates authenticator and UID combinations:
            - Ensures UID is present when adding/modifying authenticators.

--- a/aap_gateway_api/tests/management/test_detect_changed_emails.py
+++ b/aap_gateway_api/tests/management/test_detect_changed_emails.py
@@ -1,0 +1,283 @@
+from io import StringIO
+
+import pytest
+from ansible_base.activitystream.models import Entry
+from ansible_base.authentication.models import Authenticator, AuthenticatorUser
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.core.management import call_command
+
+User = get_user_model()
+
+LDAP_TYPE = "ansible_base.authentication.authenticator_plugins.ldap"
+LOCAL_TYPE = "ansible_base.authentication.authenticator_plugins.local"
+
+
+@pytest.fixture
+def local_auth(db):
+    return Authenticator.objects.get_or_create(
+        name="Local Auth",
+        defaults={"enabled": True, "type": LOCAL_TYPE, "configuration": {}},
+    )[0]
+
+
+@pytest.fixture
+def ldap_auth(db):
+    return Authenticator.objects.get_or_create(
+        name="Corp LDAP",
+        defaults={"enabled": False, "type": LDAP_TYPE, "configuration": {}},
+    )[0]
+
+
+@pytest.fixture
+def alice(db):
+    return User.objects.create_user(username="alice", email="alice@example.com")
+
+
+@pytest.fixture
+def bob(db):
+    return User.objects.create_user(username="bob", email="bob@example.com")
+
+
+@pytest.fixture
+def admin_actor(db):
+    return User.objects.create_superuser(username="admin_actor", email="admin@example.com", password="p")
+
+
+def _create_email_change_entry(target, actor, old_email, new_email):
+    user_ct = ContentType.objects.get_for_model(User)
+    return Entry.objects.create(
+        content_type=user_ct,
+        object_id=str(target.pk),
+        operation="update",
+        changes={"changed_fields": {"email": [old_email, new_email]}},
+        created_by=actor,
+    )
+
+
+def _run_command(*args):
+    out = StringIO()
+    call_command("detect_changed_emails", *args, stdout=out)
+    return out.getvalue()
+
+
+# ---------------------------------------------------------------
+# Default mode (no --audit)
+# ---------------------------------------------------------------
+class TestDefaultMode:
+    @pytest.mark.django_db
+    def test_no_changes_found(self):
+        output = _run_command()
+        assert "No email changes found" in output
+
+    @pytest.mark.django_db
+    def test_shows_email_changes(self, alice, admin_actor):
+        _create_email_change_entry(alice, admin_actor, "old@x.com", "new@x.com")
+        output = _run_command()
+        assert "1 email change(s)" in output
+        assert "admin_actor" in output
+        assert "alice" in output
+
+    @pytest.mark.django_db
+    def test_flags_non_superuser_actor(self, alice, bob):
+        _create_email_change_entry(alice, bob, "old@x.com", "new@x.com")
+        output = _run_command()
+        assert "[NON-SUPERUSER ACTOR]" in output
+        assert "--audit" in output
+
+    @pytest.mark.django_db
+    def test_flags_self_edit(self, alice):
+        _create_email_change_entry(alice, alice, "old@x.com", "new@x.com")
+        output = _run_command()
+        assert "[SELF-EDIT]" in output
+
+    @pytest.mark.django_db
+    def test_does_not_run_audit_sections(self, alice, admin_actor):
+        _create_email_change_entry(alice, admin_actor, "old@x.com", "new@x.com")
+        output = _run_command()
+        assert "AUDIT SUMMARY" not in output
+        assert "AUTHENTICATOR EMAIL vs USER EMAIL" not in output
+
+    @pytest.mark.django_db
+    def test_empty_old_email_shown(self, alice, admin_actor):
+        _create_email_change_entry(alice, admin_actor, "", "new@x.com")
+        output = _run_command()
+        assert "(empty)" in output
+
+
+# ---------------------------------------------------------------
+# Audit mode (--audit)
+# ---------------------------------------------------------------
+class TestAuditMode:
+    @pytest.mark.django_db
+    def test_runs_all_sections(self, alice, admin_actor):
+        _create_email_change_entry(alice, admin_actor, "old@x.com", "new@x.com")
+        output = _run_command("--audit")
+        assert "EMAIL CHANGES IN ACTIVITY STREAM" in output
+        assert "USERS WITH LOCAL + EXTERNAL AUTHENTICATORS" in output
+        assert "AUTHENTICATOR EMAIL vs USER EMAIL MISMATCHES" in output
+        assert "DUPLICATE EMAILS ACROSS USERS" in output
+        assert "EMAIL CHANGES BY NON-SUPERUSER ACTORS" in output
+        assert "EMAIL CHANGES THAT MATCHED ANOTHER EXISTING USER'S EMAIL" in output
+        assert "HIGH-RISK" in output
+        assert "AUDIT SUMMARY" in output
+
+    @pytest.mark.django_db
+    def test_empty_audit(self):
+        output = _run_command("--audit")
+        assert "No email changes found" in output
+        assert "No obvious indicators of email hijacking detected" in output
+
+
+# ---------------------------------------------------------------
+# Dual authenticator detection
+# ---------------------------------------------------------------
+class TestDualAuthenticators:
+    @pytest.mark.django_db
+    def test_detects_dual_auth(self, alice, local_auth, ldap_auth):
+        AuthenticatorUser.objects.create(user=alice, provider=local_auth, uid="alice")
+        AuthenticatorUser.objects.create(user=alice, provider=ldap_auth, uid="alice_ldap")
+        output = _run_command("--audit")
+        assert "1 user(s) with both local and external authenticators" in output
+        assert "alice" in output
+
+    @pytest.mark.django_db
+    def test_no_dual_auth(self, alice, local_auth):
+        AuthenticatorUser.objects.create(user=alice, provider=local_auth, uid="alice")
+        output = _run_command("--audit")
+        assert "No users found with both local and external authenticators" in output
+
+    @pytest.mark.django_db
+    def test_dual_auth_flags_email_changed(self, alice, admin_actor, local_auth, ldap_auth):
+        AuthenticatorUser.objects.create(user=alice, provider=local_auth, uid="alice")
+        AuthenticatorUser.objects.create(user=alice, provider=ldap_auth, uid="alice_ldap")
+        _create_email_change_entry(alice, admin_actor, "old@x.com", "new@x.com")
+        output = _run_command("--audit")
+        assert "EMAIL WAS CHANGED" in output
+
+
+# ---------------------------------------------------------------
+# Email mismatches
+# ---------------------------------------------------------------
+class TestEmailMismatches:
+    @pytest.mark.django_db
+    def test_detects_mismatch(self, alice, local_auth):
+        AuthenticatorUser.objects.create(user=alice, provider=local_auth, uid="alice", email="different@x.com")
+        output = _run_command("--audit")
+        assert "1 mismatch(es)" in output
+
+    @pytest.mark.django_db
+    def test_no_mismatch_when_same(self, alice, local_auth):
+        AuthenticatorUser.objects.create(user=alice, provider=local_auth, uid="alice", email="alice@example.com")
+        output = _run_command("--audit")
+        assert "No mismatches found" in output
+
+
+# ---------------------------------------------------------------
+# Duplicate emails
+# ---------------------------------------------------------------
+class TestDuplicateEmails:
+    @pytest.mark.django_db
+    def test_detects_duplicates(self, db):
+        User.objects.create_user(username="dup1", email="same@x.com")
+        User.objects.create_user(username="dup2", email="same@x.com")
+        output = _run_command("--audit")
+        assert "1 email(s) shared by multiple users" in output
+
+    @pytest.mark.django_db
+    def test_no_duplicates(self, alice, bob):
+        output = _run_command("--audit")
+        assert "No duplicate emails found" in output
+
+
+# ---------------------------------------------------------------
+# Non-superuser changes
+# ---------------------------------------------------------------
+class TestNonSuperuserChanges:
+    @pytest.mark.django_db
+    def test_detects_non_superuser_change(self, alice, bob):
+        _create_email_change_entry(alice, bob, "old@x.com", "new@x.com")
+        output = _run_command("--audit")
+        assert "1 email change(s) by non-superuser actors" in output
+
+    @pytest.mark.django_db
+    def test_no_non_superuser_changes(self, alice, admin_actor):
+        _create_email_change_entry(alice, admin_actor, "old@x.com", "new@x.com")
+        output = _run_command("--audit")
+        assert "No email changes by non-superuser actors found" in output
+
+    @pytest.mark.django_db
+    def test_labels_self_edit_vs_other(self, alice, bob):
+        _create_email_change_entry(alice, alice, "old@x.com", "self@x.com")
+        _create_email_change_entry(alice, bob, "self@x.com", "other@x.com")
+        output = _run_command("--audit")
+        assert "SELF-EDIT" in output
+        assert "EDITED ANOTHER USER" in output
+
+
+# ---------------------------------------------------------------
+# Suspicious email matches
+# ---------------------------------------------------------------
+class TestSuspiciousEmailMatches:
+    @pytest.mark.django_db
+    def test_detects_email_matching_other_user(self, alice, bob, admin_actor):
+        _create_email_change_entry(alice, admin_actor, "old@x.com", "bob@example.com")
+        output = _run_command("--audit")
+        assert "1 suspicious match(es)" in output
+        assert "bob" in output
+
+    @pytest.mark.django_db
+    def test_no_suspicious_matches(self, alice, admin_actor):
+        _create_email_change_entry(alice, admin_actor, "old@x.com", "unique@x.com")
+        output = _run_command("--audit")
+        assert "No email changes resulted in a match" in output
+
+
+# ---------------------------------------------------------------
+# High-risk combo
+# ---------------------------------------------------------------
+class TestHighRiskCombo:
+    @pytest.mark.django_db
+    def test_detects_high_risk(self, alice, admin_actor, local_auth, ldap_auth):
+        AuthenticatorUser.objects.create(user=alice, provider=local_auth, uid="alice")
+        AuthenticatorUser.objects.create(user=alice, provider=ldap_auth, uid="alice_ldap")
+        _create_email_change_entry(alice, admin_actor, "old@x.com", "new@x.com")
+        output = _run_command("--audit")
+        assert "1 high-risk user(s)" in output
+
+    @pytest.mark.django_db
+    def test_no_high_risk(self, alice, admin_actor, local_auth):
+        AuthenticatorUser.objects.create(user=alice, provider=local_auth, uid="alice")
+        _create_email_change_entry(alice, admin_actor, "old@x.com", "new@x.com")
+        output = _run_command("--audit")
+        assert "No high-risk combinations found" in output
+
+
+# ---------------------------------------------------------------
+# Summary output
+# ---------------------------------------------------------------
+class TestSummary:
+    @pytest.mark.django_db
+    def test_potential_issues_detected(self, alice, bob):
+        _create_email_change_entry(alice, bob, "old@x.com", "new@x.com")
+        output = _run_command("--audit")
+        assert "POTENTIAL ISSUES DETECTED" in output
+
+    @pytest.mark.django_db
+    def test_clean_summary(self, alice, admin_actor):
+        _create_email_change_entry(alice, admin_actor, "old@x.com", "new@x.com")
+        output = _run_command("--audit")
+        assert "No obvious indicators of email hijacking detected" in output
+
+
+# ---------------------------------------------------------------
+# Deleted user handling
+# ---------------------------------------------------------------
+class TestDeletedUser:
+    @pytest.mark.django_db
+    def test_deleted_target_shown_in_output(self, admin_actor, db):
+        temp = User.objects.create_user(username="temp", email="temp@x.com")
+        _create_email_change_entry(temp, admin_actor, "old@x.com", "new@x.com")
+        temp.delete()
+        output = _run_command()
+        assert "[DELETED user pk=" in output

--- a/aap_gateway_api/tests/serializers/test_user.py
+++ b/aap_gateway_api/tests/serializers/test_user.py
@@ -1556,7 +1556,207 @@ class TestDeprecatedAuthenticatorFields:
         # Get the full response payload so we can update just a single field
         full_payload = response.data
         full_payload['email'] = 'newemail@example.com'
-        # Make a request to the user's API client to update the user's email, it should succeed
+        # Make a request to the admin API client to update the user's email, it should succeed (admin can change email)
         updated_response = admin_api_client.patch(url, full_payload, format='json')
         assert updated_response.status_code == 200
         assert updated_response.data['email'] == full_payload['email']
+
+
+@pytest.mark.django_db
+class TestIdentityFieldRestrictions:
+    """Tests for restricting username and email changes to admins and org admins."""
+
+    def test_superuser_can_change_username(self, admin_api_client, user):
+        url = get_relative_url('user-detail', kwargs={'pk': user.id})
+        response = admin_api_client.patch(url, {'username': 'new_username'})
+        assert response.status_code == 200
+        assert response.data['username'] == 'new_username'
+
+    def test_superuser_can_change_email(self, admin_api_client, user):
+        url = get_relative_url('user-detail', kwargs={'pk': user.id})
+        response = admin_api_client.patch(url, {'email': 'newemail@example.com'})
+        assert response.status_code == 200
+        assert response.data['email'] == 'newemail@example.com'
+
+    def test_superuser_can_change_both(self, admin_api_client, user):
+        url = get_relative_url('user-detail', kwargs={'pk': user.id})
+        response = admin_api_client.patch(url, {'username': 'changed_user', 'email': 'changed@example.com'})
+        assert response.status_code == 200
+        assert response.data['username'] == 'changed_user'
+        assert response.data['email'] == 'changed@example.com'
+
+    def test_regular_user_cannot_change_own_username(self, user_api_client, user):
+        url = get_relative_url('user-detail', kwargs={'pk': user.id})
+        response = user_api_client.patch(url, {'username': 'hacked_username'})
+        assert response.status_code == 400
+        assert 'username' in response.data
+        assert 'permission' in str(response.data['username'][0]).lower()
+
+    def test_regular_user_cannot_change_own_email(self, user_api_client, user):
+        user.email = 'original@example.com'
+        user.save()
+        url = get_relative_url('user-detail', kwargs={'pk': user.id})
+        response = user_api_client.patch(url, {'email': 'hacked@example.com'})
+        assert response.status_code == 400
+        assert 'email' in response.data
+        assert 'permission' in str(response.data['email'][0]).lower()
+
+    def test_regular_user_can_change_non_identity_fields(self, user_api_client, user):
+        url = get_relative_url('user-detail', kwargs={'pk': user.id})
+        response = user_api_client.patch(url, {'first_name': 'NewFirst', 'last_name': 'NewLast'})
+        assert response.status_code == 200
+        assert response.data['first_name'] == 'NewFirst'
+        assert response.data['last_name'] == 'NewLast'
+
+    def test_regular_user_send_same_username_is_ok(self, user_api_client, user):
+        url = get_relative_url('user-detail', kwargs={'pk': user.id})
+        response = user_api_client.patch(url, {'username': user.username, 'first_name': 'Updated'})
+        assert response.status_code == 200
+        assert response.data['first_name'] == 'Updated'
+
+    def test_regular_user_send_same_email_is_ok(self, user_api_client, user):
+        user.email = 'same@example.com'
+        user.save()
+        url = get_relative_url('user-detail', kwargs={'pk': user.id})
+        response = user_api_client.patch(url, {'email': 'same@example.com', 'first_name': 'Updated'})
+        assert response.status_code == 200
+        assert response.data['first_name'] == 'Updated'
+
+    def test_org_admin_can_change_username_when_manage_org_auth_true(self, user_api_client, user, organization, preference_manager):
+        target_user = User.objects.create(username='target_user', email='target@example.com')
+        organization.add_admin(user)
+        organization.add_member(target_user)
+
+        with preference_manager.set('configuration', 'MANAGE_ORGANIZATION_AUTH', True):
+            url = get_relative_url('user-detail', kwargs={'pk': target_user.id})
+            response = user_api_client.patch(url, {'username': 'org_changed_username'})
+            assert response.status_code == 200
+            assert response.data['username'] == 'org_changed_username'
+
+    def test_org_admin_can_change_email_when_manage_org_auth_true(self, user_api_client, user, organization, preference_manager):
+        target_user = User.objects.create(username='target_user2', email='target2@example.com')
+        organization.add_admin(user)
+        organization.add_member(target_user)
+
+        with preference_manager.set('configuration', 'MANAGE_ORGANIZATION_AUTH', True):
+            url = get_relative_url('user-detail', kwargs={'pk': target_user.id})
+            response = user_api_client.patch(url, {'email': 'org_changed@example.com'})
+            assert response.status_code == 200
+            assert response.data['email'] == 'org_changed@example.com'
+
+    def test_org_admin_cannot_change_username_when_manage_org_auth_false(self, user_api_client, user, organization, preference_manager):
+        organization.add_admin(user)
+        with preference_manager.set('configuration', 'MANAGE_ORGANIZATION_AUTH', False):
+            url = get_relative_url('user-detail', kwargs={'pk': user.id})
+            response = user_api_client.patch(url, {'username': 'should_not_work'})
+            # When MANAGE_ORGANIZATION_AUTH=False, DAB permission layer blocks writes for non-superusers (403)
+            assert response.status_code == 403
+
+    def test_org_admin_cannot_change_email_when_manage_org_auth_false(self, user_api_client, user, organization, preference_manager):
+        organization.add_admin(user)
+        user.email = 'original@example.com'
+        user.save()
+        with preference_manager.set('configuration', 'MANAGE_ORGANIZATION_AUTH', False):
+            url = get_relative_url('user-detail', kwargs={'pk': user.id})
+            response = user_api_client.patch(url, {'email': 'should_not_work@example.com'})
+            # When MANAGE_ORGANIZATION_AUTH=False, DAB permission layer blocks writes for non-superusers (403)
+            assert response.status_code == 403
+
+    def test_superuser_can_change_fields_regardless_of_manage_org_auth(self, admin_api_client, user, preference_manager):
+        with preference_manager.set('configuration', 'MANAGE_ORGANIZATION_AUTH', False):
+            url = get_relative_url('user-detail', kwargs={'pk': user.id})
+            response = admin_api_client.patch(url, {'username': 'super_override', 'email': 'super@example.com'})
+            assert response.status_code == 200
+            assert response.data['username'] == 'super_override'
+            assert response.data['email'] == 'super@example.com'
+
+    @pytest.mark.parametrize('field,value', [('username', 'both_bad'), ('email', 'both_bad@example.com')])
+    def test_regular_user_change_identity_fields_errors(self, user_api_client, user, field, value):
+        if field == 'email':
+            user.email = 'existing@example.com'
+            user.save()
+        url = get_relative_url('user-detail', kwargs={'pk': user.id})
+        response = user_api_client.patch(url, {field: value})
+        assert response.status_code == 400
+        assert field in response.data
+
+    def test_org_admin_cannot_change_identity_fields_of_user_in_different_org(self, user_api_client, user, organization, organization_2, preference_manager):
+        """Org admin of Org B cannot change username/email of a user in Org A.
+
+        Even with ORG_ADMINS_CAN_SEE_ALL_USERS=True (can see the user), the
+        DAB permission layer blocks writes because the org admin doesn't
+        administer all of the target user's organizations.
+        """
+        joe = User.objects.create(username='joe', email='joe@example.com')
+        organization.add_member(joe)
+        organization_2.add_admin(user)
+
+        with preference_manager.set('configuration', 'MANAGE_ORGANIZATION_AUTH', True):
+            with preference_manager.set('configuration', 'ORG_ADMINS_CAN_SEE_ALL_USERS', True):
+                url = get_relative_url('user-detail', kwargs={'pk': joe.id})
+                response = user_api_client.patch(url, {'username': 'hacked_joe'})
+                assert response.status_code == 403
+
+                response = user_api_client.patch(url, {'email': 'hacked@example.com'})
+                assert response.status_code == 403
+
+    def test_org_admin_of_same_org_can_change_identity_fields(self, user_api_client, user, organization, preference_manager):
+        """Org admin of Org A can change username/email of a user in Org A."""
+        joe = User.objects.create(username='joe2', email='joe2@example.com')
+        organization.add_admin(user)
+        organization.add_member(joe)
+
+        with preference_manager.set('configuration', 'MANAGE_ORGANIZATION_AUTH', True):
+            url = get_relative_url('user-detail', kwargs={'pk': joe.id})
+            response = user_api_client.patch(url, {'username': 'joe_renamed'})
+            assert response.status_code == 200
+            assert response.data['username'] == 'joe_renamed'
+
+    def test_org_admin_cannot_change_identity_fields_if_user_in_multiple_orgs(self, user_api_client, user, organization, organization_2, preference_manager):
+        """Org admin of only Org A cannot change identity fields if target user is also in Org B."""
+        joe = User.objects.create(username='multi_org_joe', email='multijoe@example.com')
+        organization.add_admin(user)
+        organization.add_member(joe)
+        organization_2.add_member(joe)
+
+        with preference_manager.set('configuration', 'MANAGE_ORGANIZATION_AUTH', True):
+            url = get_relative_url('user-detail', kwargs={'pk': joe.id})
+            response = user_api_client.patch(url, {'username': 'should_fail'})
+            assert response.status_code == 403
+
+    def test_superuser_can_change_own_identity_fields(self, admin_api_client, admin_user):
+        """Superuser can change their own username and email."""
+        url = get_relative_url('user-detail', kwargs={'pk': admin_user.id})
+        response = admin_api_client.patch(url, {'username': 'super_self_renamed', 'email': 'super_self@example.com'})
+        assert response.status_code == 200
+        assert response.data['username'] == 'super_self_renamed'
+        assert response.data['email'] == 'super_self@example.com'
+
+    def test_org_admin_can_change_own_identity_fields_when_in_own_org(self, user_api_client, user, organization, preference_manager):
+        """Org admin who is also a member of their own org can change their own identity fields."""
+        organization.add_admin(user)
+        organization.add_member(user)
+
+        with preference_manager.set('configuration', 'MANAGE_ORGANIZATION_AUTH', True):
+            url = get_relative_url('user-detail', kwargs={'pk': user.id})
+            response = user_api_client.patch(url, {'username': 'self_org_admin_renamed'})
+            assert response.status_code == 200
+            assert response.data['username'] == 'self_org_admin_renamed'
+
+    def test_org_admin_cannot_change_own_identity_fields_when_also_in_unmanaged_org(
+        self, user_api_client, user, organization, organization_2, preference_manager
+    ):
+        """Org admin of Org A but also member of Org B cannot change own identity fields.
+
+        Because can_change_user requires admin of ALL the target's orgs.
+        """
+        organization.add_admin(user)
+        organization.add_member(user)
+        organization_2.add_member(user)
+
+        with preference_manager.set('configuration', 'MANAGE_ORGANIZATION_AUTH', True):
+            url = get_relative_url('user-detail', kwargs={'pk': user.id})
+            response = user_api_client.patch(url, {'username': 'should_not_work'})
+            assert response.status_code == 400
+            assert 'username' in response.data
+            assert 'permission' in str(response.data['username'][0]).lower()

--- a/aap_gateway_api/tests/serializers/test_user.py
+++ b/aap_gateway_api/tests/serializers/test_user.py
@@ -1563,34 +1563,14 @@ class TestDeprecatedAuthenticatorFields:
 
 
 @pytest.mark.django_db
-class TestIdentityFieldRestrictions:
-    """Tests for restricting username and email changes to admins and org admins."""
-
-    def test_superuser_can_change_username(self, admin_api_client, user):
-        url = get_relative_url('user-detail', kwargs={'pk': user.id})
-        response = admin_api_client.patch(url, {'username': 'new_username'})
-        assert response.status_code == 200
-        assert response.data['username'] == 'new_username'
+class TestEmailFieldRestrictions:
+    """Tests for restricting email changes to admins and org admins."""
 
     def test_superuser_can_change_email(self, admin_api_client, user):
         url = get_relative_url('user-detail', kwargs={'pk': user.id})
         response = admin_api_client.patch(url, {'email': 'newemail@example.com'})
         assert response.status_code == 200
         assert response.data['email'] == 'newemail@example.com'
-
-    def test_superuser_can_change_both(self, admin_api_client, user):
-        url = get_relative_url('user-detail', kwargs={'pk': user.id})
-        response = admin_api_client.patch(url, {'username': 'changed_user', 'email': 'changed@example.com'})
-        assert response.status_code == 200
-        assert response.data['username'] == 'changed_user'
-        assert response.data['email'] == 'changed@example.com'
-
-    def test_regular_user_cannot_change_own_username(self, user_api_client, user):
-        url = get_relative_url('user-detail', kwargs={'pk': user.id})
-        response = user_api_client.patch(url, {'username': 'hacked_username'})
-        assert response.status_code == 400
-        assert 'username' in response.data
-        assert 'permission' in str(response.data['username'][0]).lower()
 
     def test_regular_user_cannot_change_own_email(self, user_api_client, user):
         user.email = 'original@example.com'
@@ -1601,18 +1581,18 @@ class TestIdentityFieldRestrictions:
         assert 'email' in response.data
         assert 'permission' in str(response.data['email'][0]).lower()
 
+    def test_regular_user_can_change_own_username(self, user_api_client, user):
+        url = get_relative_url('user-detail', kwargs={'pk': user.id})
+        response = user_api_client.patch(url, {'username': 'new_username'})
+        assert response.status_code == 200
+        assert response.data['username'] == 'new_username'
+
     def test_regular_user_can_change_non_identity_fields(self, user_api_client, user):
         url = get_relative_url('user-detail', kwargs={'pk': user.id})
         response = user_api_client.patch(url, {'first_name': 'NewFirst', 'last_name': 'NewLast'})
         assert response.status_code == 200
         assert response.data['first_name'] == 'NewFirst'
         assert response.data['last_name'] == 'NewLast'
-
-    def test_regular_user_send_same_username_is_ok(self, user_api_client, user):
-        url = get_relative_url('user-detail', kwargs={'pk': user.id})
-        response = user_api_client.patch(url, {'username': user.username, 'first_name': 'Updated'})
-        assert response.status_code == 200
-        assert response.data['first_name'] == 'Updated'
 
     def test_regular_user_send_same_email_is_ok(self, user_api_client, user):
         user.email = 'same@example.com'
@@ -1621,17 +1601,6 @@ class TestIdentityFieldRestrictions:
         response = user_api_client.patch(url, {'email': 'same@example.com', 'first_name': 'Updated'})
         assert response.status_code == 200
         assert response.data['first_name'] == 'Updated'
-
-    def test_org_admin_can_change_username_when_manage_org_auth_true(self, user_api_client, user, organization, preference_manager):
-        target_user = User.objects.create(username='target_user', email='target@example.com')
-        organization.add_admin(user)
-        organization.add_member(target_user)
-
-        with preference_manager.set('configuration', 'MANAGE_ORGANIZATION_AUTH', True):
-            url = get_relative_url('user-detail', kwargs={'pk': target_user.id})
-            response = user_api_client.patch(url, {'username': 'org_changed_username'})
-            assert response.status_code == 200
-            assert response.data['username'] == 'org_changed_username'
 
     def test_org_admin_can_change_email_when_manage_org_auth_true(self, user_api_client, user, organization, preference_manager):
         target_user = User.objects.create(username='target_user2', email='target2@example.com')
@@ -1644,14 +1613,6 @@ class TestIdentityFieldRestrictions:
             assert response.status_code == 200
             assert response.data['email'] == 'org_changed@example.com'
 
-    def test_org_admin_cannot_change_username_when_manage_org_auth_false(self, user_api_client, user, organization, preference_manager):
-        organization.add_admin(user)
-        with preference_manager.set('configuration', 'MANAGE_ORGANIZATION_AUTH', False):
-            url = get_relative_url('user-detail', kwargs={'pk': user.id})
-            response = user_api_client.patch(url, {'username': 'should_not_work'})
-            # When MANAGE_ORGANIZATION_AUTH=False, DAB permission layer blocks writes for non-superusers (403)
-            assert response.status_code == 403
-
     def test_org_admin_cannot_change_email_when_manage_org_auth_false(self, user_api_client, user, organization, preference_manager):
         organization.add_admin(user)
         user.email = 'original@example.com'
@@ -1659,29 +1620,17 @@ class TestIdentityFieldRestrictions:
         with preference_manager.set('configuration', 'MANAGE_ORGANIZATION_AUTH', False):
             url = get_relative_url('user-detail', kwargs={'pk': user.id})
             response = user_api_client.patch(url, {'email': 'should_not_work@example.com'})
-            # When MANAGE_ORGANIZATION_AUTH=False, DAB permission layer blocks writes for non-superusers (403)
             assert response.status_code == 403
 
-    def test_superuser_can_change_fields_regardless_of_manage_org_auth(self, admin_api_client, user, preference_manager):
+    def test_superuser_can_change_email_regardless_of_manage_org_auth(self, admin_api_client, user, preference_manager):
         with preference_manager.set('configuration', 'MANAGE_ORGANIZATION_AUTH', False):
             url = get_relative_url('user-detail', kwargs={'pk': user.id})
-            response = admin_api_client.patch(url, {'username': 'super_override', 'email': 'super@example.com'})
+            response = admin_api_client.patch(url, {'email': 'super@example.com'})
             assert response.status_code == 200
-            assert response.data['username'] == 'super_override'
             assert response.data['email'] == 'super@example.com'
 
-    @pytest.mark.parametrize('field,value', [('username', 'both_bad'), ('email', 'both_bad@example.com')])
-    def test_regular_user_change_identity_fields_errors(self, user_api_client, user, field, value):
-        if field == 'email':
-            user.email = 'existing@example.com'
-            user.save()
-        url = get_relative_url('user-detail', kwargs={'pk': user.id})
-        response = user_api_client.patch(url, {field: value})
-        assert response.status_code == 400
-        assert field in response.data
-
-    def test_org_admin_cannot_change_identity_fields_of_user_in_different_org(self, user_api_client, user, organization, organization_2, preference_manager):
-        """Org admin of Org B cannot change username/email of a user in Org A.
+    def test_org_admin_cannot_change_email_of_user_in_different_org(self, user_api_client, user, organization, organization_2, preference_manager):
+        """Org admin of Org B cannot change email of a user in Org A.
 
         Even with ORG_ADMINS_CAN_SEE_ALL_USERS=True (can see the user), the
         DAB permission layer blocks writes because the org admin doesn't
@@ -1694,26 +1643,23 @@ class TestIdentityFieldRestrictions:
         with preference_manager.set('configuration', 'MANAGE_ORGANIZATION_AUTH', True):
             with preference_manager.set('configuration', 'ORG_ADMINS_CAN_SEE_ALL_USERS', True):
                 url = get_relative_url('user-detail', kwargs={'pk': joe.id})
-                response = user_api_client.patch(url, {'username': 'hacked_joe'})
-                assert response.status_code == 403
-
                 response = user_api_client.patch(url, {'email': 'hacked@example.com'})
                 assert response.status_code == 403
 
-    def test_org_admin_of_same_org_can_change_identity_fields(self, user_api_client, user, organization, preference_manager):
-        """Org admin of Org A can change username/email of a user in Org A."""
+    def test_org_admin_of_same_org_can_change_email(self, user_api_client, user, organization, preference_manager):
+        """Org admin of Org A can change email of a user in Org A."""
         joe = User.objects.create(username='joe2', email='joe2@example.com')
         organization.add_admin(user)
         organization.add_member(joe)
 
         with preference_manager.set('configuration', 'MANAGE_ORGANIZATION_AUTH', True):
             url = get_relative_url('user-detail', kwargs={'pk': joe.id})
-            response = user_api_client.patch(url, {'username': 'joe_renamed'})
+            response = user_api_client.patch(url, {'email': 'joe_new@example.com'})
             assert response.status_code == 200
-            assert response.data['username'] == 'joe_renamed'
+            assert response.data['email'] == 'joe_new@example.com'
 
-    def test_org_admin_cannot_change_identity_fields_if_user_in_multiple_orgs(self, user_api_client, user, organization, organization_2, preference_manager):
-        """Org admin of only Org A cannot change identity fields if target user is also in Org B."""
+    def test_org_admin_cannot_change_email_if_user_in_multiple_orgs(self, user_api_client, user, organization, organization_2, preference_manager):
+        """Org admin of only Org A cannot change email if target user is also in Org B."""
         joe = User.objects.create(username='multi_org_joe', email='multijoe@example.com')
         organization.add_admin(user)
         organization.add_member(joe)
@@ -1721,32 +1667,29 @@ class TestIdentityFieldRestrictions:
 
         with preference_manager.set('configuration', 'MANAGE_ORGANIZATION_AUTH', True):
             url = get_relative_url('user-detail', kwargs={'pk': joe.id})
-            response = user_api_client.patch(url, {'username': 'should_fail'})
+            response = user_api_client.patch(url, {'email': 'should_fail@example.com'})
             assert response.status_code == 403
 
-    def test_superuser_can_change_own_identity_fields(self, admin_api_client, admin_user):
-        """Superuser can change their own username and email."""
+    def test_superuser_can_change_own_email(self, admin_api_client, admin_user):
+        """Superuser can change their own email."""
         url = get_relative_url('user-detail', kwargs={'pk': admin_user.id})
-        response = admin_api_client.patch(url, {'username': 'super_self_renamed', 'email': 'super_self@example.com'})
+        response = admin_api_client.patch(url, {'email': 'super_self@example.com'})
         assert response.status_code == 200
-        assert response.data['username'] == 'super_self_renamed'
         assert response.data['email'] == 'super_self@example.com'
 
-    def test_org_admin_can_change_own_identity_fields_when_in_own_org(self, user_api_client, user, organization, preference_manager):
-        """Org admin who is also a member of their own org can change their own identity fields."""
+    def test_org_admin_can_change_own_email_when_in_own_org(self, user_api_client, user, organization, preference_manager):
+        """Org admin who is also a member of their own org can change their own email."""
         organization.add_admin(user)
         organization.add_member(user)
 
         with preference_manager.set('configuration', 'MANAGE_ORGANIZATION_AUTH', True):
             url = get_relative_url('user-detail', kwargs={'pk': user.id})
-            response = user_api_client.patch(url, {'username': 'self_org_admin_renamed'})
+            response = user_api_client.patch(url, {'email': 'self_org_admin@example.com'})
             assert response.status_code == 200
-            assert response.data['username'] == 'self_org_admin_renamed'
+            assert response.data['email'] == 'self_org_admin@example.com'
 
-    def test_org_admin_cannot_change_own_identity_fields_when_also_in_unmanaged_org(
-        self, user_api_client, user, organization, organization_2, preference_manager
-    ):
-        """Org admin of Org A but also member of Org B cannot change own identity fields.
+    def test_org_admin_cannot_change_own_email_when_also_in_unmanaged_org(self, user_api_client, user, organization, organization_2, preference_manager):
+        """Org admin of Org A but also member of Org B cannot change own email.
 
         Because can_change_user requires admin of ALL the target's orgs.
         """
@@ -1756,7 +1699,7 @@ class TestIdentityFieldRestrictions:
 
         with preference_manager.set('configuration', 'MANAGE_ORGANIZATION_AUTH', True):
             url = get_relative_url('user-detail', kwargs={'pk': user.id})
-            response = user_api_client.patch(url, {'username': 'should_not_work'})
+            response = user_api_client.patch(url, {'email': 'should_not_work@example.com'})
             assert response.status_code == 400
-            assert 'username' in response.data
-            assert 'permission' in str(response.data['username'][0]).lower()
+            assert 'email' in response.data
+            assert 'permission' in str(response.data['email'][0]).lower()

--- a/aap_gateway_api/tests/test_resource_api.py
+++ b/aap_gateway_api/tests/test_resource_api.py
@@ -1,11 +1,13 @@
+from unittest.mock import patch
+
 import pytest
 from ansible_base.rbac.models import DABContentType, DABPermission, RoleDefinition
 from ansible_base.resource_registry.models import Resource, ResourceType
 from django.db import models
 from rest_framework.exceptions import ValidationError
 
-from aap_gateway_api.models import Organization
-from aap_gateway_api.resource_api import GatewayRoleDefinitionType
+from aap_gateway_api.models import Organization, User
+from aap_gateway_api.resource_api import GatewayRoleDefinitionType, GetOrCreateProcessor
 
 
 @pytest.mark.django_db
@@ -446,3 +448,182 @@ class TestGatewayRoleDefinitionType:
 
         # Test that all permissions are correctly converted
         assert {p.api_slug for p in resource.content_object.permissions.all()} == set(permission_slugs)
+
+
+@pytest.mark.django_db
+class TestGetOrCreateProcessorSerializerValidation:
+    """Verify that GetOrCreateProcessor routes reverse-sync
+    payloads through the Gateway's own serializers so that all
+    business rules are enforced."""
+
+    @pytest.fixture
+    def target_user(self):
+        return User.objects.create_user(
+            username="target_user",
+            email="original@example.com",
+            password="password123",
+        )
+
+    @pytest.fixture
+    def superuser(self):
+        return User.objects.create_user(
+            username="admin_user",
+            email="admin@example.com",
+            password="password123",
+            is_superuser=True,
+        )
+
+    @pytest.fixture
+    def regular_user(self):
+        return User.objects.create_user(
+            username="regular_user",
+            email="regular@example.com",
+            password="password123",
+        )
+
+    @pytest.mark.parametrize(
+        "requesting_user_fixture, new_email, expected_email",
+        [
+            pytest.param(
+                "superuser",
+                "new@example.com",
+                "new@example.com",
+                id="superuser-can-change-email",
+            ),
+            pytest.param(
+                "regular_user",
+                "hijacked@example.com",
+                "original@example.com",
+                id="regular-user-email-stripped",
+            ),
+            pytest.param(
+                None,
+                "synced@example.com",
+                "synced@example.com",
+                id="no-requesting-user-allowed",
+            ),
+        ],
+    )
+    def test_email_policy_on_update(
+        self,
+        request,
+        target_user,
+        requesting_user_fixture,
+        new_email,
+        expected_email,
+    ):
+        requesting_user = request.getfixturevalue(requesting_user_fixture) if requesting_user_fixture else None
+        processor = GetOrCreateProcessor(target_user)
+
+        with patch(
+            "aap_gateway_api.resource_api.get_current_user",
+            return_value=requesting_user,
+        ):
+            processor.save(
+                {"email": new_email, "first_name": "Updated"},
+                is_new=False,
+            )
+
+        target_user.refresh_from_db()
+        assert target_user.email == expected_email
+        assert target_user.first_name == "Updated"
+
+    def test_same_email_is_always_allowed(self, target_user, regular_user):
+        """Submitting the same email should not be blocked."""
+        processor = GetOrCreateProcessor(target_user)
+
+        with patch(
+            "aap_gateway_api.resource_api.get_current_user",
+            return_value=regular_user,
+        ):
+            processor.save(
+                {
+                    "email": "original@example.com",
+                    "first_name": "Updated",
+                },
+                is_new=False,
+            )
+
+        target_user.refresh_from_db()
+        assert target_user.email == "original@example.com"
+        assert target_user.first_name == "Updated"
+
+    def test_email_policy_on_post_existing_user(self, target_user, regular_user):
+        """POST (is_new=True) with existing user should still
+        enforce validation."""
+        processor = GetOrCreateProcessor(User(username="target_user"))
+
+        with patch(
+            "aap_gateway_api.resource_api.get_current_user",
+            return_value=regular_user,
+        ):
+            result = processor.save(
+                {
+                    "username": "target_user",
+                    "email": "hijacked@example.com",
+                    "first_name": "PostUpdated",
+                },
+                is_new=True,
+            )
+
+        result.refresh_from_db()
+        assert result.email == "original@example.com"
+        assert result.first_name == "PostUpdated"
+
+    def test_non_user_model_passes_through(self):
+        """Organization updates should pass through the
+        OrganizationSerializer without issue."""
+        org = Organization.objects.create(name="test_org", description="old")
+        processor = GetOrCreateProcessor(org)
+        processor.save(
+            {"description": "new"},
+            is_new=False,
+        )
+        org.refresh_from_db()
+        assert org.description == "new"
+
+    def test_valid_fields_still_saved_when_one_is_stripped(self, target_user, regular_user):
+        """When email is blocked, first_name and last_name should
+        still be updated."""
+        processor = GetOrCreateProcessor(target_user)
+
+        with patch(
+            "aap_gateway_api.resource_api.get_current_user",
+            return_value=regular_user,
+        ):
+            processor.save(
+                {
+                    "email": "hijacked@example.com",
+                    "first_name": "NewFirst",
+                    "last_name": "NewLast",
+                },
+                is_new=False,
+            )
+
+        target_user.refresh_from_db()
+        assert target_user.email == "original@example.com"
+        assert target_user.first_name == "NewFirst"
+        assert target_user.last_name == "NewLast"
+
+    def test_serializer_exception_allows_update(self, target_user, superuser):
+        """If the serializer raises an unexpected exception the
+        update should still proceed (fail-open for robustness)."""
+        processor = GetOrCreateProcessor(target_user)
+
+        with (
+            patch(
+                "aap_gateway_api.resource_api.get_current_user",
+                return_value=superuser,
+            ),
+            patch(
+                "aap_gateway_api.resource_api._get_gateway_serializer_map",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            processor.save(
+                {"first_name": "StillWorks"},
+                is_new=False,
+            )
+
+        target_user.refresh_from_db()
+        assert target_user.first_name == "StillWorks"

--- a/aap_gateway_api/tests/test_resource_api.py
+++ b/aap_gateway_api/tests/test_resource_api.py
@@ -605,9 +605,10 @@ class TestGetOrCreateProcessorSerializerValidation:
         assert target_user.first_name == "NewFirst"
         assert target_user.last_name == "NewLast"
 
-    def test_serializer_exception_allows_update(self, target_user, superuser):
-        """If the serializer raises an unexpected exception the
-        update should still proceed (fail-open for robustness)."""
+    def test_serializer_exception_strips_sensitive_fields(self, target_user, superuser):
+        """If the serializer raises an unexpected exception,
+        sensitive fields (email, is_superuser, is_staff) are
+        stripped but non-sensitive fields still proceed."""
         processor = GetOrCreateProcessor(target_user)
 
         with (
@@ -621,9 +622,40 @@ class TestGetOrCreateProcessorSerializerValidation:
             ),
         ):
             processor.save(
-                {"first_name": "StillWorks"},
+                {
+                    "first_name": "StillWorks",
+                    "email": "evil@example.com",
+                    "is_superuser": True,
+                },
                 is_new=False,
             )
 
         target_user.refresh_from_db()
         assert target_user.first_name == "StillWorks"
+        assert target_user.email == "original@example.com"
+        assert target_user.is_superuser is False
+
+    def test_new_user_creation_bypasses_validation(self, regular_user):
+        """POST (is_new=True) for a genuinely new user creates
+        the user via update_or_create without Gateway serializer
+        validation, since there is no prior state to protect."""
+        processor = GetOrCreateProcessor(User(username="brand_new_user"))
+
+        with patch(
+            "aap_gateway_api.resource_api.get_current_user",
+            return_value=regular_user,
+        ):
+            result = processor.save(
+                {
+                    "username": "brand_new_user",
+                    "email": "newuser@example.com",
+                    "first_name": "Brand",
+                    "last_name": "New",
+                },
+                is_new=True,
+            )
+
+        result.refresh_from_db()
+        assert result.username == "brand_new_user"
+        assert result.email == "newuser@example.com"
+        assert result.first_name == "Brand"


### PR DESCRIPTION
## Backport of CVE-2026-6266 fix to devel

Backport of the following PRs from `stable-2.6` on `ansible-automation-platform/aap-gateway`:
- ansible-automation-platform/aap-gateway#1331 — Restrict username and email changes to authorized users
- ansible-automation-platform/aap-gateway#1335 — Enforce email policy via reverse-sync and delegate to DAB

JIRA: AAP-72446 (backport of AAP-71795)

Requires ansible/django-ansible-base#994

### Cherry-picked commits (9 total)

**From PR #1331:**
- `d2adcc36` — Restrict username and email changes to authorized users
- `d257a5df` — Early return when no identity fields are changing
- `60caf321` — Narrow identity field restriction to email only

**From PR #1335:**
- `f47e5aa8` — Enforce email policy via reverse-sync and delegate to DAB
- `6bf97fea` — Allow email changes when no requesting user (system sync)
- `3abd4061` — Rename detect_email_hijack to detect_changed_emails and add --audit flag
- `9f83572d` — Add tests for detect_changed_emails and fix cognitive complexity
- `40473d29` — Address PR review: fail-closed validation, improved logging, and EMAIL_ENFORCEMENT_VIA_SERIALIZER
- `210adfeb` — Add docstring for EMAIL_ENFORCEMENT_VIA_SERIALIZER on User model

### Conflict resolution notes

⚠️ **Commit `f47e5aa8` had a cherry-pick conflict** in `aap_gateway_api/resource_api.py`.

The conflict was between devel's `update_or_create` idempotency pattern (which returns `(changed, self.instance)` tuples and tracks `changed_fields`) and the CVE fix's check-for-existing + `_validate_via_gateway_serializer` pattern (which returns bare `self.instance`).

**Resolution:** Merged both intents:
- Took the CVE fix's security validation logic (`_validate_via_gateway_serializer`, check-for-existing pattern)
- Adapted return types to devel's `(changed, self.instance)` tuple API
- Kept devel's `changed_fields` tracking for the update path

Please review the resolution in `resource_api.py` carefully.