### PR TITLE
AAP-75074: Fix dispatcherd supervisorctl stop leaving orphaned processes

### DIFF
--- a/docs/dispatcherd.md
+++ b/docs/dispatcherd.md
@@ -162,12 +162,12 @@ The `conninfo` string is built from `settings.DATABASES["default"]` using DAB's 
 | Command | `/usr/bin/aap-gateway-manage dispatcherd` |
 | Group | Add `dispatcher` to the `gateway-processes` group |
 | `autorestart` | `true` |
-| `stopasgroup` | `false` |
-| `killasgroup` | `false` |
+| `stopasgroup` | `true` |
+| `killasgroup` | `true` |
 
 #### Constraints
 
-- `stopasgroup` and `killasgroup` must be `false` so dispatcherd can be independently restarted without affecting other Gateway processes.
+- `stopasgroup` and `killasgroup` must be `true`. Each supervisord program gets its own OS process group (PGID), so the signal only reaches the dispatcher's process tree — not nginx, uwsgi, or other gateway processes. Without this, the bash wrapper (`aap-gateway-manage`) absorbs SIGTERM and the Python dispatcherd process is never signaled, leaving orphaned processes on every restart.
 
 #### Files Modified
 

--- a/tools/configs/supervisord.conf
+++ b/tools/configs/supervisord.conf
@@ -82,8 +82,8 @@ stderr_logfile_maxbytes = 0
 [program:dispatcher]
 command = /usr/bin/aap-gateway-manage dispatcherd
 autorestart = true
-stopasgroup = false
-killasgroup = false
+stopasgroup = true
+killasgroup = true
 stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0
 stderr_logfile = /dev/stderr


### PR DESCRIPTION
## Summary
- Fix `supervisorctl stop/restart` for the dispatcher program leaving orphaned dispatcherd processes
- Set `stopasgroup = true` and `killasgroup = true` in the `[program:dispatcher]` supervisord block (matching all other programs)
- Update dispatcherd.md constraints section to document the rationale

## Root Cause
`/usr/bin/aap-gateway-manage` is a bash wrapper (`#!/bin/bash; python -m aap_gateway_api $@`). With `stopasgroup = false`, supervisord sends SIGTERM only to the bash process, which exits without forwarding it to the Python child. The dispatcherd process and its forkserver/worker children become orphans on every stop/restart cycle.

Each supervisord program gets its own OS process group (PGID), so `stopasgroup = true` only signals the dispatcher's own process tree — nginx, uwsgi, and control-plane are unaffected. The dispatcherd library already handles process-group SIGTERM correctly.

## Test plan
- [x] Verified via `ps -eo pid,pgid,ppid,comm` that each program has its own PGID
- [x] `supervisorctl stop gateway-processes:dispatcher` — all dispatcher processes exit cleanly, no orphans
- [x] `supervisorctl start gateway-processes:dispatcher` — clean single process tree
- [x] `supervisorctl restart gateway-processes:dispatcher` — old processes fully cleaned up, new ones start correctly
- [x] Other gateway processes (nginx, uwsgi, control-plane) retain original PIDs/uptimes through dispatcher restart

Fixes: [AAP-75074](https://redhat.atlassian.net/browse/AAP-75074)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated dispatcher configuration documentation for process group handling during restarts.

* **Chores**
  * Updated dispatcher process group termination settings to align with other managed programs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->