### PR TITLE
[AAP-75136] fix(ci): restore checkout for Codecov source mapping

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -28,6 +28,15 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       !github.event.repository.fork
     steps:
+      # Codecov needs the source tree to map coverage XML paths to actual files.
+      # This checks out the PR head in a workflow_run context, but no code from
+      # the checkout is executed — only downloaded artifacts are processed.
+      # persist-credentials: false prevents GITHUB_TOKEN from leaking via git config.
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
+
       - name: Download coverage artifacts
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -44,11 +44,12 @@ jobs:
           run_id: ${{ github.event.workflow_run.id }}
           name: coverage-
           name_is_regexp: true
+          path: codecov-artifacts
 
       - name: Discover coverage files and PR number
         id: coverage
         run: |
-          files=$(find . -name "coverage-*.xml" -type f)
+          files=$(find codecov-artifacts -name "coverage-*.xml" -type f)
           count=$(echo "$files" | grep -c . || true)
           echo "Found $count coverage file(s):"
           echo "$files"


### PR DESCRIPTION
## Description

- Restores `actions/checkout` in the Codecov workflow — Codecov needs the source tree to map
  file paths in coverage XML to actual files. Without it, reports are rejected as unusable.
- Uses `persist-credentials: false` to avoid storing GITHUB_TOKEN in git config.
- SHA-pinned to `actions/checkout@v4.2.2`.
- No scripts from the checkout are executed — only downloaded coverage artifacts are processed.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have considered the security impact of these changes

## Testing Instructions

### Steps to Test
1. Merge this PR to devel
2. Merge the baseline PR (#46) after this
3. Confirm Codecov processes the upload without errors

### Expected Results
- Codecov upload succeeds and coverage data appears on the dashboard

Assisted-by: Claude Code / Opus 4.6 (Anthropic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved test coverage reporting: the CI workflow now reliably retrieves test coverage artifacts, isolates them into a dedicated directory, and more accurately discovers and uploads coverage files (including optional PR attribution) to Codecov using secure token authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->