### PR TITLE
AAP-75418: Fix dispatcherd health check returning false positive

### DIFF
--- a/aap_gateway_api/tests/views/api/v1/ping/test_ping.py
+++ b/aap_gateway_api/tests/views/api/v1/ping/test_ping.py
@@ -10,7 +10,7 @@ from aap_gateway_api.version import get_aap_version
 
 
 @pytest.mark.django_db
-@mock.patch("aap_gateway_api.views.api.v1.ping.PingView._check_dispatcherd")
+@mock.patch("aap_gateway_api.views.api.v1.ping.PingView._check_dispatcherd", return_value=True)
 @mock.patch("aap_gateway_api.views.api.v1.ping.requests.request")
 def test_ping_all_up(request, mock_dispatcherd, unauthenticated_api_client):
     request.return_value = mock.Mock(status_code=200, json=lambda: {"test": "test"})
@@ -27,7 +27,7 @@ def test_ping_all_up(request, mock_dispatcherd, unauthenticated_api_client):
 
 
 @pytest.mark.django_db
-@mock.patch("aap_gateway_api.views.api.v1.ping.PingView._check_dispatcherd")
+@mock.patch("aap_gateway_api.views.api.v1.ping.PingView._check_dispatcherd", return_value=True)
 @mock.patch("aap_gateway_api.views.api.v1.ping.requests.request")
 def test_ping_db_down(request, mock_dispatcherd, unauthenticated_api_client):
     request.return_value = mock.Mock(status_code=200, json=lambda: {"test": "test"})
@@ -41,7 +41,7 @@ def test_ping_db_down(request, mock_dispatcherd, unauthenticated_api_client):
 
 
 @pytest.mark.django_db
-@mock.patch("aap_gateway_api.views.api.v1.ping.PingView._check_dispatcherd")
+@mock.patch("aap_gateway_api.views.api.v1.ping.PingView._check_dispatcherd", return_value=True)
 @mock.patch("aap_gateway_api.views.api.v1.ping.requests.request")
 def test_ping_proxy_exception(request, mock_dispatcherd, unauthenticated_api_client, service_cluster_gateway):
     request.side_effect = Exception('testing')
@@ -62,7 +62,7 @@ def test_ping_proxy_exception(request, mock_dispatcherd, unauthenticated_api_cli
 
 
 @pytest.mark.django_db
-@mock.patch("aap_gateway_api.views.api.v1.ping.PingView._check_dispatcherd")
+@mock.patch("aap_gateway_api.views.api.v1.ping.PingView._check_dispatcherd", return_value=True)
 @mock.patch("aap_gateway_api.views.api.v1.ping.requests.request")
 def test_ping_proxy_non_200(request, mock_dispatcherd, unauthenticated_api_client, service_cluster_gateway):
     request.return_value = mock.Mock(status_code=500, json=lambda: {"test": "test"})
@@ -83,15 +83,28 @@ def test_ping_proxy_non_200(request, mock_dispatcherd, unauthenticated_api_clien
 
 
 @pytest.mark.django_db
-@mock.patch("aap_gateway_api.views.api.v1.ping.PingView._check_dispatcherd", side_effect=Exception("connection refused"))
+@mock.patch("aap_gateway_api.views.api.v1.ping.PingView._check_dispatcherd", return_value=False)
 @mock.patch("aap_gateway_api.views.api.v1.ping.requests.request")
-def test_ping_dispatcherd_down(request, mock_dispatcherd, unauthenticated_api_client):
-    """Dispatcherd failure must not degrade overall status (informational only)."""
+def test_ping_dispatcherd_not_running(request, mock_dispatcherd, unauthenticated_api_client):
+    """Dispatcherd not running (empty alive reply) must not degrade overall status."""
     request.return_value = mock.Mock(status_code=200, json=lambda: {"test": "test"})
 
     url = get_relative_url("ping-view")
     response = unauthenticated_api_client.get(url)
     assert response.status_code == 200
     assert response.data['dispatcherd_connected'] is False
-    # Status must remain GOOD — dispatcherd is not a critical dependency
+    assert response.data['status'] == STATUS_GOOD
+
+
+@pytest.mark.django_db
+@mock.patch("aap_gateway_api.views.api.v1.ping.PingView._check_dispatcherd", side_effect=Exception("connection refused"))
+@mock.patch("aap_gateway_api.views.api.v1.ping.requests.request")
+def test_ping_dispatcherd_exception(request, mock_dispatcherd, unauthenticated_api_client):
+    """Dispatcherd error must not degrade overall status (informational only)."""
+    request.return_value = mock.Mock(status_code=200, json=lambda: {"test": "test"})
+
+    url = get_relative_url("ping-view")
+    response = unauthenticated_api_client.get(url)
+    assert response.status_code == 200
+    assert response.data['dispatcherd_connected'] is False
     assert response.data['status'] == STATUS_GOOD

--- a/aap_gateway_api/views/api/v1/ping.py
+++ b/aap_gateway_api/views/api/v1/ping.py
@@ -24,10 +24,11 @@ class PingView(AnsibleBaseView):
             cursor.execute("SELECT 1")
 
     def _check_dispatcherd(self):
-        """Raises on failure — the alive command either gets a reply or throws."""
+        """Returns True if dispatcherd responds to alive, False if no reply, or raises on error."""
         from dispatcherd.factories import get_control_from_settings
 
-        get_control_from_settings().control_with_reply("alive", timeout=getattr(settings, "DISPATCHERD_HEALTH_CHECK_TIMEOUT", 5))
+        reply = get_control_from_settings().control_with_reply("alive", timeout=getattr(settings, "DISPATCHERD_HEALTH_CHECK_TIMEOUT", 5))
+        return bool(reply)
 
     def get(self, request):
         timeout = getattr(settings, "PING_PAGE_CHECK_TIMEOUT", 5)
@@ -71,8 +72,7 @@ class PingView(AnsibleBaseView):
 
         # Dispatcherd check is informational only — does not affect overall status
         try:
-            self._check_dispatcherd()
-            response['dispatcherd_connected'] = True
+            response['dispatcherd_connected'] = self._check_dispatcherd()
         except Exception:
             logger.warning("Dispatcherd health check failed", exc_info=True)
             response['dispatcherd_connected'] = False


### PR DESCRIPTION
control_with_reply("alive") returns an empty list when dispatcherd is not running instead of raising an exception. Check the return value with bool(reply) so an empty reply correctly reports dispatcherd_connected as false.

Assisted-by: Claude Code claude-opus-4-6 1M context

## Description

<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
  - ping API checks the response from dispatcher control command
- Why is this change needed?
  - initial implementation of ping API has been always reporting dispatcherd as connected. When dispatcherd is not running, the response from the control command is an empty list
- How does this change address the issue?
  - by checking the return value of the control command we can properly detect dispatcherd running. If the response is empty or control command raises an exception, the dispatcher is indeed not connected.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. Pull down the PR
2. Start the dev environment
3. Open the ping API: <https://localhost:8000/api/gateway/v1/ping/>
4. Check the result of the dispatcherd in the response in the above
5. Exec into the gateway container with command:
    ```sh
    docker exec -ti aap_gw_1 /bin/bash
    ```
6. While in the container, stop dispatcherd with command:
    ```sh
    supervisorctl stop gateway-processes:dispatcher
    ```
7. Refresh the ping API and notice the change on the dispatcherd

### Expected Results
Initial output:
```json
{
    "status": "good",
    "version": "0.1",
    "pong": "2026-05-14 14:47:41.998764",
    "db_connected": true,
    "proxy_connected": true,
    "dispatcherd_connected": true
}
```
Output after stopping dispatcherd
```json
{
    "status": "good",
    "version": "0.1",
    "pong": "2026-05-14 14:47:41.998764",
    "db_connected": true,
    "proxy_connected": true,
    "dispatcherd_connected": false
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate reporting of dispatcherd connectivity in health responses: connectivity is now explicitly reported as true/false, preventing false positives when dispatcherd is unreachable or errors occur.

* **Tests**
  * Expanded health-check tests: added a case for dispatcherd not running and refined the exception scenario to assert connectivity is reported as false while overall status remains healthy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->