### PR TITLE
fix(AAP-73972): fix oidc group membership

### DIFF
--- a/aap_gateway_api/oauth2_validator.py
+++ b/aap_gateway_api/oauth2_validator.py
@@ -1,5 +1,9 @@
+import logging
+
 from ansible_base.lib.workload_identity import SCOPE_REGISTRY
 from oauth2_provider.oauth2_validators import OAuth2Validator
+
+logger = logging.getLogger('aap_gateway_api.oauth2_validator')
 
 # Standard OIDC user identity claims advertised in discovery
 USER_IDENTITY_CLAIMS = ['sub', 'preferred_username', 'email', 'name', 'given_name', 'family_name']
@@ -45,9 +49,12 @@ class GatewayOIDCValidator(OAuth2Validator):
         Role claims use the aap_ prefix to avoid collision with other OIDC providers.
         Structured objects are used instead of flat strings because org/team names
         can contain arbitrary characters (including colons, slashes, etc.):
-        - aap_organizations: [{"name": "...", "roles": ["admin", "member"]}, ...]
-        - aap_teams: [{"name": "...", "organization": "...", "roles": ["admin", "member"]}, ...]
+        - aap_organizations: [{"name": "...", "roles": ["member"]}, ...]
+        - aap_teams: [{"name": "...", "organization": "...", "roles": ["member"]}, ...]
         - aap_system_role: scalar string (system_administrator, system_auditor, or normal_user)
+
+        The roles list contains all explicit assignments for a given object
+        (e.g. ["admin"], ["member"], or ["admin", "member"] when both are assigned).
 
         Claims reflect explicit RoleUserAssignment records only; implicit superuser
         access is not included (platform-level access is conveyed by aap_system_role).
@@ -60,41 +67,57 @@ class GatewayOIDCValidator(OAuth2Validator):
 
             from aap_gateway_api.models import Organization, Team
 
-            role_defs = {
-                rd.name: rd for rd in RoleDefinition.objects.filter(name__in=['Organization Admin', 'Organization Member', 'Team Admin', 'Team Member'])
-            }
-            org_admin_id = role_defs['Organization Admin'].id
-            org_member_id = role_defs['Organization Member'].id
-            team_admin_id = role_defs['Team Admin'].id
-            team_member_id = role_defs['Team Member'].id
+            expected_names = ['Organization Admin', 'Organization Member', 'Team Admin', 'Team Member']
+            role_defs = {rd.name: rd for rd in RoleDefinition.objects.filter(name__in=expected_names)}
 
-            org_roles = {}
-            for obj_id, rd_id in RoleUserAssignment.objects.filter(
-                user=user,
-                role_definition_id__in=[org_admin_id, org_member_id],
-            ).values_list('object_id', 'role_definition_id'):
-                org_roles.setdefault(obj_id, [])
-                org_roles[obj_id].append('admin' if rd_id == org_admin_id else 'member')
+            missing = set(expected_names) - role_defs.keys()
+            if missing:
+                logger.error("OIDC role claims unavailable: missing RoleDefinition(s): %s", ', '.join(sorted(missing)))
+                claims['aap_organizations'] = []
+                claims['aap_teams'] = []
+            else:
+                org_admin_id = role_defs['Organization Admin'].id
+                org_member_id = role_defs['Organization Member'].id
+                team_admin_id = role_defs['Team Admin'].id
+                team_member_id = role_defs['Team Member'].id
 
-            orgs_by_pk = {str(org.pk): org for org in Organization.objects.filter(pk__in=org_roles.keys())}
-            claims['aap_organizations'] = [
-                {'name': orgs_by_pk[obj_id].name, 'roles': sorted(roles)} for obj_id, roles in org_roles.items() if obj_id in orgs_by_pk
-            ]
+                org_roles = {}
+                for obj_id, rd_id in RoleUserAssignment.objects.filter(
+                    user=user,
+                    role_definition_id__in=[org_admin_id, org_member_id],
+                ).values_list('object_id', 'role_definition_id'):
+                    org_roles.setdefault(obj_id, set())
+                    org_roles[obj_id].add('admin' if rd_id == org_admin_id else 'member')
 
-            team_roles = {}
-            for obj_id, rd_id in RoleUserAssignment.objects.filter(
-                user=user,
-                role_definition_id__in=[team_admin_id, team_member_id],
-            ).values_list('object_id', 'role_definition_id'):
-                team_roles.setdefault(obj_id, [])
-                team_roles[obj_id].append('admin' if rd_id == team_admin_id else 'member')
+                orgs_by_pk = {str(org.pk): org for org in Organization.objects.filter(pk__in=org_roles.keys())}
+                orphaned_orgs = set(org_roles.keys()) - set(orgs_by_pk.keys())
+                if orphaned_orgs:
+                    logger.warning("User %s has RoleUserAssignment(s) for non-existent Organization(s): %s", user.pk, orphaned_orgs)
+                claims['aap_organizations'] = sorted(
+                    [{'name': orgs_by_pk[obj_id].name, 'roles': sorted(roles)} for obj_id, roles in org_roles.items() if obj_id in orgs_by_pk],
+                    key=lambda o: o['name'],
+                )
 
-            teams_by_pk = {str(t.pk): t for t in Team.objects.filter(pk__in=team_roles.keys()).select_related('organization')}
-            claims['aap_teams'] = [
-                {'name': teams_by_pk[obj_id].name, 'organization': teams_by_pk[obj_id].organization.name, 'roles': sorted(roles)}
-                for obj_id, roles in team_roles.items()
-                if obj_id in teams_by_pk
-            ]
+                team_roles = {}
+                for obj_id, rd_id in RoleUserAssignment.objects.filter(
+                    user=user,
+                    role_definition_id__in=[team_admin_id, team_member_id],
+                ).values_list('object_id', 'role_definition_id'):
+                    team_roles.setdefault(obj_id, set())
+                    team_roles[obj_id].add('admin' if rd_id == team_admin_id else 'member')
+
+                teams_by_pk = {str(t.pk): t for t in Team.objects.filter(pk__in=team_roles.keys()).select_related('organization')}
+                orphaned_teams = set(team_roles.keys()) - set(teams_by_pk.keys())
+                if orphaned_teams:
+                    logger.warning("User %s has RoleUserAssignment(s) for non-existent Team(s): %s", user.pk, orphaned_teams)
+                claims['aap_teams'] = sorted(
+                    [
+                        {'name': teams_by_pk[obj_id].name, 'organization': teams_by_pk[obj_id].organization.name, 'roles': sorted(roles)}
+                        for obj_id, roles in team_roles.items()
+                        if obj_id in teams_by_pk
+                    ],
+                    key=lambda t: (t['organization'], t['name']),
+                )
 
             if user.is_superuser:
                 claims['aap_system_role'] = 'system_administrator'

--- a/aap_gateway_api/oauth2_validator.py
+++ b/aap_gateway_api/oauth2_validator.py
@@ -45,31 +45,55 @@ class GatewayOIDCValidator(OAuth2Validator):
         Role claims use the aap_ prefix to avoid collision with other OIDC providers.
         Structured objects are used instead of flat strings because org/team names
         can contain arbitrary characters (including colons, slashes, etc.):
-        - aap_organizations: [{"name": "...", "role": "admin|member"}, ...]
-        - aap_teams: [{"name": "...", "organization": "...", "role": "admin|member"}, ...]
+        - aap_organizations: [{"name": "...", "roles": ["admin", "member"]}, ...]
+        - aap_teams: [{"name": "...", "organization": "...", "roles": ["admin", "member"]}, ...]
         - aap_system_role: scalar string (system_administrator, system_auditor, or normal_user)
+
+        Claims reflect explicit RoleUserAssignment records only; implicit superuser
+        access is not included (platform-level access is conveyed by aap_system_role).
         """
         claims = super().get_userinfo_claims(request)
         user = request.user
 
         if user and getattr(user, 'is_authenticated', False) and 'roles' in request.scopes:
+            from ansible_base.rbac.models import RoleDefinition, RoleUserAssignment
+
             from aap_gateway_api.models import Organization, Team
 
-            # Determine org memberships with role type (admin vs member)
-            admin_org_ids = set(Organization.access_qs(user, 'change').values_list('pk', flat=True))
-            member_orgs = Organization.access_qs(user, 'member')
-            claims['aap_organizations'] = [{'name': org.name, 'role': 'admin' if org.pk in admin_org_ids else 'member'} for org in member_orgs]
+            role_defs = {
+                rd.name: rd for rd in RoleDefinition.objects.filter(name__in=['Organization Admin', 'Organization Member', 'Team Admin', 'Team Member'])
+            }
+            org_admin_id = role_defs['Organization Admin'].id
+            org_member_id = role_defs['Organization Member'].id
+            team_admin_id = role_defs['Team Admin'].id
+            team_member_id = role_defs['Team Member'].id
 
-            # Determine team memberships with role type (admin vs member)
-            admin_team_ids = set(Team.access_qs(user, 'change').values_list('pk', flat=True))
-            member_teams = Team.access_qs(user, 'member').select_related('organization')
+            org_roles = {}
+            for obj_id, rd_id in RoleUserAssignment.objects.filter(
+                user=user,
+                role_definition_id__in=[org_admin_id, org_member_id],
+            ).values_list('object_id', 'role_definition_id'):
+                org_roles.setdefault(obj_id, [])
+                org_roles[obj_id].append('admin' if rd_id == org_admin_id else 'member')
+
+            orgs_by_pk = {str(org.pk): org for org in Organization.objects.filter(pk__in=org_roles.keys())}
+            claims['aap_organizations'] = [
+                {'name': orgs_by_pk[obj_id].name, 'roles': sorted(roles)} for obj_id, roles in org_roles.items() if obj_id in orgs_by_pk
+            ]
+
+            team_roles = {}
+            for obj_id, rd_id in RoleUserAssignment.objects.filter(
+                user=user,
+                role_definition_id__in=[team_admin_id, team_member_id],
+            ).values_list('object_id', 'role_definition_id'):
+                team_roles.setdefault(obj_id, [])
+                team_roles[obj_id].append('admin' if rd_id == team_admin_id else 'member')
+
+            teams_by_pk = {str(t.pk): t for t in Team.objects.filter(pk__in=team_roles.keys()).select_related('organization')}
             claims['aap_teams'] = [
-                {
-                    'name': team.name,
-                    'organization': team.organization.name,
-                    'role': 'admin' if team.pk in admin_team_ids else 'member',
-                }
-                for team in member_teams
+                {'name': teams_by_pk[obj_id].name, 'organization': teams_by_pk[obj_id].organization.name, 'roles': sorted(roles)}
+                for obj_id, roles in team_roles.items()
+                if obj_id in teams_by_pk
             ]
 
             if user.is_superuser:

--- a/aap_gateway_api/tests/test_oidc_user_identity.py
+++ b/aap_gateway_api/tests/test_oidc_user_identity.py
@@ -131,12 +131,12 @@ class TestValidatorUserinfoClaims:
         assert 'aap_organizations' in claims
         org_entry = next((o for o in claims['aap_organizations'] if o['name'] == organization.name), None)
         assert org_entry is not None
-        assert org_entry['role'] == 'member'
+        assert org_entry['roles'] == ['member']
         assert 'aap_teams' in claims
         team_entry = next((t for t in claims['aap_teams'] if t['name'] == team.name), None)
         assert team_entry is not None
         assert team_entry['organization'] == organization.name
-        assert team_entry['role'] == 'member'
+        assert team_entry['roles'] == ['member']
 
     def test_userinfo_excludes_roles_without_scope(self, admin_user):
         validator = GatewayOIDCValidator()
@@ -184,8 +184,12 @@ class TestValidatorUserinfoClaims:
 
         org_names = {o['name'] for o in claims['aap_organizations']}
         assert org_names == {'Org Alpha', 'Org Beta'}
+        for org_entry in claims['aap_organizations']:
+            assert org_entry['roles'] == ['member']
         team_names = {t['name'] for t in claims['aap_teams']}
         assert team_names == {'Team X', 'Team Y'}
+        for team_entry in claims['aap_teams']:
+            assert team_entry['roles'] == ['member']
 
     def test_userinfo_admin_vs_member_roles(self, user_factory, organization_factory, team_factory):
         """Admin and member roles are correctly distinguished."""
@@ -209,14 +213,14 @@ class TestValidatorUserinfoClaims:
 
         admin_org = next(o for o in claims['aap_organizations'] if o['name'] == 'Admin Org')
         member_org = next(o for o in claims['aap_organizations'] if o['name'] == 'Member Org')
-        assert admin_org['role'] == 'admin'
-        assert member_org['role'] == 'member'
+        assert admin_org['roles'] == ['admin']
+        assert member_org['roles'] == ['member']
 
         admin_team = next(t for t in claims['aap_teams'] if t['name'] == 'Admin Team')
         member_team = next(t for t in claims['aap_teams'] if t['name'] == 'Member Team')
-        assert admin_team['role'] == 'admin'
+        assert admin_team['roles'] == ['admin']
         assert admin_team['organization'] == 'Admin Org'
-        assert member_team['role'] == 'member'
+        assert member_team['roles'] == ['member']
         assert member_team['organization'] == 'Member Org'
 
     def test_roles_scope_without_openid(self, admin_user, organization):
@@ -342,8 +346,8 @@ class TestValidatorUserinfoClaims:
 
         admin_entry = next(o for o in claims['aap_organizations'] if o['name'] == 'Org Where Admin')
         member_entry = next(o for o in claims['aap_organizations'] if o['name'] == 'Org Where Member')
-        assert admin_entry['role'] == 'admin'
-        assert member_entry['role'] == 'member'
+        assert admin_entry['roles'] == ['admin']
+        assert member_entry['roles'] == ['member']
 
     def test_special_characters_in_org_team_names(self, user_factory, organization_factory, team_factory):
         """Org/team names with unicode, colons, slashes serialize correctly in claims."""
@@ -369,6 +373,97 @@ class TestValidatorUserinfoClaims:
         assert team_entry is not None
         assert team_entry['name'] == 'Team — émojis & slashes/colons:'
         assert team_entry['organization'] == org.name
+
+    def test_superuser_no_explicit_memberships(self, admin_user, organization_factory, team_factory):
+        """Superuser with no explicit org/team assignments gets empty arrays.
+
+        Platform-level access is conveyed by aap_system_role, not org/team claims.
+        """
+        organization_factory('Org That Exists')
+        team_factory('Team That Exists', organization_factory('Another Org'))
+
+        validator = GatewayOIDCValidator()
+        request = MagicMock()
+        request.user = admin_user
+        request.scopes = ['openid', 'roles']
+
+        claims = validator.get_userinfo_claims(request)
+
+        assert claims['aap_organizations'] == []
+        assert claims['aap_teams'] == []
+        assert claims['aap_system_role'] == 'system_administrator'
+
+    def test_superuser_with_explicit_memberships(self, admin_user, organization_factory, team_factory):
+        """Superuser with explicit assignments only shows those, not all objects."""
+        org_assigned = organization_factory('Assigned Org')
+        org_not_assigned = organization_factory('Not Assigned Org')
+        team_assigned = team_factory('Assigned Team', org_assigned)
+        team_factory('Not Assigned Team', org_not_assigned)
+
+        RoleDefinition.objects.managed.org_member.give_permission(admin_user, org_assigned)
+        RoleDefinition.objects.managed.team_member.give_permission(admin_user, team_assigned)
+
+        validator = GatewayOIDCValidator()
+        request = MagicMock()
+        request.user = admin_user
+        request.scopes = ['openid', 'roles']
+
+        claims = validator.get_userinfo_claims(request)
+
+        org_names = {o['name'] for o in claims['aap_organizations']}
+        assert org_names == {'Assigned Org'}
+        team_names = {t['name'] for t in claims['aap_teams']}
+        assert team_names == {'Assigned Team'}
+        assert claims['aap_system_role'] == 'system_administrator'
+
+    def test_user_both_admin_and_member_same_org(self, user_factory, organization_factory, team_factory):
+        """User with both admin and member roles on the same org/team gets both in roles list."""
+        user = user_factory('dual_role_user')
+        org = organization_factory('Dual Role Org')
+        team = team_factory('Dual Role Team', org)
+
+        RoleDefinition.objects.managed.org_admin.give_permission(user, org)
+        RoleDefinition.objects.managed.org_member.give_permission(user, org)
+        RoleDefinition.objects.managed.team_admin.give_permission(user, team)
+        RoleDefinition.objects.managed.team_member.give_permission(user, team)
+
+        validator = GatewayOIDCValidator()
+        request = MagicMock()
+        request.user = user
+        request.scopes = ['openid', 'roles']
+
+        claims = validator.get_userinfo_claims(request)
+
+        org_entry = next(o for o in claims['aap_organizations'] if o['name'] == 'Dual Role Org')
+        assert org_entry['roles'] == ['admin', 'member']
+
+        team_entry = next(t for t in claims['aap_teams'] if t['name'] == 'Dual Role Team')
+        assert team_entry['roles'] == ['admin', 'member']
+
+    def test_platform_auditor_only_explicit_memberships(self, user_factory, organization_factory, team_factory):
+        """Platform auditor only sees explicit assignments, not all objects."""
+        user = user_factory('auditor_explicit')
+        user.is_platform_auditor = True
+        user.save()
+
+        org_assigned = organization_factory('Auditor Assigned Org')
+        org_not_assigned = organization_factory('Auditor Not Assigned Org')
+        team_assigned = team_factory('Auditor Assigned Team', org_assigned)
+        team_factory('Auditor Not Assigned Team', org_not_assigned)
+
+        RoleDefinition.objects.managed.org_member.give_permission(user, org_assigned)
+        RoleDefinition.objects.managed.team_member.give_permission(user, team_assigned)
+
+        validator = GatewayOIDCValidator()
+        request = MagicMock()
+        request.user = user
+        request.scopes = ['openid', 'roles']
+
+        claims = validator.get_userinfo_claims(request)
+
+        assert {o['name'] for o in claims['aap_organizations']} == {'Auditor Assigned Org'}
+        assert {t['name'] for t in claims['aap_teams']} == {'Auditor Assigned Team'}
+        assert claims['aap_system_role'] == 'system_auditor'
 
 
 class TestValidatorDiscoveryClaims:

--- a/aap_gateway_api/tests/test_oidc_user_identity.py
+++ b/aap_gateway_api/tests/test_oidc_user_identity.py
@@ -465,6 +465,25 @@ class TestValidatorUserinfoClaims:
         assert {t['name'] for t in claims['aap_teams']} == {'Auditor Assigned Team'}
         assert claims['aap_system_role'] == 'system_auditor'
 
+    def test_missing_role_definitions_degrades_gracefully(self, user_factory, organization_factory):
+        """If managed RoleDefinitions are missing, return empty claims instead of crashing."""
+        user = user_factory('missing_rd_user')
+        org = organization_factory('Some Org')
+        RoleDefinition.objects.managed.org_member.give_permission(user, org)
+
+        RoleDefinition.objects.filter(name='Organization Member').delete()
+
+        validator = GatewayOIDCValidator()
+        request = MagicMock()
+        request.user = user
+        request.scopes = ['openid', 'roles']
+
+        claims = validator.get_userinfo_claims(request)
+
+        assert claims['aap_organizations'] == []
+        assert claims['aap_teams'] == []
+        assert claims['aap_system_role'] == 'normal_user'
+
 
 class TestValidatorDiscoveryClaims:
     def test_discovery_claims_include_user_identity(self):


### PR DESCRIPTION
## Description

OIDC token claims `aap_organizations` and `aap_teams` incorrectly included every organization and team in the system when the authenticated user was a system administrator. This happened because `access_qs()` bypasses RBAC evaluation for superusers via `has_super_permission()`, returning the full unfiltered queryset. OIDC group claims should reflect explicit membership, not implicit superuser access — platform-level privilege is already conveyed by `aap_system_role: system_administrator`.

This change replaces `Organization.access_qs()` / `Team.access_qs()` with direct `RoleUserAssignment` queries that only return explicit role assignments. It also changes the claim format from `"role"` (singular string) to `"roles"` (sorted list) to correctly represent users who hold both admin and member assignments on the same org or team.

**Before:**
```json
{
  "aap_organizations": [
    {"name": "Default", "role": "admin"},
    {"name": "Org2", "role": "admin"},
    {"name": "admins", "role": "admin"}
  ],
  "aap_system_role": "system_administrator"
}
```

**After (superuser with no explicit assignments):**
```json
{
  "aap_organizations": [],
  "aap_teams": [],
  "aap_system_role": "system_administrator"
}
```

**After (user with both admin and member on same org):**
```json
{
  "aap_organizations": [
    {"name": "My Org", "roles": ["admin", "member"]}
  ]
}
```

Fixes: [AAP-73972](https://redhat.atlassian.net/browse/AAP-73972)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

The `role` (string) -> `roles` (list) format change is breaking for any OIDC relying party consuming these claims. The blast radius is small since the OIDC provider feature was recently added (AAP-68137).

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites
- AAP instance with multiple organizations and teams
- A system administrator user with no explicit org/team memberships
- OIDC authentication configured via AAP Gateway

### Steps to Test
1. Authenticate as a system administrator via OIDC
2. Decode the OIDC token and inspect `aap_organizations` and `aap_teams`
3. Verify they are empty arrays (not every org/team in the system)
4. Verify `aap_system_role` is `system_administrator`
5. Explicitly assign the superuser as a member of one org and one team via the API
6. Re-authenticate and verify only those explicit assignments appear in the token
7. Assign a normal user as both admin and member of the same org
8. Verify the token shows `"roles": ["admin", "member"]` for that org

### Expected Results
- Superuser with no explicit assignments: `aap_organizations: []`, `aap_teams: []`
- Superuser with explicit assignments: only those assignments appear
- User with dual roles: `roles` list contains both `"admin"` and `"member"`
- `aap_system_role` is unaffected and correctly reflects `system_administrator`, `system_auditor`, or `normal_user`

## Additional Context

### Root cause
`oauth2_validator.py` called `Organization.access_qs(user, 'member')` and `Team.access_qs(user, 'member')` to build claims. `access_qs()` delegates to `AccessibleObjectsDescriptor` in `django-ansible-base/ansible_base/rbac/evaluations.py`, which short-circuits at line 86-87 and returns the full queryset for any user where `has_super_permission()` is true. This is correct for RBAC authorization checks but semantically wrong for OIDC group claims.

### Query optimization
Replaced 4 separate `RoleDefinition.objects.managed.*` lookups (each calling `get_or_create`) with a single `RoleDefinition.objects.filter(name__in=[...])` query. Total DB queries per `get_userinfo_claims` call: 5 (1 role definition lookup + 2 assignment queries + 2 object queries).

### Required Actions
- [x] Requires documentation updates
  <!-- OIDC claim format change: "role" -> "roles", document the new list format -->
- [ ] Requires downstream repository changes
- [ ] Requires infrastructure/deployment changes
- [ ] Requires coordination with other teams


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Enhanced user role information in authentication claims. Organizations and teams now display role assignments as lists for clearer visibility into permission levels.

* **Tests**
  * Expanded test coverage for authentication claims validation, including multi-role scenarios and system administrator/auditor behavior verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->