### PR TITLE
AAP-74397: Remove Django 4.2 CI testing support from GitHub workflows

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,7 +12,7 @@ env:
   TARGET_REPOSITORY: 'ansible/jewel'
 jobs:
   unit-test:
-    name: ${{ matrix.batch.name }} (Django ${{ matrix.django-version }})
+    name: ${{ matrix.batch.name }}
     runs-on: ubuntu-24.04
     env:
       # Avoid KeyError: 'Gateway' with Docker API 1.52+ (tox-docker expects NetworkSettings.Gateway).
@@ -25,10 +25,6 @@ jobs:
     # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#tools
     # https://github.com/tox-dev/tox-docker/pull/196
     if: github.repository == 'ansible/jewel' || github.repository == 'ansible/jewel-debug'
-    # Django 4.2 tests are informational only on devel (for backport compatibility checking)
-    # Django 5.2 tests must always pass - this is the production version for devel
-    # On stable-* branches, BOTH Django versions must pass (production uses 4.2 there)
-    continue-on-error: ${{ matrix.django-version == '4.2' && (github.base_ref == 'devel' || (github.event_name == 'push' && github.ref_name == 'devel')) }}
     services:
       redis:
         image: redis
@@ -41,7 +37,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        django-version: ["4.2", "5.2"]
         batch:
           # Views are split alphabetically by v1/ subdirectory name so both
           # halves stay roughly balanced as new test dirs are added.  Anything
@@ -97,15 +92,10 @@ jobs:
           python tools/scripts/get_pr_checkout.py \
             --always-clone-repos 'ansible/django-ansible-base'
 
-      # Construct tox environment name based on Django version
-      # e.g., py312-django42 or py312-django52
       - name: Set tox environment name
         id: tox-env
         run: |
-          DJANGO_VERSION="${{ matrix.django-version }}"
-          TOX_ENV="py312-django${DJANGO_VERSION/./}"
-          echo "name=${TOX_ENV}" >> $GITHUB_OUTPUT
-          echo "Using tox environment: ${TOX_ENV}"
+          echo "name=py312" >> "$GITHUB_OUTPUT"
 
       - name: Create tox environment and run setup
         # We use --collect-only instead of --notest because:
@@ -145,17 +135,14 @@ jobs:
           PYTEST_NUM_PROCESSES: ${{ matrix.batch.processes }}
           GATEWAY_TEST_DIRS: ""
         run: |
-          DJANGO_VERSION="${{ matrix.django-version }}"
-          ARTIFACT_SUFFIX="${{ matrix.batch.artifact-suffix }}-django${DJANGO_VERSION/./}"
           tox -e ${{ steps.tox-env.outputs.name }} -- ${{ matrix.batch.test-filter }} -v \
-            --cov=. --cov-report=xml:coverage-${ARTIFACT_SUFFIX}.xml \
-            --junit-xml=junit-${ARTIFACT_SUFFIX}.xml
+            --cov=. --cov-report=xml:coverage-${{ matrix.batch.artifact-suffix }}.xml \
+            --junit-xml=junit-${{ matrix.batch.artifact-suffix }}.xml
 
       - name: Set artifact suffix
         id: artifact
         run: |
-          DJANGO_VERSION="${{ matrix.django-version }}"
-          echo "suffix=${{ matrix.batch.artifact-suffix }}-django${DJANGO_VERSION/./}" >> $GITHUB_OUTPUT
+          echo "suffix=${{ matrix.batch.artifact-suffix }}" >> "$GITHUB_OUTPUT"
 
       - name: Inject PR number into coverage file
         if: github.event_name == 'pull_request'
@@ -177,8 +164,7 @@ jobs:
     name: Merge junit and upload results
     runs-on: ubuntu-latest
     needs: unit-test
-    # Run even if some jobs failed (Django 4.2 might fail with continue-on-error)
-    # but only if at least one job completed
+    # Run even if some jobs failed, but only if at least one job completed
     if: |
       always() &&
       (needs.unit-test.result == 'success' || needs.unit-test.result == 'failure') &&

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,8 +96,6 @@ legacy_tox_ini = """
         check-oauth2-permissions
         check-help-text
         py312
-        py312-django42
-        py312-django52
         312
         py311
         311
@@ -137,7 +135,7 @@ legacy_tox_ini = """
     deps =
         -r{toxinidir}/requirements/requirements_test.txt
 
-    [testenv:py311,py312,py312-django42,py312-django52]
+    [testenv:py311,py312]
     allowlist_externals =
         ./tools/scripts/ci/tox-reinstall-django-ansible-base.sh
         ./tools/scripts/ci/install_django_venv.sh

--- a/requirements/constraints_django42.txt
+++ b/requirements/constraints_django42.txt
@@ -1,7 +1,0 @@
-# Django 4.2 LTS constraint file for transition testing
-# This file is used during the Django 4.2 -> 5.2 transition period
-# to test backward compatibility with stable branches.
-#
-# IMPORTANT: Keep this pin in sync with stable branch requirements.txt
-#
-Django==4.2.26

--- a/requirements/constraints_django52.txt
+++ b/requirements/constraints_django52.txt
@@ -1,6 +1,0 @@
-# Django 5.2 LTS constraint file
-# This is the current production version for devel branch.
-#
-# IMPORTANT: Keep this pin in sync with requirements.txt
-#
-Django==5.2.9

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,6 +1,5 @@
 cryptography >= 46.0.5 # Updated for CVE-2026-26007
-# NOTE: When updating Django version, also update requirements/constraints_django52.txt
-Django>=5.2.8,<5.3 # Upgrade to Django 5.2 LTS - see AAP-55610 and CVE-2025-64459
+Django>=5.2.8,<5.3 # Django 5.2 LTS - see AAP-55610
 djangorestframework
 django-crum
 django-dynamic-preferences

--- a/tools/scripts/ci/install_django_venv.sh
+++ b/tools/scripts/ci/install_django_venv.sh
@@ -1,14 +1,9 @@
 #!/usr/bin/env sh
 #
 # NOTE: This script is meant to be used by tox as an install_command.
-# It handles installing Django dependencies with proper django-ansible-base handling.
+# It handles installing dependencies with proper django-ansible-base handling.
 #
 # Usage: install_django_venv.sh <envname> <pip_opts> <packages>
-#
-# The script detects Django version from the envname:
-#   - py312-django42 -> uses constraints_django42.txt
-#   - py312-django52 -> uses constraints_django52.txt
-#   - py312 (no suffix) -> uses constraints_django52.txt (default)
 
 # Exit on any error
 set -e
@@ -16,17 +11,6 @@ set -e
 # Pass in the tox env name as the first argument
 ENV_NAME="$1"
 shift  # Remove first argument, rest are pip options and packages from tox
-
-# Determine Django constraint file based on environment name
-CONSTRAINT_FILE=""
-case "$ENV_NAME" in
-    *-django42*)
-        CONSTRAINT_FILE="requirements/constraints_django42.txt"
-        ;;
-    *-django52*|py311|py312)
-        CONSTRAINT_FILE="requirements/constraints_django52.txt"
-        ;;
-esac
 
 # First, handle django-ansible-base installation
 # If this fails, the script will exit due to 'set -e'
@@ -40,16 +24,5 @@ if ! pip show django-ansible-base > /dev/null 2>&1; then
     GIT_REQUIREMENTS="-r requirements/requirements_git.txt"
 fi
 
-# Install all dependencies from requirements.txt (includes pinned Django version for production)
+# Install all dependencies from requirements.txt (includes pinned Django version)
 pip install psycopg[binary] -r requirements/requirements.txt ${GIT_REQUIREMENTS} "$@"
-
-# If a Django constraint file was determined, reinstall Django to match the constraint.
-# This is used for CI testing against different Django versions (e.g., 4.2 vs 5.2)
-# while keeping requirements.txt pinned to the production version.
-# Note: pip constraints don't override explicit == pins, so we must reinstall explicitly.
-if [ -n "$CONSTRAINT_FILE" ] && [ -f "$CONSTRAINT_FILE" ]; then
-    echo "Reinstalling Django with constraint file: $CONSTRAINT_FILE"
-    pip install --force-reinstall -c "$CONSTRAINT_FILE" Django
-    echo "Django version after constraint applied:"
-    pip show django | grep Version
-fi


### PR DESCRIPTION
## Summary

Now that the Django 5.2 upgrade has fully shipped across all branches (devel, stable-2.5, stable-2.6) and the upgrade epic (AAP-55610) is closed, this PR removes the Django 4.2 backward-compatibility testing scaffolding that was introduced during the transition period (PR #1201 / AAP-60155 and PR #1226 / AAP-64316).

This halves the CI unit test matrix (from 8 jobs to 4) and simplifies the workflow configuration.

## Changes

### `.github/workflows/unit-tests.yml`
- Removed the `django-version: ["4.2", "5.2"]` matrix dimension
- Removed the `continue-on-error` conditional that allowed Django 4.2 failures on devel
- Simplified job names (removed `(Django ${{ matrix.django-version }})` suffix)
- Simplified artifact naming (removed `-django${VERSION}` suffixes)
- Simplified tox environment to static `py312` instead of dynamic `py312-django42`/`py312-django52`
- Removed Django 4.2-related comments

### `requirements/constraints_django42.txt`
- Deleted — no longer needed since Django 4.2 is not tested

### `requirements/constraints_django52.txt`
- Deleted — redundant since `requirements/requirements.txt` already pins `django==5.2.9` and there is no longer a need to force-reinstall a different Django version

### `tools/scripts/ci/install_django_venv.sh`
- Removed the `case` statement that selected constraint files based on tox env name
- Removed the `--force-reinstall` logic (Django is now installed directly from `requirements.txt`)

### `pyproject.toml` (tox configuration)
- Removed `py312-django42` and `py312-django52` from `env_list`
- Simplified testenv header from `[testenv:py311,py312,py312-django42,py312-django52]` to `[testenv:py311,py312]`

### `requirements/requirements.in`
- Removed stale comment referencing `constraints_django52.txt`

## Issue

AAP-74397

## Test plan

- [ ] CI unit tests pass on all 4 batch jobs (Views A-R, Views S-Z, Non-views, Service tests)
- [ ] No references to `django42`, `constraints_django42`, or `constraints_django52` remain in CI config
- [ ] Tox `py312` environment works correctly with Django 5.2 from `requirements.txt`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Django 4.2 from the test matrix, consolidating testing around Django 5.2 LTS only
  * Simplified CI environment setup and dependency installation process
  * Streamlined test environment naming conventions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->