### PR TITLE
AAP-65394: Add dispatcherd to supervisorctl configuration in gateway dev environment

### DIFF
--- a/docs/dispatcherd.md
+++ b/docs/dispatcherd.md
@@ -14,9 +14,11 @@ Epic: [AAP-59888](https://redhat.atlassian.net/browse/AAP-59888)
 
 <!-- Update this section after each story is completed so the next person gets a quick snapshot. -->
 
-**Last updated**: 2026-05-01
+**Last updated**: 2026-05-06
 
 AAP-65393 (core implementation) is code-complete, tested in a dev environment, and in review. The dispatch module, management commands, settings defaults, app config wiring, logging config, and unit tests are all in place.
+
+AAP-65394 (supervisord config) is code-complete. The dispatcher program block has been added to supervisord.conf and the podman startup config has been updated with gateway status endpoint preferences.
 
 ---
 
@@ -148,7 +150,7 @@ The `conninfo` string is built from `settings.DATABASES["default"]` using DAB's 
 
 ### AAP-65394: Add dispatcherd to supervisord configuration
 
-**Story**: [AAP-65394](https://redhat.atlassian.net/browse/AAP-65394) | **Status**: Backlog
+**Story**: [AAP-65394](https://redhat.atlassian.net/browse/AAP-65394) | **Status**: In Review
 **Depends on**: AAP-65393
 
 #### Requirements
@@ -157,7 +159,7 @@ The `conninfo` string is built from `settings.DATABASES["default"]` using DAB's 
 | --- | --- |
 | Config file | `tools/configs/supervisord.conf` |
 | Program block | `[program:dispatcher]` |
-| Command | `/usr/bin/aap-gateway-manage dispatcherctl start` |
+| Command | `/usr/bin/aap-gateway-manage dispatcherd` |
 | Group | Add `dispatcher` to the `gateway-processes` group |
 | `autorestart` | `true` |
 | `stopasgroup` | `false` |
@@ -169,7 +171,8 @@ The `conninfo` string is built from `settings.DATABASES["default"]` using DAB's 
 
 #### Files Modified
 
-<!-- TODO: Confirm exact changes to supervisord.conf once complete -->
+- Modified: `tools/configs/supervisord.conf` — added `[program:dispatcher]` block; added `dispatcher` to `gateway-processes` group
+- Modified: `tools/configs/container-startup-podman.yml` — added `gateway_preferences` for status endpoint timeout and TLS verify settings
 
 ---
 
@@ -446,7 +449,7 @@ If a future psycopg regression reintroduces this issue, set `"max_connection_idl
 | Story | Summary | Status | Depends On |
 | --- | --- | --- | --- |
 | [AAP-65393](https://redhat.atlassian.net/browse/AAP-65393) | Implement dispatcherd in Gateway | In Review | — |
-| [AAP-65394](https://redhat.atlassian.net/browse/AAP-65394) | Add dispatcherd to supervisord config | Backlog | AAP-65393 |
+| [AAP-65394](https://redhat.atlassian.net/browse/AAP-65394) | Add dispatcherd to supervisord config | In Review | AAP-65393 |
 | [AAP-65395](https://redhat.atlassian.net/browse/AAP-65395) | Add dispatcherd health check to ping | Backlog | AAP-65393 |
 | [AAP-65396](https://redhat.atlassian.net/browse/AAP-65396) | Update Gateway container build | Backlog | AAP-65393 |
 | [AAP-65397](https://redhat.atlassian.net/browse/AAP-65397) | Baseline performance test | Backlog | AAP-65396 |

--- a/tools/configs/container-startup-podman.yml
+++ b/tools/configs/container-startup-podman.yml
@@ -17,6 +17,11 @@ gateway_container_name: aap_gw_1
 redis_cluster_enabled: False
 redis_tls_enabled: True
 
+### Gateway preferences that will be set
+gateway_preferences:
+  status_endpoint_backend_timeout_seconds: 10
+  status_endpoint_backend_verify: false
+
 ### Sidecars (uncomment to enable):
 # keycloak_enabled: True
 # ldap_enabled: True

--- a/tools/configs/supervisord.conf
+++ b/tools/configs/supervisord.conf
@@ -80,7 +80,7 @@ stderr_logfile = /dev/stderr
 stderr_logfile_maxbytes = 0
 
 [program:dispatcher]
-command = /usr/bin/aap-gateway-manage dispatcherd run
+command = /usr/bin/aap-gateway-manage dispatcherd
 autorestart = true
 stopasgroup = false
 killasgroup = false

--- a/tools/configs/supervisord.conf
+++ b/tools/configs/supervisord.conf
@@ -79,8 +79,18 @@ stdout_logfile_maxbytes = 0
 stderr_logfile = /dev/stderr
 stderr_logfile_maxbytes = 0
 
+[program:dispatcher]
+command = /usr/bin/aap-gateway-manage dispatcherd run
+autorestart = true
+stopasgroup = false
+killasgroup = false
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
+stderr_logfile = /dev/stderr
+stderr_logfile_maxbytes = 0
+
 [group:gateway-processes]
-programs = nginx,uwsgi,control-plane
+programs = nginx,uwsgi,control-plane,dispatcher
 priority = 5
 
 [unix_http_server]


### PR DESCRIPTION
## Summary

Add dispatcherd to the supervisorctl configuration so it is managed alongside other Gateway services in the container dev environment.

**Jira**: [AAP-65394](https://redhat.atlassian.net/browse/AAP-65394)
**Depends on**: AAP-65393

## Changes

### `tools/configs/supervisord.conf`
- Added `[program:dispatcher]` section with `command = /usr/bin/aap-gateway-manage dispatcherd`
- Set `autorestart = true` for automatic restart on failure
- Set `stopasgroup = false` and `killasgroup = false` so dispatcher can be restarted independently
- Added `dispatcher` to the `gateway-processes` group

### `tools/configs/container-startup-podman.yml`
- Added `gateway_preferences` with status endpoint timeout and TLS verify settings

### `docs/dispatcherd.md`
- Updated story status and implementation details
- Corrected the dispatcherd command (was `dispatcherctl start`, now `dispatcherd`)
- Added files-modified section

## Acceptance Criteria Verified

| # | Criterion | Result |
|---|-----------|--------|
| 1 | Dispatcherd starts automatically with other gateway processes | **PASS** — runs in `gateway-processes` group |
| 2 | Dispatcherd restarts on failure | **PASS** — `kill -9` → auto-restarted within 3s |
| 3 | Independently restartable without affecting other processes | **PASS** — nginx/uwsgi/control-plane PIDs unchanged after dispatcher restart |
| 4 | `supervisorctl status` shows dispatcher running | **PASS** — `gateway-processes:dispatcher RUNNING` |
| 5 | `dispatcherctl status` returns valid dispatcher state | **PASS** — returns full state with worker pool, producers, tasks |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated dispatcherd documentation with new configuration guidance.

* **Chores**
  * Added dispatcherd service to supervisord process management configuration.
  * Configured gateway preferences for status endpoint handling with timeout and verification settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->