### PR TITLE
[AAP-75748] Reduce timeout when checking dispatcherd status in ping

### DIFF
--- a/aap_gateway_api/views/api/v1/ping.py
+++ b/aap_gateway_api/views/api/v1/ping.py
@@ -27,7 +27,7 @@ class PingView(AnsibleBaseView):
         """Returns True if dispatcherd responds to alive, False if no reply, or raises on error."""
         from dispatcherd.factories import get_control_from_settings
 
-        reply = get_control_from_settings().control_with_reply("alive", timeout=getattr(settings, "DISPATCHERD_HEALTH_CHECK_TIMEOUT", 5))
+        reply = get_control_from_settings().control_with_reply("alive", timeout=getattr(settings, "DISPATCHERD_HEALTH_CHECK_TIMEOUT", 0.25))
         return bool(reply)
 
     def get(self, request):


### PR DESCRIPTION
## Description

<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
  - shorter timeout for checking dispatcherd liveness
- Why is this change needed?
  - when dispatcherd is not running, whole ping API response takes at least the amount of time set as timeout for checking dispatcherd status
- How does this change address the issue?
  - with shorter timeout for checking dispatcherd status, ping API responds in reasonable amount of time


## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. Pull down the PR
2. Start the development environment
3. Exec into the container and check status of the dispatcherd with command: `supervisorctl status gateway-processes:*`
4. In terminal(outside container) run the curl command: `curl -w '\nConnect: %{time_connect}s\nTTFB: %{time_starttransfer}s\nTotal: %{time_total}s\n' -k https://localhost:8000/api/gateway/v1/ping/` and note the timings
5. Stop the dispatcherd in the container with command: `supervisorctl stop gateway-processes:dispatcher`
6. Re-run the curl command

### Expected Results
<!-- Describe what should happen after following the steps -->
In both cases the curl command should report sub-second response times:
```
$> curl -w '\nConnect: %{time_connect}s\nTTFB: %{time_starttransfer}s\nTotal: %{time_total}s\n' -k https://localhost:8000/api/gateway/v1/ping/
{"status":"good","version":"0.1","pong":"2026-05-14 21:17:14.968524","db_connected":true,"proxy_connected":true,"dispatcherd_connected":true}
Connect: 0.000132s
TTFB: 0.072930s
Total: 0.072957s
```
```
$> curl -w '\nConnect: %{time_connect}s\nTTFB: %{time_starttransfer}s\nTotal: %{time_total}s\n' -k https://localhost:8000/api/gateway/v1/ping/
{"status":"good","version":"0.1","pong":"2026-05-14 21:01:51.374312","db_connected":true,"proxy_connected":true,"dispatcherd_connected":false}
Connect: 0.000133s
TTFB: 0.322019s
Total: 0.322050s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized health check timeout configuration for improved system responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->