### PR TITLE
[AAP-59804] Extract duplicated string literals into named constants

### DIFF
--- a/aap_gateway_api/common/envoy.py
+++ b/aap_gateway_api/common/envoy.py
@@ -1,2 +1,27 @@
+from envoy.extensions.access_loggers.stream.v3 import stream_pb2
+from envoy.extensions.filters.http.ext_authz.v3 import ext_authz_pb2
+from envoy.extensions.filters.http.lua.v3 import lua_pb2
+from envoy.extensions.filters.http.router.v3 import router_pb2
+from envoy.extensions.filters.network.http_connection_manager.v3 import http_connection_manager_pb2
+from envoy.extensions.transport_sockets.tls.v3 import tls_pb2
+
+_TYPE_URL_PREFIX = "type.googleapis.com"
+
+
+def _type_url(descriptor) -> str:
+    return f"{_TYPE_URL_PREFIX}/{descriptor.full_name}"
+
+
+# Filter name used in Envoy filter chain config — not a type URL.
 EXT_AUTH_FILTER = "envoy.filters.http.ext_authz"
-EXT_AUTH_PER_ROUTE = "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute"
+
+# Type URLs derived from protobuf message descriptors.
+EXT_AUTH_PER_ROUTE = _type_url(ext_authz_pb2.ExtAuthzPerRoute.DESCRIPTOR)
+UPSTREAM_TLS_CONTEXT = _type_url(tls_pb2.UpstreamTlsContext.DESCRIPTOR)
+DOWNSTREAM_TLS_CONTEXT = _type_url(tls_pb2.DownstreamTlsContext.DESCRIPTOR)
+LUA_FILTER = _type_url(lua_pb2.Lua.DESCRIPTOR)
+LUA_PER_ROUTE = _type_url(lua_pb2.LuaPerRoute.DESCRIPTOR)
+EXT_AUTHZ_FILTER = _type_url(ext_authz_pb2.ExtAuthz.DESCRIPTOR)
+HTTP_ROUTER = _type_url(router_pb2.Router.DESCRIPTOR)
+HTTP_CONNECTION_MANAGER = _type_url(http_connection_manager_pb2.HttpConnectionManager.DESCRIPTOR)
+STDOUT_ACCESS_LOG = _type_url(stream_pb2.StdoutAccessLog.DESCRIPTOR)

--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -7,6 +7,13 @@ from ansible_base.authentication.models import AuthenticatorUser
 from ansible_base.authentication.models.authenticator import Authenticator
 from ansible_base.rbac.models import DABContentType, DABPermission, RoleDefinition, RoleTeamAssignment, RoleUserAssignment
 from ansible_base.rbac.remote import RemoteObject
+from ansible_base.resource_registry.constants import (
+    SHARED_AAP_FLAG_RESOURCE_TYPE,
+    SHARED_ORGANIZATION_RESOURCE_TYPE,
+    SHARED_ROLE_DEFINITION_RESOURCE_TYPE,
+    SHARED_TEAM_RESOURCE_TYPE,
+    SHARED_USER_RESOURCE_TYPE,
+)
 from ansible_base.resource_registry.models import Resource, ResourceType, service_id
 from ansible_base.resource_registry.rest_client import ResourceRequestBody
 from django.conf import settings
@@ -133,38 +140,38 @@ class Command(BaseCommand):
         # The order here matters. Organizations need to be migrated first.
         self.resource_types_to_migrate = OrderedDict()
 
-        self.resource_types_to_migrate["shared.organization"] = {
+        self.resource_types_to_migrate[SHARED_ORGANIZATION_RESOURCE_TYPE] = {
             "merge": merge_organizations,
-            "type": ResourceType.objects.get(name="shared.organization"),
+            "type": ResourceType.objects.get(name=SHARED_ORGANIZATION_RESOURCE_TYPE),
             "unique_fields": [
                 "name",
             ],
         }
-        self.resource_types_to_migrate["shared.team"] = {
+        self.resource_types_to_migrate[SHARED_TEAM_RESOURCE_TYPE] = {
             "merge": merge_teams,
-            "type": ResourceType.objects.get(name="shared.team"),
+            "type": ResourceType.objects.get(name=SHARED_TEAM_RESOURCE_TYPE),
             "unique_fields": [
                 "name",
                 "organization",
             ],
         }
-        self.resource_types_to_migrate["shared.user"] = {
+        self.resource_types_to_migrate[SHARED_USER_RESOURCE_TYPE] = {
             "merge": True,  # only indicates we merge the admin user
-            "type": ResourceType.objects.get(name="shared.user"),
+            "type": ResourceType.objects.get(name=SHARED_USER_RESOURCE_TYPE),
             "unique_fields": [
                 "username",
             ],
         }
-        self.resource_types_to_migrate["shared.roledefinition"] = {
+        self.resource_types_to_migrate[SHARED_ROLE_DEFINITION_RESOURCE_TYPE] = {
             "merge": True,  # the JWT roles are already shared effectively
-            "type": ResourceType.objects.get(name="shared.roledefinition"),
+            "type": ResourceType.objects.get(name=SHARED_ROLE_DEFINITION_RESOURCE_TYPE),
             "unique_fields": [
                 "name",
             ],
         }
-        self.resource_types_to_migrate["shared.aapflag"] = {
+        self.resource_types_to_migrate[SHARED_AAP_FLAG_RESOURCE_TYPE] = {
             "merge": True,
-            "type": ResourceType.objects.get(name="shared.aapflag"),
+            "type": ResourceType.objects.get(name=SHARED_AAP_FLAG_RESOURCE_TYPE),
             "unique_fields": [
                 "name",
                 "condition",
@@ -452,7 +459,7 @@ class Command(BaseCommand):
         Used for producing updated resource data for resource that failed validation.
         """
         # if the resource is a user and there is only one validation error for email field, we can remove the field
-        if resource_type_name == "shared.user" and "email" in original_resource_data.errors and len(original_resource_data.errors.keys()) == 1:
+        if resource_type_name == SHARED_USER_RESOURCE_TYPE and "email" in original_resource_data.errors and len(original_resource_data.errors.keys()) == 1:
             self.stderr.write(f"Removing invalid email address '{original_resource_data.data['email']}' for user: {original_resource_data.data['username']}")
             # we want to update the email to empty string
             updated_resource_data = original_resource_data.data
@@ -649,7 +656,7 @@ class Command(BaseCommand):
         self.stdout.write(f"Items remaining: {data['count']}")
         results = data['results']
         # As special case exclude the system user, since Gateway excludes this in its own resources
-        if resource_type_name == 'shared.user':
+        if resource_type_name == SHARED_USER_RESOURCE_TYPE:
             # SYSTEM_USERNAME can theoretically vary by service
             # Currently, the system username is None in controller, and in hub and eda it's the same as gateway's,
             # If Hub and EDA system username is updated to != gateway's, we are migrating it too and we should avoid it
@@ -698,7 +705,7 @@ class Command(BaseCommand):
         validated_resource_data = self._deserialize_and_validate_resource_data(upstream_resource, resource_context["type_serializer"])
 
         # Sync superuser flags for user resources
-        if resource_context["type_name"] == "shared.user":
+        if resource_context["type_name"] == SHARED_USER_RESOURCE_TYPE:
             upstream_resource = self._sync_user_superuser_flag(upstream_resource, validated_resource_data)
             # Re-validate after potential superuser flag changes
             validated_resource_data = self._deserialize_and_validate_resource_data(upstream_resource, resource_context["type_serializer"])
@@ -941,7 +948,7 @@ class Command(BaseCommand):
         # Get all users from the shared resource registry (no service_id filter since
         # after migration all resources have Gateway's service_id)
         filters = {
-            "content_type__resource_type__name": "shared.user",
+            "content_type__resource_type__name": SHARED_USER_RESOURCE_TYPE,
         }
 
         controller_superusers = set()
@@ -995,7 +1002,7 @@ class Command(BaseCommand):
 
         filters = {
             "service_id": str(service_id()),
-            "content_type__resource_type__name": "shared.user",
+            "content_type__resource_type__name": SHARED_USER_RESOURCE_TYPE,
         }
 
         demoted_users = []
@@ -1046,7 +1053,9 @@ class Command(BaseCommand):
 
         gateway_service_id = service_id()
         partially_migrated_resources = (
-            Resource.objects.filter(content_type__resource_type__name="shared.user").exclude(service_id=gateway_service_id).select_related('content_type')
+            Resource.objects.filter(content_type__resource_type__name=SHARED_USER_RESOURCE_TYPE)
+            .exclude(service_id=gateway_service_id)
+            .select_related('content_type')
         )
 
         total_partially_migrated_users = len(partially_migrated_resources)

--- a/aap_gateway_api/models/route.py
+++ b/aap_gateway_api/models/route.py
@@ -6,7 +6,7 @@ from django.db import models
 from django.urls import reverse
 from django.utils.translation import gettext as _
 
-from aap_gateway_api.common.envoy import EXT_AUTH_FILTER, EXT_AUTH_PER_ROUTE
+from aap_gateway_api.common.envoy import EXT_AUTH_FILTER, EXT_AUTH_PER_ROUTE, LUA_PER_ROUTE, UPSTREAM_TLS_CONTEXT
 from aap_gateway_api.models.http_port import HTTPPort
 from aap_gateway_api.models.service_cluster import ServiceCluster
 from aap_gateway_api.models.service_type import DefaultServiceType
@@ -205,7 +205,7 @@ class Route(UniqueNamedCommonModel, AuditableModel):
             cfg["transport_socket"] = {
                 "name": "envoy.transport_sockets.tls",
                 "typed_config": {
-                    "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+                    "@type": UPSTREAM_TLS_CONTEXT,
                     "common_tls_context": {
                         "tls_params": {
                             "tls_maximum_protocol_version": "TLSv1_3",
@@ -265,7 +265,7 @@ class Route(UniqueNamedCommonModel, AuditableModel):
             cfg["metadata"]["filter_metadata"] = {"envoy.filters.http.lua": {"prefix": self.gateway_path, "prefix_rewrite": self.service_path}}
 
             cfg["typed_per_filter_config"]["envoy.filters.http.lua"] = {
-                "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute",
+                "@type": LUA_PER_ROUTE,
                 "name": "rewrite.lua",
             }
 

--- a/aap_gateway_api/resource_api.py
+++ b/aap_gateway_api/resource_api.py
@@ -4,6 +4,13 @@ from typing import Optional
 
 from ansible_base.feature_flags.models import AAPFlag
 from ansible_base.rbac.models import DABPermission, RoleDefinition
+from ansible_base.resource_registry.constants import (
+    SHARED_AAP_FLAG_RESOURCE_TYPE,
+    SHARED_ORGANIZATION_RESOURCE_TYPE,
+    SHARED_ROLE_DEFINITION_RESOURCE_TYPE,
+    SHARED_TEAM_RESOURCE_TYPE,
+    SHARED_USER_RESOURCE_TYPE,
+)
 from ansible_base.resource_registry.registry import ParentResource, ResourceConfig, ServiceAPIConfig, SharedResource
 from ansible_base.resource_registry.shared_types import FeatureFlagType, OrganizationType, RoleDefinitionType, TeamType, UserType
 from ansible_base.resource_registry.utils.resource_type_processor import ResourceTypeProcessor
@@ -250,11 +257,11 @@ class GatewayRoleDefinitionType(RoleDefinitionType):
 class APIConfig(ServiceAPIConfig):
     service_type = "aap"
     custom_resource_processors = {
-        "shared.organization": GetOrCreateProcessor,
-        "shared.team": GetOrCreateProcessor,
-        "shared.user": GetOrCreateProcessor,
-        "shared.roledefinition": GatewayRoleDefinitionProcessor,
-        "shared.aapflag": GetOrCreateProcessor,
+        SHARED_ORGANIZATION_RESOURCE_TYPE: GetOrCreateProcessor,
+        SHARED_TEAM_RESOURCE_TYPE: GetOrCreateProcessor,
+        SHARED_USER_RESOURCE_TYPE: GetOrCreateProcessor,
+        SHARED_ROLE_DEFINITION_RESOURCE_TYPE: GatewayRoleDefinitionProcessor,
+        SHARED_AAP_FLAG_RESOURCE_TYPE: GetOrCreateProcessor,
     }
 
 

--- a/aap_gateway_api/tests/test_constants.py
+++ b/aap_gateway_api/tests/test_constants.py
@@ -1,0 +1,144 @@
+"""Tests for extracted constants (SonarCloud maintainability fixes).
+
+Verifies that duplicated string literals have been properly extracted into
+named constants and are used consistently across the codebase.
+"""
+
+from unittest.mock import patch
+
+from ansible_base.resource_registry.constants import SHARED_USER_RESOURCE_TYPE
+
+from aap_gateway_api.common.envoy import (
+    DOWNSTREAM_TLS_CONTEXT,
+    EXT_AUTH_FILTER,
+    EXT_AUTH_PER_ROUTE,
+    EXT_AUTHZ_FILTER,
+    HTTP_CONNECTION_MANAGER,
+    HTTP_ROUTER,
+    LUA_FILTER,
+    LUA_PER_ROUTE,
+    STDOUT_ACCESS_LOG,
+    UPSTREAM_TLS_CONTEXT,
+)
+from aap_gateway_api.urls import API_GATEWAY_V1_PREFIX
+
+
+class TestSharedUserResourceTypeConstant:
+    """Verify the SHARED_USER_RESOURCE_TYPE constant value and usage."""
+
+    def test_shared_user_resource_type_value(self):
+        assert SHARED_USER_RESOURCE_TYPE == "shared.user"
+
+    def test_shared_user_in_api_config(self):
+        """APIConfig.custom_resource_processors should use the constant."""
+        from aap_gateway_api.resource_api import APIConfig
+
+        assert SHARED_USER_RESOURCE_TYPE in APIConfig.custom_resource_processors
+
+
+class TestEnvoyTypeUrlConstants:
+    """Verify the Envoy type URL constants have correct values."""
+
+    def test_upstream_tls_context_value(self):
+        assert UPSTREAM_TLS_CONTEXT == "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext"
+
+    def test_downstream_tls_context_value(self):
+        assert DOWNSTREAM_TLS_CONTEXT == "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext"
+
+    def test_lua_filter_value(self):
+        assert LUA_FILTER == "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua"
+
+    def test_lua_per_route_value(self):
+        assert LUA_PER_ROUTE == "type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute"
+
+    def test_ext_authz_filter_value(self):
+        assert EXT_AUTHZ_FILTER == "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz"
+
+    def test_http_router_value(self):
+        assert HTTP_ROUTER == "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+
+    def test_http_connection_manager_value(self):
+        assert HTTP_CONNECTION_MANAGER == "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
+
+    def test_stdout_access_log_value(self):
+        assert STDOUT_ACCESS_LOG == "type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog"
+
+    def test_ext_auth_filter_value(self):
+        """Pre-existing constant -- ensure it is unchanged."""
+        assert EXT_AUTH_FILTER == "envoy.filters.http.ext_authz"
+
+    def test_ext_auth_per_route_value(self):
+        """Pre-existing constant -- ensure it is unchanged."""
+        assert EXT_AUTH_PER_ROUTE == "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute"
+
+
+class TestXdsConfigsUseConstants:
+    """Verify that xds_configs.py functions produce configs using the constants."""
+
+    @patch("aap_gateway_api.utils.xds_configs.settings")
+    def test_path_rewrite_filter_uses_lua_filter(self, mock_settings):
+        mock_settings.GATEWAY_PATH_REWRITE_SCRIPT_FILE = "/tmp/rewrite.lua"
+        from aap_gateway_api.utils.xds_configs import path_rewrite_filter
+
+        result = path_rewrite_filter()
+        assert result["typed_config"]["@type"] == LUA_FILTER
+
+    @patch("aap_gateway_api.utils.xds_configs.settings")
+    def test_external_auth_filter_uses_ext_authz_filter(self, mock_settings):
+        mock_settings.GRPC_SERVER_AUTH_SERVICE_TIMEOUT = "5s"
+        mock_settings.GRPC_SERVER_MAX_RECEIVE_MESSAGE_LENGTH = 16384
+        from aap_gateway_api.utils.xds_configs import external_auth_filter
+
+        result = external_auth_filter()
+        assert result["typed_config"]["@type"] == EXT_AUTHZ_FILTER
+
+    @patch("aap_gateway_api.utils.xds_configs.settings")
+    def test_http_router_filter_uses_http_router(self, mock_settings):
+        from aap_gateway_api.utils.xds_configs import http_router_filter
+
+        result = http_router_filter()
+        assert result["typed_config"]["@type"] == HTTP_ROUTER
+
+    @patch("aap_gateway_api.utils.xds_configs.settings")
+    def test_network_manager_filter_uses_constants(self, mock_settings):
+        mock_settings.XDS_XFF_NUM_TRUSTED_HOPS = 0
+        from aap_gateway_api.utils.xds_configs import network_manager_filter
+
+        result = network_manager_filter()
+        assert result["typed_config"]["@type"] == HTTP_CONNECTION_MANAGER
+        assert result["typed_config"]["access_log"][0]["typed_config"]["@type"] == STDOUT_ACCESS_LOG
+
+    @patch("aap_gateway_api.utils.xds_configs.settings")
+    def test_transport_socket_uses_downstream_tls_context(self, mock_settings):
+        mock_settings.GATEWAY_CERT_FILE = "/tmp/cert.pem"
+        mock_settings.GATEWAY_KEY_FILE = "/tmp/key.pem"
+        mock_settings.SDS_CLUSTER_NAMES = ["sds_cluster"]
+        mock_settings.SDS_REFRESH_DELAY_PROTOBUF_DURATION = "30s"
+        from aap_gateway_api.utils.xds_configs import transport_socket
+
+        result = transport_socket()
+        assert result["typed_config"]["@type"] == DOWNSTREAM_TLS_CONTEXT
+
+
+class TestApiGatewayV1PrefixConstant:
+    """Verify the API_GATEWAY_V1_PREFIX constant value and usage in URL patterns."""
+
+    def test_api_gateway_v1_prefix_value(self):
+        assert API_GATEWAY_V1_PREFIX == "api/gateway/v1/"
+
+    def test_prefix_used_in_urlpatterns(self):
+        """Verify that URL patterns resolve correctly using the constant."""
+        from aap_gateway_api.urls import urlpatterns
+
+        # Check that we have URL patterns defined
+        assert len(urlpatterns) > 0
+
+        # Verify key URL patterns exist by checking their names
+        url_names = [getattr(p, 'name', None) for p in urlpatterns]
+        assert 'ping-view' in url_names
+        assert 'status-view' in url_names
+        assert 'jwt-key-view' in url_names
+        assert 'login' in url_names
+        assert 'logout' in url_names
+        assert 'me-list' in url_names
+        assert 'session-view' in url_names

--- a/aap_gateway_api/urls.py
+++ b/aap_gateway_api/urls.py
@@ -16,6 +16,7 @@ from aap_gateway_api.views.api.envoy.rest_control_plane import ClusterDiscoverSe
 
 logger = logging.getLogger('aap.gateway.urls')
 
+API_GATEWAY_V1_PREFIX = "api/gateway/v1/"
 
 user_access_view = UserAccessViewSet.as_view({'get': 'list'})
 team_access_view = TeamAccessViewSet.as_view({'get': 'list'})
@@ -26,44 +27,48 @@ register_converter(IntOrUUIDConverter, "int_or_uuid")
 
 urlpatterns = [
     # Load base URLs first
-    path('api/gateway/v1/', include(api_version_urls)),
+    path(API_GATEWAY_V1_PREFIX, include(api_version_urls)),
     path('api/gateway/', include(api_urls)),
     path('', include(root_urls)),
     # Extra DAB RBAC views that need to be included because we exclude it from api_version_urls
     path(r'role_metadata/', RoleMetadataView.as_view(), name="role-metadata"),
-    path('api/gateway/v1/role_user_access/<str:model_name>/<int_or_uuid:pk>/', user_access_view, name="role-user-access"),
-    path('api/gateway/v1/role_team_access/<str:model_name>/<int_or_uuid:pk>/', team_access_view, name="role-team-access"),
+    path(f'{API_GATEWAY_V1_PREFIX}role_user_access/<str:model_name>/<int_or_uuid:pk>/', user_access_view, name="role-user-access"),
+    path(f'{API_GATEWAY_V1_PREFIX}role_team_access/<str:model_name>/<int_or_uuid:pk>/', team_access_view, name="role-team-access"),
     path(
-        'api/gateway/v1/role_user_access/<str:model_name>/<int_or_uuid:pk>/<str:actor_pk>/',
+        f'{API_GATEWAY_V1_PREFIX}role_user_access/<str:model_name>/<int_or_uuid:pk>/<str:actor_pk>/',
         user_access_assignment_view,
         name='role-user-access-assignments',
     ),
     path(
-        'api/gateway/v1/role_team_access/<str:model_name>/<int_or_uuid:pk>/<str:actor_pk>/',
+        f'{API_GATEWAY_V1_PREFIX}role_team_access/<str:model_name>/<int_or_uuid:pk>/<str:actor_pk>/',
         team_access_assignment_view,
         name='role-team-access-assignments',
     ),
     path('admin/', admin.site.urls),
     path('api/', views.ApiRootView.as_view(), name='api_root_view'),
     path('api/gateway/', views.GatewayRootView.as_view(), name='api_gateway_root_view'),
-    path('api/gateway/v1/', views.V1RootView.as_view(), name='api_gateway_v1_root_view'),
-    path('api/gateway/v1/jwt_key/', views.JWTKeyView.as_view(), name='jwt-key-view'),
-    path('api/gateway/v1/ping/', views.PingView.as_view(), name='ping-view'),
-    path('api/gateway/v1/status/', views.StatusView.as_view(), name='status-view'),
-    re_path('api/gateway/v1/users/(?P<pk>[0-9]+)/teams/', views.UserTeamViewSet.as_view({'get': 'list'}), name='user-teams-list'),
-    re_path('api/gateway/v1/users/(?P<pk>[0-9]+)/organizations/', views.UserOrganizationViewSet.as_view({'get': 'list'}), name='user-organizations-list'),
+    path(API_GATEWAY_V1_PREFIX, views.V1RootView.as_view(), name='api_gateway_v1_root_view'),
+    path(f'{API_GATEWAY_V1_PREFIX}jwt_key/', views.JWTKeyView.as_view(), name='jwt-key-view'),
+    path(f'{API_GATEWAY_V1_PREFIX}ping/', views.PingView.as_view(), name='ping-view'),
+    path(f'{API_GATEWAY_V1_PREFIX}status/', views.StatusView.as_view(), name='status-view'),
+    re_path(f'{API_GATEWAY_V1_PREFIX}users/(?P<pk>[0-9]+)/teams/', views.UserTeamViewSet.as_view({'get': 'list'}), name='user-teams-list'),
+    re_path(
+        f'{API_GATEWAY_V1_PREFIX}users/(?P<pk>[0-9]+)/organizations/',
+        views.UserOrganizationViewSet.as_view({'get': 'list'}),
+        name='user-organizations-list',
+    ),
     path(
-        'api/gateway/v1/login/',
+        f'{API_GATEWAY_V1_PREFIX}login/',
         views.LoggedLoginView.as_view(template_name='rest_framework/login.html', extra_context={'inside_login_context': True}),
         name='login',
     ),
-    path('api/gateway/v1/logout/', views.LoggedLogoutView.as_view(next_page='/api/', redirect_field_name='next'), name='logout'),
-    path('api/gateway/v1/me/', views.MeViewSet.as_view({'get': 'list'}), name='me-list'),
-    path('api/gateway/v1/session/', views.SessionView.as_view(), name='session-view'),
+    path(f'{API_GATEWAY_V1_PREFIX}logout/', views.LoggedLogoutView.as_view(next_page='/api/', redirect_field_name='next'), name='logout'),
+    path(f'{API_GATEWAY_V1_PREFIX}me/', views.MeViewSet.as_view({'get': 'list'}), name='me-list'),
+    path(f'{API_GATEWAY_V1_PREFIX}session/', views.SessionView.as_view(), name='session-view'),
     # settings
-    re_path(r'api/gateway/v1/settings/(?P<category_slug>[a-z0-9_]+)/$', views.SettingSectionView.as_view(), name='setting-section-list'),
+    re_path(rf'{API_GATEWAY_V1_PREFIX}settings/(?P<category_slug>[a-z0-9_]+)/$', views.SettingSectionView.as_view(), name='setting-section-list'),
     re_path(
-        r'^api/gateway/v1/settings/(?P<category_slug>[a-z0-9_]+)/(?P<preference_name>[a-zA-Z0-9_]+)/$',
+        rf'^{API_GATEWAY_V1_PREFIX}settings/(?P<category_slug>[a-z0-9_]+)/(?P<preference_name>[a-zA-Z0-9_]+)/$',
         views.SettingPreferenceView.as_view(),
         name='setting-detail',
     ),
@@ -72,15 +77,15 @@ urlpatterns = [
     path('v3/discovery:clusters', ClusterDiscoverServiceView.as_view(), name='cds'),
     path('v3/discovery:secrets', SecretDiscoverServiceView.as_view(), name='sds'),
     # Social auth
-    path('api/gateway/v1/', include(router.urls)),
-    path('api/gateway/v1/', include(resource_api_urls)),
-    path('api/gateway/v1/', include(rbac_service_urls)),
+    path(API_GATEWAY_V1_PREFIX, include(router.urls)),
+    path(API_GATEWAY_V1_PREFIX, include(resource_api_urls)),
+    path(API_GATEWAY_V1_PREFIX, include(rbac_service_urls)),
     # JWT claims endpoint
-    path('api/gateway/v1/jwt_claims/<str:user_ansible_id>/', views.JWTClaimsView.as_view(), name='jwt-claims-view'),
+    path(f'{API_GATEWAY_V1_PREFIX}jwt_claims/<str:user_ansible_id>/', views.JWTClaimsView.as_view(), name='jwt-claims-view'),
     # OIDC Workload Identity endpoints (behind feature flag)
     flagged_path(
         'FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED',
-        'api/gateway/v1/workload_identity_tokens/',
+        f'{API_GATEWAY_V1_PREFIX}workload_identity_tokens/',
         views.WorkloadIdentityTokensView.as_view(),
         name='workload-identity-tokens-view',
         state=True,

--- a/aap_gateway_api/utils/xds_configs.py
+++ b/aap_gateway_api/utils/xds_configs.py
@@ -1,5 +1,7 @@
 from django.conf import settings
 
+from aap_gateway_api.common.envoy import DOWNSTREAM_TLS_CONTEXT, EXT_AUTHZ_FILTER, HTTP_CONNECTION_MANAGER, HTTP_ROUTER, LUA_FILTER, STDOUT_ACCESS_LOG
+
 SDS_SECRET_CONFIG_NAME = "validation_context_sds"
 
 
@@ -7,7 +9,7 @@ def path_rewrite_filter():
     return {
         "name": "lua_path_rewrite",
         "typed_config": {
-            "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
+            "@type": LUA_FILTER,
             "source_codes": {"rewrite.lua": {"filename": settings.GATEWAY_PATH_REWRITE_SCRIPT_FILE}},
         },
     }
@@ -17,7 +19,7 @@ def external_auth_filter():
     return {
         "name": "envoy.filters.http.ext_authz",
         "typed_config": {
-            "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
+            "@type": EXT_AUTHZ_FILTER,
             "grpc_service": {
                 "envoy_grpc": {"cluster_name": "gateway_control_plane"},
                 "timeout": settings.GRPC_SERVER_AUTH_SERVICE_TIMEOUT,
@@ -35,14 +37,14 @@ def external_auth_filter():
 
 
 def http_router_filter():
-    return {"name": "envoy.filters.http.router", "typed_config": {"@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"}}
+    return {"name": "envoy.filters.http.router", "typed_config": {"@type": HTTP_ROUTER}}
 
 
 def network_manager_filter(http_filters=[], routes=[]):
     return {
         "name": "envoy.filters.network.http_connection_manager",
         "typed_config": {
-            "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+            "@type": HTTP_CONNECTION_MANAGER,
             "stat_prefix": "ingress_http",
             "upgrade_configs": [
                 {"upgrade_type": "websocket"},
@@ -50,7 +52,7 @@ def network_manager_filter(http_filters=[], routes=[]):
             "access_log": [
                 {
                     "name": "envoy.access_loggers.stdout",
-                    "typed_config": {"@type": "type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog"},
+                    "typed_config": {"@type": STDOUT_ACCESS_LOG},
                 },
             ],
             "http_filters": http_filters,
@@ -76,7 +78,7 @@ def transport_socket():
     return {
         "name": "envoy.transport_sockets.tls",
         "typed_config": {
-            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+            "@type": DOWNSTREAM_TLS_CONTEXT,
             "require_client_certificate": False,
             "common_tls_context": {
                 "tls_certificates": [


### PR DESCRIPTION
## Summary

Address SonarCloud HIGH maintainability findings (#109) by extracting duplicated string literals into named constants. Incorporates reviewer feedback:

- **Shared resource type constants moved to DAB** — `SHARED_USER_RESOURCE_TYPE` and siblings now live in `ansible_base/resource_registry/constants.py` and are imported by gateway
- **All `custom_resource_processors` keys use constants** — fixes visual inconsistency where only one key used a constant
- **Envoy type URL constants derived from protobuf descriptors** — provides type safety; if a proto changes in an `xds-protos` upgrade, you get an import error rather than a silent mismatch
- **`API_GATEWAY_V1_PREFIX`** for URL prefix deduplication (unchanged from original PR)

## Requires

- https://github.com/ansible/django-ansible-base/pull/1005

## Changes

- **`aap_gateway_api/resource_api.py`**: Import all 5 shared resource type constants from DAB; use them consistently in `custom_resource_processors`
- **`aap_gateway_api/management/commands/migrate_service_data.py`**: Import from DAB; replace all remaining `"shared.*"` string literals with constants
- **`aap_gateway_api/common/envoy.py`**: Derive 9 type URL constants from protobuf message descriptors via `DESCRIPTOR.full_name`; keep `EXT_AUTH_FILTER` as a hand-coded filter name
- **`aap_gateway_api/urls.py`**: `API_GATEWAY_V1_PREFIX` constant (unchanged)
- **`aap_gateway_api/tests/test_constants.py`**: Comprehensive tests for all constants and their usage

## Risk Assessment

- **Confidence:** High — mechanical refactor with no behavioral changes
- **Risk:** Low — existing tests cover all affected code paths; Envoy value-assertion tests serve as regression guards against protobuf upgrades
- **Scope:** 7 file(s) changed (6 production + 1 test)

## Testing

- [ ] Unit tests pass
- [ ] Lint checks pass

## JIRA

- Ticket: [AAP-59804](https://redhat.atlassian.net/browse/AAP-59804)

---
*Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com> | Review carefully before merging.*

[AAP-59804]: https://redhat.atlassian.net/browse/AAP-59804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced scattered hardcoded type strings and resource-type literals with centralized constants for Envoy types, shared resource types, and API v1 route prefix.
  * Updated gateway route and XDS config generation to reference these constants for consistent typed-config values and routing prefixes.
  * Switched registration of shared resource processors to use the shared resource-type constants.

* **Tests**
  * Added tests validating constant values and that configuration builders and URL patterns use them consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->