### PR TITLE
[AAP-75136] feat(ci): add Codecov coverage upload workflow

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -28,17 +28,13 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       (github.repository == 'ansible/jewel' || github.repository == 'ansible/jewel-debug')
     steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-
       - name: Download coverage artifacts
-        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: Unit Tests
           run_id: ${{ github.event.workflow_run.id }}
-          pattern: coverage-*
+          name: coverage-
+          name_is_regexp: true
 
       - name: Discover coverage files and PR number
         id: coverage
@@ -51,8 +47,13 @@ jobs:
           csv=$(echo "$files" | paste -sd ',' -)
           echo "file_list=$csv" >> "$GITHUB_OUTPUT"
 
-          first=$(echo "$files" | head -1)
-          pr=$(grep -m 1 '<!-- PR' "$first" 2>/dev/null | awk '{print $3}' || true)
+          pr=""
+          for f in $files; do
+            pr=$(grep -oP '<!-- PR \K\d+' "$f" 2>/dev/null | head -1)
+            if [ -n "$pr" ]; then
+              break
+            fi
+          done
           echo "pr_number=$pr" >> "$GITHUB_OUTPUT"
           if [ -n "$pr" ]; then
             echo "Detected PR #$pr from coverage artifact"

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,73 @@
+# Codecov coverage upload for jewel
+#
+# Triggered after Unit Tests complete (workflow_run), so coverage artifacts
+# are always available before upload. Mirrors the sonar-pr.yml pattern.
+#
+# JOB 1: codecov-upload (for both PRs and branch pushes)
+# - Downloads coverage XML artifacts produced by unit-test matrix jobs
+# - Uploads all coverage files to Codecov with the unit-tests flag
+# - PR events: Codecov posts a coverage summary comment on the PR
+# - Push events: establishes baseline coverage for diff calculations
+
+name: Codecov
+on:
+  workflow_run:
+    workflows:
+      - Unit Tests
+    types:
+      - completed
+
+jobs:
+  codecov-upload:
+    name: Upload coverage to Codecov
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      (github.repository == 'ansible/jewel' || github.repository == 'ansible/jewel-debug')
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Download coverage artifacts
+        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: Unit Tests
+          run_id: ${{ github.event.workflow_run.id }}
+          pattern: coverage-*
+
+      - name: Discover coverage files and PR number
+        id: coverage
+        run: |
+          files=$(find . -name "coverage-*.xml" -type f)
+          count=$(echo "$files" | grep -c . || true)
+          echo "Found $count coverage file(s):"
+          echo "$files"
+
+          csv=$(echo "$files" | paste -sd ',' -)
+          echo "file_list=$csv" >> "$GITHUB_OUTPUT"
+
+          first=$(echo "$files" | head -1)
+          pr=$(grep -m 1 '<!-- PR' "$first" 2>/dev/null | awk '{print $3}' || true)
+          echo "pr_number=$pr" >> "$GITHUB_OUTPUT"
+          if [ -n "$pr" ]; then
+            echo "Detected PR #$pr from coverage artifact"
+          else
+            echo "No PR number found (branch push)"
+          fi
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+        with:
+          files: ${{ steps.coverage.outputs.file_list }}
+          flags: unit-tests
+          fail_ci_if_error: true
+          override_commit: ${{ github.event.workflow_run.head_sha }}
+          override_branch: ${{ github.event.workflow_run.head_branch }}
+          override_pr: ${{ steps.coverage.outputs.pr_number }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
-      (github.repository == 'ansible/jewel' || github.repository == 'ansible/jewel-debug')
+      !github.event.repository.fork
     steps:
       - name: Download coverage artifacts
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,36 @@
+# Codecov configuration for jewel
+# Coverage exclusions mirror sonar.coverage.exclusions in sonar-project.properties
+# Keep both in sync when adding or removing patterns.
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+    patch:
+      default:
+        target: auto
+
+ignore:
+  - "**/tests/**"
+  - "**/.tox/**"
+  - "**/test_*.py"
+  - "**/*_test.py"
+  - "**/conftest.py"
+  - "**/migrations/**"
+  - "**/settings*.py"
+  - "**/defaults.py"
+  - "**/grpc_defaults.py"
+  - "**/manage.py"
+  - "**/wsgi.py"
+  - "**/asgi.py"
+  - "**/__main__.py"
+  - "**/*.js"
+  - "aap-dev/**"
+  - "tools/scripts/**"
+
+flags:
+  unit-tests:
+    paths:
+      - aap_gateway_api/
+    carryforward: true


### PR DESCRIPTION
## Description

- Adds a `workflow_run`-triggered GitHub Actions workflow that uploads coverage to Codecov.
  Fires after every Unit Tests completion — both PR runs (for diff coverage comments) and
  devel merges (to establish the baseline that PR diffs are measured against).
- Adds `codecov.yml` configuration with coverage exclusions matching SonarCloud's
  `sonar.coverage.exclusions` and a `unit-tests` flag for flag analytics.
- Follows the same artifact-download pattern as the sonar-pr.yml workflow.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases

## Testing Instructions

### Prerequisites
- CODECOV_TOKEN must be set as a GitHub Actions secret (done)
- Codecov GitHub App must be installed on the repo (done)

### Steps to Test
1. Merge this PR to devel
2. Observe the Codecov workflow triggers after Unit Tests complete on devel
3. Open a new PR and confirm Codecov posts a coverage summary comment

### Expected Results
- Coverage appears in Codecov dashboard under ansible/jewel
- PR coverage comments show patch and project coverage
- Flag analytics shows the `unit-tests` flag in the Codecov Flags tab

## Additional Context

### Intent Adherence: 85/100

| Criterion | Score |
|-----------|-------|
| Solves the problem described in the story | 40/40 |
| No deviations from stated intent | 20/20 |
| No over-engineering or scope creep | 15/20 |
| A reviewer would agree the code matches the story | 10/20 |

### Required Actions
- [ ] Requires coordination with other teams
  COVERPORT-105 approval for public repo onboarding
- [ ] Enable flag analytics in Codecov UI (Flags tab) after first upload

Assisted-by: Claude Code / Opus 4.6 (Anthropic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now collects unit-test coverage artifacts after successful test runs and automatically uploads them to Codecov, helping track coverage over time and fail CI on upload errors.
  * Added Codecov configuration to control which files are measured, set coverage targets to automatic, and enable a dedicated "unit-tests" coverage flag for clearer, carry-forward coverage reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->