### PR TITLE
[AAP-75136] docs: fix typo in TESTING.md

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -235,7 +235,7 @@ All service fixtures depend on `ensure_jwt_keys` for authentication:
 
 **Service Fixtures:**
 - `simulated_controller_resource_api`
-- `simmulated_hub_resource_api`
+- `simulated_hub_resource_api`
 - `simulated_eda_resource_api`
 - `migration_service*` (all variants)
 


### PR DESCRIPTION
## Description

- Fix typo: `simmulated_hub_resource_api` → `simulated_hub_resource_api` in the Service Fixtures section

## Type of Change
- [x] Documentation update

## Self-Review Checklist
- [x] I have performed a self-review of my code

## Testing Instructions

N/A — documentation-only change.

## Additional Context

No-op change to establish Codecov baseline after merging [AAP-75136] codecov workflow (#43).

Assisted-by: Claude Code / Opus 4.6 (Anthropic)

[AAP-75136]: https://redhat.atlassian.net/browse/AAP-75136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a spelling error in testing documentation for service fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->