### PR TITLE
AAP-65395: Add dispatcherd health check to ping endpoint

### DIFF
--- a/aap_gateway_api/serializers/status.py
+++ b/aap_gateway_api/serializers/status.py
@@ -32,6 +32,7 @@ class PingSerializer(serializers.Serializer):
     proxy_connected = serializers.BooleanField(required=False)
     proxy_status_code = serializers.IntegerField(required=False)
     proxy_exception_type = serializers.CharField(required=False)
+    dispatcherd_connected = serializers.BooleanField(required=False)
 
 
 class RedisResponseSerializer(serializers.Serializer):

--- a/aap_gateway_api/tests/views/api/v1/ping/test_ping.py
+++ b/aap_gateway_api/tests/views/api/v1/ping/test_ping.py
@@ -83,19 +83,6 @@ def test_ping_proxy_non_200(request, mock_dispatcherd, unauthenticated_api_clien
 
 
 @pytest.mark.django_db
-@mock.patch("aap_gateway_api.views.api.v1.ping.PingView._check_dispatcherd")
-@mock.patch("aap_gateway_api.views.api.v1.ping.requests.request")
-def test_ping_dispatcherd_up(request, mock_dispatcherd, unauthenticated_api_client):
-    request.return_value = mock.Mock(status_code=200, json=lambda: {"test": "test"})
-
-    url = get_relative_url("ping-view")
-    response = unauthenticated_api_client.get(url)
-    assert response.status_code == 200
-    assert response.data['dispatcherd_connected'] is True
-    assert response.data['status'] == STATUS_GOOD
-
-
-@pytest.mark.django_db
 @mock.patch("aap_gateway_api.views.api.v1.ping.PingView._check_dispatcherd", side_effect=Exception("connection refused"))
 @mock.patch("aap_gateway_api.views.api.v1.ping.requests.request")
 def test_ping_dispatcherd_down(request, mock_dispatcherd, unauthenticated_api_client):

--- a/aap_gateway_api/tests/views/api/v1/ping/test_ping.py
+++ b/aap_gateway_api/tests/views/api/v1/ping/test_ping.py
@@ -10,8 +10,9 @@ from aap_gateway_api.version import get_aap_version
 
 
 @pytest.mark.django_db
+@mock.patch("aap_gateway_api.views.api.v1.ping.PingView._check_dispatcherd")
 @mock.patch("aap_gateway_api.views.api.v1.ping.requests.request")
-def test_ping_all_up(request, unauthenticated_api_client):
+def test_ping_all_up(request, mock_dispatcherd, unauthenticated_api_client):
     request.return_value = mock.Mock(status_code=200, json=lambda: {"test": "test"})
 
     url = get_relative_url("ping-view")
@@ -22,6 +23,7 @@ def test_ping_all_up(request, unauthenticated_api_client):
 
     assert response.data["version"] == get_aap_version()
     assert response.data['status'] == STATUS_GOOD, response.data
+    assert response.data['dispatcherd_connected'] is True
 
 
 @pytest.mark.django_db
@@ -75,3 +77,31 @@ def test_ping_proxy_non_200(request, unauthenticated_api_client, service_cluster
     assert response.status_code == 200
     assert response.data['status'] == STATUS_DEGRADED
     assert response.data['proxy_status_code'] == 500
+
+
+@pytest.mark.django_db
+@mock.patch("aap_gateway_api.views.api.v1.ping.PingView._check_dispatcherd")
+@mock.patch("aap_gateway_api.views.api.v1.ping.requests.request")
+def test_ping_dispatcherd_up(request, mock_dispatcherd, unauthenticated_api_client):
+    request.return_value = mock.Mock(status_code=200, json=lambda: {"test": "test"})
+
+    url = get_relative_url("ping-view")
+    response = unauthenticated_api_client.get(url)
+    assert response.status_code == 200
+    assert response.data['dispatcherd_connected'] is True
+    assert response.data['status'] == STATUS_GOOD
+
+
+@pytest.mark.django_db
+@mock.patch("aap_gateway_api.views.api.v1.ping.PingView._check_dispatcherd", side_effect=Exception("connection refused"))
+@mock.patch("aap_gateway_api.views.api.v1.ping.requests.request")
+def test_ping_dispatcherd_down(request, mock_dispatcherd, unauthenticated_api_client):
+    """Dispatcherd failure must not degrade overall status (informational only)."""
+    request.return_value = mock.Mock(status_code=200, json=lambda: {"test": "test"})
+
+    url = get_relative_url("ping-view")
+    response = unauthenticated_api_client.get(url)
+    assert response.status_code == 200
+    assert response.data['dispatcherd_connected'] is False
+    # Status must remain GOOD — dispatcherd is not a critical dependency
+    assert response.data['status'] == STATUS_GOOD

--- a/aap_gateway_api/tests/views/api/v1/ping/test_ping.py
+++ b/aap_gateway_api/tests/views/api/v1/ping/test_ping.py
@@ -27,8 +27,9 @@ def test_ping_all_up(request, mock_dispatcherd, unauthenticated_api_client):
 
 
 @pytest.mark.django_db
+@mock.patch("aap_gateway_api.views.api.v1.ping.PingView._check_dispatcherd")
 @mock.patch("aap_gateway_api.views.api.v1.ping.requests.request")
-def test_ping_db_down(request, unauthenticated_api_client):
+def test_ping_db_down(request, mock_dispatcherd, unauthenticated_api_client):
     request.return_value = mock.Mock(status_code=200, json=lambda: {"test": "test"})
 
     with mock.patch("aap_gateway_api.views.api.v1.ping.PingView._check_db", side_effect=DatabaseError):
@@ -40,8 +41,9 @@ def test_ping_db_down(request, unauthenticated_api_client):
 
 
 @pytest.mark.django_db
+@mock.patch("aap_gateway_api.views.api.v1.ping.PingView._check_dispatcherd")
 @mock.patch("aap_gateway_api.views.api.v1.ping.requests.request")
-def test_ping_proxy_exception(request, unauthenticated_api_client, service_cluster_gateway):
+def test_ping_proxy_exception(request, mock_dispatcherd, unauthenticated_api_client, service_cluster_gateway):
     request.side_effect = Exception('testing')
 
     HTTPPort(name="api", number=9080, is_api_port=True).save()
@@ -60,8 +62,9 @@ def test_ping_proxy_exception(request, unauthenticated_api_client, service_clust
 
 
 @pytest.mark.django_db
+@mock.patch("aap_gateway_api.views.api.v1.ping.PingView._check_dispatcherd")
 @mock.patch("aap_gateway_api.views.api.v1.ping.requests.request")
-def test_ping_proxy_non_200(request, unauthenticated_api_client, service_cluster_gateway):
+def test_ping_proxy_non_200(request, mock_dispatcherd, unauthenticated_api_client, service_cluster_gateway):
     request.return_value = mock.Mock(status_code=500, json=lambda: {"test": "test"})
 
     HTTPPort(name="api", number=9080, is_api_port=True).save()

--- a/aap_gateway_api/views/api/v1/ping.py
+++ b/aap_gateway_api/views/api/v1/ping.py
@@ -12,7 +12,7 @@ from aap_gateway_api.serializers.status import PingSerializer
 from aap_gateway_api.version import get_aap_version
 from aap_gateway_api.views.api.v1.common import AnsibleBaseView
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('aap.gateway.views.api.v1.ping')
 
 
 class PingView(AnsibleBaseView):

--- a/aap_gateway_api/views/api/v1/ping.py
+++ b/aap_gateway_api/views/api/v1/ping.py
@@ -20,6 +20,11 @@ class PingView(AnsibleBaseView):
         with connection.cursor() as cursor:
             cursor.execute("SELECT 1")
 
+    def _check_dispatcherd(self):
+        from dispatcherd.factories import get_control_from_settings
+
+        get_control_from_settings().control_with_reply("alive", timeout=getattr(settings, "DISPATCHERD_HEALTH_CHECK_TIMEOUT", 5))
+
     def get(self, request):
         timeout = getattr(settings, "PING_PAGE_CHECK_TIMEOUT", 5)
         ignore_cert = getattr(settings, "PING_PAGE_CHECK_IGNORE_CERT", False)
@@ -59,6 +64,13 @@ class PingView(AnsibleBaseView):
             response.update(
                 {'status': STATUS_DEGRADED, 'db_connected': False, 'db_exception': type(e).__name__, 'proxy_exception_type': 'Skipped, DB unavailable.'}
             )
+
+        # Dispatcherd check is informational only — does not affect overall status
+        try:
+            self._check_dispatcherd()
+            response['dispatcherd_connected'] = True
+        except Exception:
+            response['dispatcherd_connected'] = False
 
         serialized = self.serializer_class(response)
         return Response(serialized.data)

--- a/aap_gateway_api/views/api/v1/ping.py
+++ b/aap_gateway_api/views/api/v1/ping.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime
 
 import requests
@@ -11,6 +12,8 @@ from aap_gateway_api.serializers.status import PingSerializer
 from aap_gateway_api.version import get_aap_version
 from aap_gateway_api.views.api.v1.common import AnsibleBaseView
 
+logger = logging.getLogger(__name__)
+
 
 class PingView(AnsibleBaseView):
     permission_classes = []
@@ -21,6 +24,7 @@ class PingView(AnsibleBaseView):
             cursor.execute("SELECT 1")
 
     def _check_dispatcherd(self):
+        """Raises on failure — the alive command either gets a reply or throws."""
         from dispatcherd.factories import get_control_from_settings
 
         get_control_from_settings().control_with_reply("alive", timeout=getattr(settings, "DISPATCHERD_HEALTH_CHECK_TIMEOUT", 5))
@@ -70,6 +74,7 @@ class PingView(AnsibleBaseView):
             self._check_dispatcherd()
             response['dispatcherd_connected'] = True
         except Exception:
+            logger.warning("Dispatcherd health check failed", exc_info=True)
             response['dispatcherd_connected'] = False
 
         serialized = self.serializer_class(response)


### PR DESCRIPTION
## Description

<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
  - Ping endpoint is updated to show status of dispatcherd
- Why is this change needed?
  - To provide visibility of dispatcherd status
- How does this change address the issue?
  - Add dispatcherd_connected boolean field to the ping response. The check uses dispatcherd's alive control command and is informational only — it does not affect overall status.

Assisted-by: Claude Code claude-opus-4-6 1M context

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. Make sure you have latest code and then pull down the changes in this PR
2. Start the gateway
3. Check the ping endpoint output

### Expected Results
<!-- Describe what should happen after following the steps -->
It should show:
```json
{
    "status": "good",
    "version": "0.1",
    "pong": "2026-05-08 14:56:30.875622",
    "db_connected": true,
    "proxy_connected": true,
    "dispatcherd_connected": true
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status/ping API now reports a dispatcherd connectivity flag; connectivity failures are logged and treated as informational (they do not affect overall health status).

* **Tests**
  * Added and updated ping tests to cover dispatcherd-connected and dispatcherd-down scenarios and to integrate the new connectivity check into existing health checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->