### PR TITLE
Support reading committer identity from GitHub repository variables

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -47,15 +47,13 @@ on:
         required: false
         type: string
       git_committer_name:
-        description: "Git committer name for backported commits"
+        description: "Git committer name (falls back to BACKPORT_COMMITTER_NAME variable, then github-actions[bot])"
         required: false
         type: string
-        default: "github-actions[bot]"
       git_committer_email:
-        description: "Git committer email — must match the GPG key's UID for the Verified badge"
+        description: "Git committer email — must match the GPG key's UID for Verified badge (falls back to BACKPORT_COMMITTER_EMAIL variable, then github-actions[bot] email)"
         required: false
         type: string
-        default: "41898282+github-actions[bot]@users.noreply.github.com"
   workflow_call:
     inputs:
       source_commits:
@@ -86,15 +84,13 @@ on:
         required: false
         type: string
       git_committer_name:
-        description: "Git committer name for backported commits"
+        description: "Git committer name (falls back to BACKPORT_COMMITTER_NAME variable, then github-actions[bot])"
         required: false
         type: string
-        default: "github-actions[bot]"
       git_committer_email:
-        description: "Git committer email — must match the GPG key's UID for the Verified badge"
+        description: "Git committer email — must match the GPG key's UID for Verified badge (falls back to BACKPORT_COMMITTER_EMAIL variable, then github-actions[bot] email)"
         required: false
         type: string
-        default: "41898282+github-actions[bot]@users.noreply.github.com"
     secrets:
       GPG_PRIVATE_KEY:
         description: "Base64-encoded armored GPG private key for commit signing (no passphrase)"
@@ -248,8 +244,8 @@ jobs:
           SOURCE_BRANCH_NAME: ${{ inputs.source_branch }}
           SERVER_URL: ${{ github.server_url }}
           JIRA_BASE_URL: ${{ inputs.jira_base_url || vars.JIRA_BASE_URL }}
-          GIT_COMMITTER_NAME_INPUT: ${{ inputs.git_committer_name }}
-          GIT_COMMITTER_EMAIL_INPUT: ${{ inputs.git_committer_email }}
+          GIT_COMMITTER_NAME_INPUT: ${{ inputs.git_committer_name || vars.BACKPORT_COMMITTER_NAME || 'github-actions[bot]' }}
+          GIT_COMMITTER_EMAIL_INPUT: ${{ inputs.git_committer_email || vars.BACKPORT_COMMITTER_EMAIL || '41898282+github-actions[bot]@users.noreply.github.com' }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Description

<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
  - Default values for git committer for backport PRs
- Why is this change needed?
  - To have the committer name and email configured rather than provided on every run
- How does this change address the issue?
  - The git_committer_name and git_committer_email inputs now follow a three-tier fallback chain: caller input → GitHub repository variable (BACKPORT_COMMITTER_NAME / BACKPORT_COMMITTER_EMAIL) → github-actions[bot] default.

Assisted-by: Claude Code claude-opus-4-6 1M

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [x] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x]  I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->

This will be tested in downstream repository. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced backport workflow to support dynamic committer identity configuration. The workflow now resolves committer name and email from repository variables when available, with automatic fallback to default values, providing more flexible control over backported commit attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->