### PR TITLE
[AAP-75114] Pin cryptography>=46.0.7 for CVE-2026-39892

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,4 +1,4 @@
-cryptography >= 46.0.5 # Updated for CVE-2026-26007
+cryptography >= 46.0.7 # CVE-2026-39892
 Django>=5.2.8,<5.3 # Django 5.2 LTS - see AAP-55610
 djangorestframework
 django-crum

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -16,7 +16,7 @@ cffi==2.0.0
     #   cryptography
 charset-normalizer==3.4.0
     # via requests
-cryptography==46.0.5
+cryptography==48.0.0
     # via -r requirements/requirements.in
 dispatcherd[pg-notify]==2026.3.25
     # via -r requirements/requirements.in


### PR DESCRIPTION
## Description

- Bumps the `cryptography` floor pin from `>= 46.0.5` to `>= 46.0.7` (resolves to 48.0.0)
- Addresses CVE-2026-39892: buffer overflow via non-contiguous buffer in cryptography API (affects 45.0.0 through 46.0.6)
- JIRA: [AAP-75030](https://redhat.atlassian.net/browse/AAP-75030)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have considered the security impact of these changes
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites
None

### Steps to Test
1. `pip install -r requirements/requirements.txt`
2. `pip show cryptography`

### Expected Results
- cryptography version >= 46.0.7

## Additional Context

### Required Actions
- [ ] Requires downstream repository changes
  MintMaker will propagate to `automation-gateway-container` automatically after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cryptography dependency to address security vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->