### PR TITLE
[AAP-75712] feat: add rotate_secret_key management command

### DIFF
--- a/aap_gateway_api/management/commands/rotate_secret_key.py
+++ b/aap_gateway_api/management/commands/rotate_secret_key.py
@@ -302,9 +302,7 @@ class Command(BaseCommand):
             logger.warning("Cannot decrypt %s with the current SECRET_KEY; skipping", label)
             return None
 
-    def _paginated_reencrypt(
-        self, first_page_sql: str, next_page_sql: str, update_sql: str, dry_run: bool, *, label: str
-    ) -> int:
+    def _paginated_reencrypt(self, first_page_sql: str, next_page_sql: str, update_sql: str, dry_run: bool, *, label: str) -> int:
         """Paginate through rows and re-encrypt values.
 
         Used by both ``_reencrypt_column`` and ``_rotate_preferences``

--- a/aap_gateway_api/management/commands/rotate_secret_key.py
+++ b/aap_gateway_api/management/commands/rotate_secret_key.py
@@ -1,0 +1,362 @@
+r"""Re-encrypt all gateway-managed secrets after changing SECRET_KEY.
+
+Handles all encrypted data in the gateway database:
+
+* ``AbstractCommonModel.encrypted_fields`` columns (e.g. ``ServiceKey.secret``)
+* ``Authenticator.configuration`` sub-fields marked as encrypted by each
+  authenticator plugin
+* ``Preference`` rows stored with ``encrypted=True``
+* Preference cache (flushed so stale ciphertext is not served)
+
+Mirrors the operational pattern of ``awx-manage regenerate_secret_key``
+(Automation Controller) and ``aap-eda-manage rotate_db_encryption_key``
+(EDA Server): stop traffic, run the command, update the deployment secret
+with the new key, then restart services.
+
+Usage::
+
+    gateway-manage rotate_secret_key
+    GATEWAY_SECRET_KEY='...' \
+      gateway-manage rotate_secret_key --use-custom-key
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+from typing import Iterator
+
+from ansible_base.authentication.authenticator_plugins.utils import get_authenticator_plugin
+from ansible_base.authentication.models import Authenticator
+from ansible_base.lib.abstract_models.common import AbstractCommonModel
+from ansible_base.lib.utils.encryption import ENCRYPTED_STRING
+from django.apps import apps
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.db import connection, transaction
+
+from aap_gateway_api.utils.encryption import decrypt_with_key, encrypt_with_key
+
+logger = logging.getLogger('aap.gateway.management.rotate_secret_key')
+
+_FETCH_BATCH_SIZE = 2000
+
+
+def _iter_models_with_encrypted_fields() -> Iterator[tuple[type, list[str]]]:
+    """Yield ``(model_class, field_names)`` for every model with non-empty encrypted_fields.
+
+    Only yields fields defined directly on the model (not inherited)
+    to avoid processing the same column twice in multi-table
+    inheritance hierarchies.
+    """
+    for model in apps.get_models():
+        if not issubclass(model, AbstractCommonModel):
+            continue
+        fields = getattr(model, 'encrypted_fields', [])
+        if not fields:
+            continue
+        local_field_names = {f.name for f in model._meta.local_fields}
+        own_fields = [f for f in fields if f in local_field_names]
+        if own_fields:
+            yield model, own_fields
+
+
+class Command(BaseCommand):
+    """Re-encrypt every secret in the gateway database with a new SECRET_KEY.
+
+    The entire re-encryption runs inside a single database transaction so
+    that a failure at any point rolls back all changes automatically.
+    """
+
+    help = "Re-encrypt all gateway database secrets after rotating SECRET_KEY. Covers encrypted model fields, Authenticator config, and Preferences."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--use-custom-key',
+            dest='use_custom_key',
+            action='store_true',
+            default=False,
+            help="Use the key from the GATEWAY_SECRET_KEY environment variable instead of generating a new one.",
+        )
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            default=False,
+            help="Report affected rows without writing to the database.",
+        )
+
+    @transaction.atomic
+    def handle(self, *args, **options):
+        use_custom_key: bool = options['use_custom_key']
+        dry_run: bool = options['dry_run']
+
+        self.old_key = settings.SECRET_KEY
+
+        if use_custom_key:
+            self.new_key = os.environ.get('GATEWAY_SECRET_KEY')
+            if not self.new_key:
+                raise CommandError("--use-custom-key was specified but GATEWAY_SECRET_KEY is not set in the environment.")
+        else:
+            self.new_key = base64.encodebytes(os.urandom(33)).decode().rstrip()
+
+        if self.new_key == self.old_key:
+            raise CommandError("New encryption key is identical to the current SECRET_KEY; rotation aborted.")
+
+        total = 0
+        total += self._rotate_encrypted_fields(dry_run)
+        total += self._rotate_authenticator_configs(dry_run)
+        total += self._rotate_preferences(dry_run)
+
+        self._flush_preference_cache(dry_run)
+
+        if dry_run:
+            self.stdout.write(f"{total} value(s) would be re-encrypted.")
+            self.stdout.write("Preference cache would be flushed.")
+        else:
+            self.stdout.write(f"{total} value(s) re-encrypted.")
+            self.stdout.write("Preference cache flushed.")
+
+        if not dry_run and not use_custom_key:
+            self.stdout.write(self.new_key)
+
+    # ── encrypted_fields on AbstractCommonModel subclasses ───────────────
+
+    def _rotate_encrypted_fields(self, dry_run: bool) -> int:
+        total = 0
+        for model, field_names in _iter_models_with_encrypted_fields():
+            for field_name in field_names:
+                try:
+                    field_obj = model._meta.get_field(field_name)
+                except Exception:
+                    logger.warning("Model %s declares encrypted field %r but has no such DB column", model.__name__, field_name)
+                    continue
+                total += self._reencrypt_column(model, field_obj.column, dry_run)
+        return total
+
+    # ── Authenticator.configuration encrypted sub-fields ─────────────────
+
+    def _rotate_authenticator_configs(self, dry_run: bool) -> int:
+        total = 0
+        select_sql = self._build_authenticator_select_sql()
+        update_sql = self._build_authenticator_update_sql()
+
+        with connection.cursor() as cur:
+            cur.execute(select_sql)
+            while True:
+                rows = cur.fetchmany(_FETCH_BATCH_SIZE)
+                if not rows:
+                    break
+                for pk, auth_type, config in rows:
+                    if not config or not isinstance(config, dict):
+                        continue
+                    try:
+                        plugin = get_authenticator_plugin(auth_type)
+                    except ImportError:
+                        logger.warning("Cannot load plugin %r for Authenticator pk=%s; skipping", auth_type, pk)
+                        continue
+                    encrypted_fields = getattr(plugin, 'configuration_encrypted_fields', [])
+                    changed = False
+                    for field in encrypted_fields:
+                        val = config.get(field)
+                        if not val or not isinstance(val, str) or ENCRYPTED_STRING not in val:
+                            continue
+                        try:
+                            clear = decrypt_with_key(val, self.old_key)
+                        except Exception:
+                            logger.warning("Cannot decrypt Authenticator pk=%s field %r with the current SECRET_KEY; skipping", pk, field)
+                            continue
+                        config[field] = encrypt_with_key(clear, self.new_key)
+                        changed = True
+                        total += 1
+                    if changed and not dry_run:
+                        with connection.cursor() as ucur:
+                            ucur.execute(update_sql, [json.dumps(config), pk])
+        return total
+
+    @staticmethod
+    def _build_authenticator_select_sql() -> str:
+        """Build SELECT for authenticator config scanning.
+
+        Safe from SQL injection: all identifiers originate from Django
+        model metadata and are quoted via the database backend.
+        """
+        qn = connection.ops.quote_name
+        return "SELECT {pk}, {type}, {config} FROM {table}".format(
+            pk=qn(Authenticator._meta.pk.column),
+            type=qn(Authenticator._meta.get_field('type').column),
+            config=qn(Authenticator._meta.get_field('configuration').column),
+            table=qn(Authenticator._meta.db_table),
+        )
+
+    @staticmethod
+    def _build_authenticator_update_sql() -> str:
+        """Build UPDATE for authenticator config re-encryption.
+
+        Safe from SQL injection: all identifiers originate from Django
+        model metadata and are quoted via the database backend.
+        """
+        qn = connection.ops.quote_name
+        return "UPDATE {table} SET {config} = %s WHERE {pk} = %s".format(
+            table=qn(Authenticator._meta.db_table),
+            config=qn(Authenticator._meta.get_field('configuration').column),
+            pk=qn(Authenticator._meta.pk.column),
+        )
+
+    # ── Preference rows (encrypted=True) ─────────────────────────────────
+
+    def _rotate_preferences(self, dry_run: bool) -> int:
+        from aap_gateway_api.models import Preference
+
+        select_sql = self._build_preference_select_sql(Preference)
+        update_sql = self._build_preference_update_sql(Preference)
+        count = 0
+        last_pk = None
+
+        while True:
+            with connection.cursor() as cur:
+                if last_pk is None:
+                    cur.execute(select_sql.format(pk_clause=""))
+                else:
+                    cur.execute(select_sql.format(pk_clause="AND {pk} > %s ".format(pk=connection.ops.quote_name(Preference._meta.pk.column))), [last_pk])
+                rows = cur.fetchall()
+            if not rows:
+                break
+            last_pk = rows[-1][0]
+            for pk, raw in rows:
+                if not raw or ENCRYPTED_STRING not in str(raw):
+                    continue
+                try:
+                    clear = decrypt_with_key(raw, self.old_key)
+                except Exception:
+                    logger.warning("Cannot decrypt Preference pk=%s with the current SECRET_KEY; skipping", pk)
+                    continue
+                new_val = encrypt_with_key(clear, self.new_key)
+                if not dry_run:
+                    with connection.cursor() as ucur:
+                        ucur.execute(update_sql, [new_val, pk])
+                count += 1
+        return count
+
+    @staticmethod
+    def _build_preference_select_sql(model) -> str:
+        """Build paginated SELECT for preference scanning.
+
+        Returns a format string with a ``{pk_clause}`` placeholder that
+        is filled in at call time (empty for the first page, ``AND pk > %s``
+        for subsequent pages).
+
+        Safe from SQL injection: all identifiers originate from Django
+        model metadata and are quoted via the database backend.
+        """
+        qn = connection.ops.quote_name
+        return ("SELECT {pk}, {val} FROM {table} WHERE {val} IS NOT NULL {{pk_clause}}ORDER BY {pk} LIMIT {limit}").format(
+            pk=qn(model._meta.pk.column),
+            val=qn('raw_value'),
+            table=qn(model._meta.db_table),
+            limit=_FETCH_BATCH_SIZE,
+        )
+
+    @staticmethod
+    def _build_preference_update_sql(model) -> str:
+        """Build UPDATE for preference re-encryption.
+
+        Safe from SQL injection: all identifiers originate from Django
+        model metadata and are quoted via the database backend.
+        """
+        qn = connection.ops.quote_name
+        return "UPDATE {table} SET {val} = %s WHERE {pk} = %s".format(
+            table=qn(model._meta.db_table),
+            val=qn('raw_value'),
+            pk=qn(model._meta.pk.column),
+        )
+
+    # ── Cache flush ──────────────────────────────────────────────────────
+
+    def _flush_preference_cache(self, dry_run: bool) -> None:
+        """Clear the preference cache so stale encrypted values are not served."""
+        if dry_run:
+            return
+        try:
+            from aap_gateway_api.preferences import gateway_preference_registry
+
+            manager = gateway_preference_registry.manager()
+            if hasattr(manager, 'cache'):
+                manager.cache.clear()
+                logger.info("Preference cache cleared after secret key rotation.")
+        except Exception:
+            logger.warning("Could not clear preference cache; manual cache flush may be needed.", exc_info=True)
+
+    # ── Shared column re-encryption ──────────────────────────────────────
+
+    @staticmethod
+    def _build_column_select_sql(model, column_name, *, with_pk_bound: bool) -> str:
+        """Build a paginated SELECT for encrypted column scanning.
+
+        When *with_pk_bound* is ``True`` the query includes a
+        ``WHERE pk > %s`` predicate for keyset pagination.  The first
+        page is fetched without this predicate so no assumption about
+        the PK type (integer vs UUID) is needed.
+
+        Safe from SQL injection: all identifiers originate from Django
+        model metadata and are quoted via the database backend.
+        """
+        qn = connection.ops.quote_name
+        pk = qn(model._meta.pk.column)
+        col = qn(column_name)
+        table = qn(model._meta.db_table)
+
+        pk_clause = "AND {pk} > %s ".format(pk=pk) if with_pk_bound else ""
+        return "SELECT {pk}, {col} FROM {table} WHERE {col} IS NOT NULL {pk_clause}ORDER BY {pk} LIMIT {limit}".format(
+            pk=pk,
+            col=col,
+            table=table,
+            pk_clause=pk_clause,
+            limit=_FETCH_BATCH_SIZE,
+        )
+
+    @staticmethod
+    def _build_column_update_sql(model, column_name) -> str:
+        """Build an UPDATE query for re-encrypting a single row.
+
+        Safe from SQL injection: all identifiers originate from Django
+        model metadata and are quoted via the database backend.
+        """
+        qn = connection.ops.quote_name
+        return "UPDATE {table} SET {col} = %s WHERE {pk} = %s".format(
+            table=qn(model._meta.db_table),
+            col=qn(column_name),
+            pk=qn(model._meta.pk.column),
+        )
+
+    def _reencrypt_column(self, model, column_name: str, dry_run: bool) -> int:
+        first_page_sql = self._build_column_select_sql(model, column_name, with_pk_bound=False)
+        next_page_sql = self._build_column_select_sql(model, column_name, with_pk_bound=True)
+        update_sql = self._build_column_update_sql(model, column_name)
+        count = 0
+        last_pk = None
+        while True:
+            with connection.cursor() as cur:
+                if last_pk is None:
+                    cur.execute(first_page_sql)
+                else:
+                    cur.execute(next_page_sql, [last_pk])
+                rows = cur.fetchall()
+            if not rows:
+                break
+            last_pk = rows[-1][0]
+            for pk, raw in rows:
+                if not raw or ENCRYPTED_STRING not in str(raw):
+                    continue
+                try:
+                    clear = decrypt_with_key(raw, self.old_key)
+                except Exception:
+                    logger.warning("Cannot decrypt %s.%s pk=%s with the current SECRET_KEY; skipping", model.__name__, column_name, pk)
+                    continue
+                new_val = encrypt_with_key(clear, self.new_key)
+                if not dry_run:
+                    with connection.cursor() as ucur:
+                        ucur.execute(update_sql, [new_val, pk])
+                count += 1
+        return count

--- a/aap_gateway_api/management/commands/rotate_secret_key.py
+++ b/aap_gateway_api/management/commands/rotate_secret_key.py
@@ -213,8 +213,10 @@ class Command(BaseCommand):
     def _build_authenticator_update_sql() -> str:
         """Build UPDATE for authenticator config re-encryption.
 
-        The ``%s::jsonb`` cast ensures the text parameter is correctly
-        stored in the jsonb column regardless of the database adapter.
+        Uses the PostgreSQL-specific ``::jsonb`` cast to ensure the text
+        parameter is stored correctly in the ``jsonb`` column.  This is
+        not portable to SQLite or MySQL, but the gateway requires
+        PostgreSQL in both production and test environments.
 
         Safe from SQL injection: all identifiers originate from Django
         model metadata and are quoted via the database backend.

--- a/aap_gateway_api/management/commands/rotate_secret_key.py
+++ b/aap_gateway_api/management/commands/rotate_secret_key.py
@@ -72,7 +72,12 @@ class Command(BaseCommand):
     that a failure at any point rolls back all changes automatically.
     """
 
-    help = "Re-encrypt all gateway database secrets after rotating SECRET_KEY. Covers encrypted model fields, Authenticator config, and Preferences."
+    help = (
+        "Re-encrypt all gateway database secrets after rotating SECRET_KEY. "
+        "Covers encrypted model fields, Authenticator config, and Preferences. "
+        "Workflow: stop traffic, run this command, update the deployment secret "
+        "with the printed key, then restart services."
+    )
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/aap_gateway_api/management/commands/rotate_secret_key.py
+++ b/aap_gateway_api/management/commands/rotate_secret_key.py
@@ -23,6 +23,7 @@ Usage::
 from __future__ import annotations
 
 import base64
+import json
 import logging
 import os
 from typing import Iterator
@@ -140,37 +141,41 @@ class Command(BaseCommand):
     def _rotate_authenticator_configs(self, dry_run: bool) -> int:
         total = 0
         select_sql = self._build_authenticator_select_sql()
+        update_sql = self._build_authenticator_update_sql()
 
         with connection.cursor() as cur:
             cur.execute(select_sql)
-            while True:
-                rows = cur.fetchmany(_FETCH_BATCH_SIZE)
-                if not rows:
-                    break
-                for pk, auth_type, config in rows:
-                    if not config or not isinstance(config, dict):
-                        continue
-                    try:
-                        plugin = get_authenticator_plugin(auth_type)
-                    except ImportError:
-                        logger.warning("Cannot load plugin %r for Authenticator pk=%s; skipping", auth_type, pk)
-                        continue
-                    encrypted_fields = getattr(plugin, 'configuration_encrypted_fields', [])
-                    changed = False
-                    for field in encrypted_fields:
-                        val = config.get(field)
-                        if not val or not isinstance(val, str) or ENCRYPTED_STRING not in val:
-                            continue
-                        try:
-                            clear = decrypt_with_key(val, self.old_key)
-                        except Exception:
-                            logger.warning("Cannot decrypt Authenticator pk=%s field %r with the current SECRET_KEY; skipping", pk, field)
-                            continue
-                        config[field] = encrypt_with_key(clear, self.new_key)
-                        changed = True
-                        total += 1
-                    if changed and not dry_run:
-                        Authenticator.objects.filter(pk=pk).update(configuration=config)
+            rows = cur.fetchall()
+
+        for pk, auth_type, config in rows:
+            if not config:
+                continue
+            if isinstance(config, str):
+                config = json.loads(config)
+            if not isinstance(config, dict):
+                continue
+            try:
+                plugin = get_authenticator_plugin(auth_type)
+            except ImportError:
+                logger.warning("Cannot load plugin %r for Authenticator pk=%s; skipping", auth_type, pk)
+                continue
+            encrypted_fields = getattr(plugin, 'configuration_encrypted_fields', [])
+            changed = False
+            for field in encrypted_fields:
+                val = config.get(field)
+                if not val or not isinstance(val, str) or ENCRYPTED_STRING not in val:
+                    continue
+                try:
+                    clear = decrypt_with_key(val, self.old_key)
+                except Exception:
+                    logger.warning("Cannot decrypt Authenticator pk=%s field %r with the current SECRET_KEY; skipping", pk, field)
+                    continue
+                config[field] = encrypt_with_key(clear, self.new_key)
+                changed = True
+                total += 1
+            if changed and not dry_run:
+                with connection.cursor() as ucur:
+                    ucur.execute(update_sql, [json.dumps(config), pk])
         return total
 
     @staticmethod
@@ -186,6 +191,23 @@ class Command(BaseCommand):
             type=qn(Authenticator._meta.get_field('type').column),
             config=qn(Authenticator._meta.get_field('configuration').column),
             table=qn(Authenticator._meta.db_table),
+        )
+
+    @staticmethod
+    def _build_authenticator_update_sql() -> str:
+        """Build UPDATE for authenticator config re-encryption.
+
+        The ``%s::jsonb`` cast ensures the text parameter is correctly
+        stored in the jsonb column regardless of the database adapter.
+
+        Safe from SQL injection: all identifiers originate from Django
+        model metadata and are quoted via the database backend.
+        """
+        qn = connection.ops.quote_name
+        return "UPDATE {table} SET {config} = %s::jsonb WHERE {pk} = %s".format(
+            table=qn(Authenticator._meta.db_table),
+            config=qn(Authenticator._meta.get_field('configuration').column),
+            pk=qn(Authenticator._meta.pk.column),
         )
 
     # ── Preference rows (encrypted=True) ─────────────────────────────────

--- a/aap_gateway_api/management/commands/rotate_secret_key.py
+++ b/aap_gateway_api/management/commands/rotate_secret_key.py
@@ -23,7 +23,6 @@ Usage::
 from __future__ import annotations
 
 import base64
-import json
 import logging
 import os
 from typing import Iterator
@@ -141,7 +140,6 @@ class Command(BaseCommand):
     def _rotate_authenticator_configs(self, dry_run: bool) -> int:
         total = 0
         select_sql = self._build_authenticator_select_sql()
-        update_sql = self._build_authenticator_update_sql()
 
         with connection.cursor() as cur:
             cur.execute(select_sql)
@@ -172,8 +170,7 @@ class Command(BaseCommand):
                         changed = True
                         total += 1
                     if changed and not dry_run:
-                        with connection.cursor() as ucur:
-                            ucur.execute(update_sql, [json.dumps(config), pk])
+                        Authenticator.objects.filter(pk=pk).update(configuration=config)
         return total
 
     @staticmethod
@@ -189,20 +186,6 @@ class Command(BaseCommand):
             type=qn(Authenticator._meta.get_field('type').column),
             config=qn(Authenticator._meta.get_field('configuration').column),
             table=qn(Authenticator._meta.db_table),
-        )
-
-    @staticmethod
-    def _build_authenticator_update_sql() -> str:
-        """Build UPDATE for authenticator config re-encryption.
-
-        Safe from SQL injection: all identifiers originate from Django
-        model metadata and are quoted via the database backend.
-        """
-        qn = connection.ops.quote_name
-        return "UPDATE {table} SET {config} = %s WHERE {pk} = %s".format(
-            table=qn(Authenticator._meta.db_table),
-            config=qn(Authenticator._meta.get_field('configuration').column),
-            pk=qn(Authenticator._meta.pk.column),
         )
 
     # ── Preference rows (encrypted=True) ─────────────────────────────────

--- a/aap_gateway_api/management/commands/rotate_secret_key.py
+++ b/aap_gateway_api/management/commands/rotate_secret_key.py
@@ -34,6 +34,7 @@ from ansible_base.lib.abstract_models.common import AbstractCommonModel
 from ansible_base.lib.utils.encryption import ENCRYPTED_STRING
 from django.apps import apps
 from django.conf import settings
+from django.core.exceptions import FieldDoesNotExist
 from django.core.management.base import BaseCommand, CommandError
 from django.db import connection, transaction
 
@@ -129,7 +130,7 @@ class Command(BaseCommand):
             for field_name in field_names:
                 try:
                     field_obj = model._meta.get_field(field_name)
-                except Exception:
+                except FieldDoesNotExist:
                     logger.warning("Model %s declares encrypted field %r but has no such DB column", model.__name__, field_name)
                     continue
                 total += self._reencrypt_column(model, field_obj.column, dry_run)
@@ -209,7 +210,8 @@ class Command(BaseCommand):
     def _rotate_preferences(self, dry_run: bool) -> int:
         from aap_gateway_api.models import Preference
 
-        select_sql = self._build_preference_select_sql(Preference)
+        first_page_sql = self._build_preference_select_sql(Preference, with_pk_bound=False)
+        next_page_sql = self._build_preference_select_sql(Preference, with_pk_bound=True)
         update_sql = self._build_preference_update_sql(Preference)
         count = 0
         last_pk = None
@@ -217,9 +219,9 @@ class Command(BaseCommand):
         while True:
             with connection.cursor() as cur:
                 if last_pk is None:
-                    cur.execute(select_sql.format(pk_clause=""))
+                    cur.execute(first_page_sql)
                 else:
-                    cur.execute(select_sql.format(pk_clause="AND {pk} > %s ".format(pk=connection.ops.quote_name(Preference._meta.pk.column))), [last_pk])
+                    cur.execute(next_page_sql, [last_pk])
                 rows = cur.fetchall()
             if not rows:
                 break
@@ -240,21 +242,28 @@ class Command(BaseCommand):
         return count
 
     @staticmethod
-    def _build_preference_select_sql(model) -> str:
+    def _build_preference_select_sql(model, *, with_pk_bound: bool) -> str:
         """Build paginated SELECT for preference scanning.
 
-        Returns a format string with a ``{pk_clause}`` placeholder that
-        is filled in at call time (empty for the first page, ``AND pk > %s``
-        for subsequent pages).
+        When *with_pk_bound* is ``True`` the query includes a
+        ``WHERE ... AND pk > %s`` predicate for keyset pagination.
+        The first page is fetched without this predicate so no
+        assumption about the PK type is needed.
 
         Safe from SQL injection: all identifiers originate from Django
         model metadata and are quoted via the database backend.
         """
         qn = connection.ops.quote_name
-        return ("SELECT {pk}, {val} FROM {table} WHERE {val} IS NOT NULL {{pk_clause}}ORDER BY {pk} LIMIT {limit}").format(
-            pk=qn(model._meta.pk.column),
-            val=qn('raw_value'),
-            table=qn(model._meta.db_table),
+        pk = qn(model._meta.pk.column)
+        val = qn('raw_value')
+        table = qn(model._meta.db_table)
+
+        pk_clause = "AND {pk} > %s ".format(pk=pk) if with_pk_bound else ""
+        return "SELECT {pk}, {val} FROM {table} WHERE {val} IS NOT NULL {pk_clause}ORDER BY {pk} LIMIT {limit}".format(
+            pk=pk,
+            val=val,
+            table=table,
+            pk_clause=pk_clause,
             limit=_FETCH_BATCH_SIZE,
         )
 

--- a/aap_gateway_api/management/commands/rotate_secret_key.py
+++ b/aap_gateway_api/management/commands/rotate_secret_key.py
@@ -32,6 +32,7 @@ from ansible_base.authentication.authenticator_plugins.utils import get_authenti
 from ansible_base.authentication.models import Authenticator
 from ansible_base.lib.abstract_models.common import AbstractCommonModel
 from ansible_base.lib.utils.encryption import ENCRYPTED_STRING
+from cryptography.fernet import InvalidToken
 from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import FieldDoesNotExist
@@ -105,6 +106,8 @@ class Command(BaseCommand):
         if self.new_key == self.old_key:
             raise CommandError("New encryption key is identical to the current SECRET_KEY; rotation aborted.")
 
+        self._skipped_count = 0
+
         total = 0
         total += self._rotate_encrypted_fields(dry_run)
         total += self._rotate_authenticator_configs(dry_run)
@@ -118,6 +121,15 @@ class Command(BaseCommand):
         else:
             self.stdout.write(f"{total} value(s) re-encrypted.")
             self.stdout.write("Preference cache flushed.")
+
+        if self._skipped_count > 0:
+            self.stderr.write(
+                self.style.WARNING(
+                    f"WARNING: {self._skipped_count} value(s) could not be decrypted "
+                    f"and were NOT re-encrypted. The old SECRET_KEY must be preserved "
+                    f"for these rows. See log for details."
+                )
+            )
 
         if not dry_run and not use_custom_key:
             self.stdout.write(self.new_key)
@@ -164,7 +176,10 @@ class Command(BaseCommand):
         if not config:
             return None
         if isinstance(config, str):
-            config = json.loads(config)
+            try:
+                config = json.loads(config)
+            except json.JSONDecodeError:
+                return None
         return config if isinstance(config, dict) else None
 
     def _reencrypt_authenticator_fields(self, pk, auth_type: str, config: dict) -> tuple[bool, int]:
@@ -176,7 +191,7 @@ class Command(BaseCommand):
         """
         try:
             plugin = get_authenticator_plugin(auth_type)
-        except ImportError:
+        except Exception:
             logger.warning("Cannot load plugin %r for Authenticator pk=%s; skipping", auth_type, pk)
             return False, 0
         encrypted_fields = getattr(plugin, 'configuration_encrypted_fields', [])
@@ -297,11 +312,18 @@ class Command(BaseCommand):
     # ── Shared helpers ──────────────────────────────────────────────────
 
     def _try_decrypt(self, value: str, *, label: str):
-        """Attempt to decrypt *value* with the old key, returning the cleartext or ``None``."""
+        """Attempt to decrypt *value* with the old key, returning the cleartext or ``None``.
+
+        Only catches ``InvalidToken`` (wrong key) and ``ValueError``
+        (malformed ciphertext format).  Any other exception is a
+        programming error and is allowed to propagate, rolling back the
+        ``@transaction.atomic`` block.
+        """
         try:
             return decrypt_with_key(value, self.old_key)
-        except Exception:
+        except (InvalidToken, ValueError):
             logger.warning("Cannot decrypt %s with the current SECRET_KEY; skipping", label)
+            self._skipped_count += 1
             return None
 
     def _paginated_reencrypt(self, first_page_sql: str, next_page_sql: str, update_sql: str, dry_run: bool, *, label: str) -> int:

--- a/aap_gateway_api/management/commands/rotate_secret_key.py
+++ b/aap_gateway_api/management/commands/rotate_secret_key.py
@@ -148,35 +148,51 @@ class Command(BaseCommand):
             rows = cur.fetchall()
 
         for pk, auth_type, config in rows:
-            if not config:
+            config = self._parse_config(config)
+            if config is None:
                 continue
-            if isinstance(config, str):
-                config = json.loads(config)
-            if not isinstance(config, dict):
-                continue
-            try:
-                plugin = get_authenticator_plugin(auth_type)
-            except ImportError:
-                logger.warning("Cannot load plugin %r for Authenticator pk=%s; skipping", auth_type, pk)
-                continue
-            encrypted_fields = getattr(plugin, 'configuration_encrypted_fields', [])
-            changed = False
-            for field in encrypted_fields:
-                val = config.get(field)
-                if not val or not isinstance(val, str) or ENCRYPTED_STRING not in val:
-                    continue
-                try:
-                    clear = decrypt_with_key(val, self.old_key)
-                except Exception:
-                    logger.warning("Cannot decrypt Authenticator pk=%s field %r with the current SECRET_KEY; skipping", pk, field)
-                    continue
-                config[field] = encrypt_with_key(clear, self.new_key)
-                changed = True
-                total += 1
+            changed, field_count = self._reencrypt_authenticator_fields(pk, auth_type, config)
+            total += field_count
             if changed and not dry_run:
                 with connection.cursor() as ucur:
                     ucur.execute(update_sql, [json.dumps(config), pk])
         return total
+
+    @staticmethod
+    def _parse_config(config) -> dict | None:
+        """Normalise a configuration value to a dict, or ``None`` if unusable."""
+        if not config:
+            return None
+        if isinstance(config, str):
+            config = json.loads(config)
+        return config if isinstance(config, dict) else None
+
+    def _reencrypt_authenticator_fields(self, pk, auth_type: str, config: dict) -> tuple[bool, int]:
+        """Re-encrypt encrypted sub-fields within a single authenticator's configuration.
+
+        Returns ``(changed, field_count)`` where *changed* is ``True``
+        if any field was modified and *field_count* is the number of
+        fields re-encrypted.
+        """
+        try:
+            plugin = get_authenticator_plugin(auth_type)
+        except ImportError:
+            logger.warning("Cannot load plugin %r for Authenticator pk=%s; skipping", auth_type, pk)
+            return False, 0
+        encrypted_fields = getattr(plugin, 'configuration_encrypted_fields', [])
+        changed = False
+        count = 0
+        for field in encrypted_fields:
+            val = config.get(field)
+            if not val or not isinstance(val, str) or ENCRYPTED_STRING not in val:
+                continue
+            clear = self._try_decrypt(val, label=f"Authenticator pk={pk} field {field!r}")
+            if clear is None:
+                continue
+            config[field] = encrypt_with_key(clear, self.new_key)
+            changed = True
+            count += 1
+        return changed, count
 
     @staticmethod
     def _build_authenticator_select_sql() -> str:
@@ -218,33 +234,7 @@ class Command(BaseCommand):
         first_page_sql = self._build_preference_select_sql(Preference, with_pk_bound=False)
         next_page_sql = self._build_preference_select_sql(Preference, with_pk_bound=True)
         update_sql = self._build_preference_update_sql(Preference)
-        count = 0
-        last_pk = None
-
-        while True:
-            with connection.cursor() as cur:
-                if last_pk is None:
-                    cur.execute(first_page_sql)
-                else:
-                    cur.execute(next_page_sql, [last_pk])
-                rows = cur.fetchall()
-            if not rows:
-                break
-            last_pk = rows[-1][0]
-            for pk, raw in rows:
-                if not raw or ENCRYPTED_STRING not in str(raw):
-                    continue
-                try:
-                    clear = decrypt_with_key(raw, self.old_key)
-                except Exception:
-                    logger.warning("Cannot decrypt Preference pk=%s with the current SECRET_KEY; skipping", pk)
-                    continue
-                new_val = encrypt_with_key(clear, self.new_key)
-                if not dry_run:
-                    with connection.cursor() as ucur:
-                        ucur.execute(update_sql, [new_val, pk])
-                count += 1
-        return count
+        return self._paginated_reencrypt(first_page_sql, next_page_sql, update_sql, dry_run, label="Preference")
 
     @staticmethod
     def _build_preference_select_sql(model, *, with_pk_bound: bool) -> str:
@@ -302,7 +292,61 @@ class Command(BaseCommand):
         except Exception:
             logger.warning("Could not clear preference cache; manual cache flush may be needed.", exc_info=True)
 
-    # ── Shared column re-encryption ──────────────────────────────────────
+    # ── Shared helpers ──────────────────────────────────────────────────
+
+    def _try_decrypt(self, value: str, *, label: str):
+        """Attempt to decrypt *value* with the old key, returning the cleartext or ``None``."""
+        try:
+            return decrypt_with_key(value, self.old_key)
+        except Exception:
+            logger.warning("Cannot decrypt %s with the current SECRET_KEY; skipping", label)
+            return None
+
+    def _paginated_reencrypt(
+        self, first_page_sql: str, next_page_sql: str, update_sql: str, dry_run: bool, *, label: str
+    ) -> int:
+        """Paginate through rows and re-encrypt values.
+
+        Used by both ``_reencrypt_column`` and ``_rotate_preferences``
+        to avoid duplicating the pagination and per-row re-encryption
+        logic.
+        """
+        count = 0
+        last_pk = None
+        while True:
+            with connection.cursor() as cur:
+                if last_pk is None:
+                    cur.execute(first_page_sql)
+                else:
+                    cur.execute(next_page_sql, [last_pk])
+                rows = cur.fetchall()
+            if not rows:
+                break
+            last_pk = rows[-1][0]
+            for pk, raw in rows:
+                new_val = self._reencrypt_value(raw, label=f"{label} pk={pk}")
+                if new_val is None:
+                    continue
+                if not dry_run:
+                    with connection.cursor() as ucur:
+                        ucur.execute(update_sql, [new_val, pk])
+                count += 1
+        return count
+
+    def _reencrypt_value(self, raw, *, label: str) -> str | None:
+        """Decrypt a single value with the old key and re-encrypt with the new key.
+
+        Returns the new ciphertext, or ``None`` if the value is not
+        encrypted or cannot be decrypted.
+        """
+        if not raw or ENCRYPTED_STRING not in str(raw):
+            return None
+        clear = self._try_decrypt(raw, label=label)
+        if clear is None:
+            return None
+        return encrypt_with_key(clear, self.new_key)
+
+    # ── SQL builders ─────────────────────────────────────────────────────
 
     @staticmethod
     def _build_column_select_sql(model, column_name, *, with_pk_bound: bool) -> str:
@@ -348,29 +392,5 @@ class Command(BaseCommand):
         first_page_sql = self._build_column_select_sql(model, column_name, with_pk_bound=False)
         next_page_sql = self._build_column_select_sql(model, column_name, with_pk_bound=True)
         update_sql = self._build_column_update_sql(model, column_name)
-        count = 0
-        last_pk = None
-        while True:
-            with connection.cursor() as cur:
-                if last_pk is None:
-                    cur.execute(first_page_sql)
-                else:
-                    cur.execute(next_page_sql, [last_pk])
-                rows = cur.fetchall()
-            if not rows:
-                break
-            last_pk = rows[-1][0]
-            for pk, raw in rows:
-                if not raw or ENCRYPTED_STRING not in str(raw):
-                    continue
-                try:
-                    clear = decrypt_with_key(raw, self.old_key)
-                except Exception:
-                    logger.warning("Cannot decrypt %s.%s pk=%s with the current SECRET_KEY; skipping", model.__name__, column_name, pk)
-                    continue
-                new_val = encrypt_with_key(clear, self.new_key)
-                if not dry_run:
-                    with connection.cursor() as ucur:
-                        ucur.execute(update_sql, [new_val, pk])
-                count += 1
-        return count
+        label = f"{model.__name__}.{column_name}"
+        return self._paginated_reencrypt(first_page_sql, next_page_sql, update_sql, dry_run, label=label)

--- a/aap_gateway_api/tests/management/test_rotate_secret_key.py
+++ b/aap_gateway_api/tests/management/test_rotate_secret_key.py
@@ -1,5 +1,6 @@
 import io
 import os
+import re
 from unittest.mock import patch
 
 import pytest
@@ -137,6 +138,84 @@ def test_preference_rotation(settings):
     assert decrypt_with_key(new_cipher, new_key) == "my-secret-pref-value"
 
 
+@pytest.mark.django_db(transaction=True)
+def test_authenticator_config_rotation(settings):
+    """Authenticator.configuration encrypted sub-fields are re-encrypted."""
+    from ansible_base.authentication.models import Authenticator
+
+    old_key = settings.SECRET_KEY
+    new_key = "new-auth-config-key"
+
+    secret_val = encrypt_with_key("my-oidc-secret", old_key)
+    authenticator = Authenticator.objects.create(
+        name="Test OIDC Rotator",
+        enabled=True,
+        create_objects=True,
+        type="ansible_base.authentication.authenticator_plugins.oidc",
+        configuration={
+            "ACCESS_TOKEN_URL": "https://idp.example.com/token",
+            "AUTHORIZATION_URL": "https://idp.example.com/auth",
+            "KEY": "my-client-id",
+            "SECRET": secret_val,
+        },
+    )
+
+    out = io.StringIO()
+    with patch.dict(os.environ, {"GATEWAY_SECRET_KEY": new_key}):
+        call_command("rotate_secret_key", use_custom_key=True, stdout=out)
+
+    assert "re-encrypted" in out.getvalue()
+
+    authenticator.refresh_from_db()
+    new_secret = authenticator.configuration.get("SECRET", "")
+    assert ENCRYPTED_STRING in new_secret
+    assert new_secret != secret_val
+    assert decrypt_with_key(new_secret, new_key) == "my-oidc-secret"
+    assert authenticator.configuration["KEY"] == "my-client-id"
+
+
+# ── Graceful skip on decryption failure ──────────────────────────────────
+
+
+@pytest.mark.django_db(transaction=True)
+def test_undecryptable_row_is_skipped(settings):
+    """Rows encrypted with a different key are skipped without aborting."""
+    from aap_gateway_api.models import Preference
+
+    old_key = settings.SECRET_KEY
+    new_key = "new-skip-test-key"
+    wrong_key = "completely-different-key"
+
+    good_cipher = encrypt_with_key("good-value", old_key)
+    bad_cipher = encrypt_with_key("bad-value", wrong_key)
+
+    Preference.objects.update_or_create(section="test_skip", name="good_pref", defaults={"raw_value": good_cipher})
+    Preference.objects.update_or_create(section="test_skip", name="bad_pref", defaults={"raw_value": bad_cipher})
+
+    out = io.StringIO()
+    with patch.dict(os.environ, {"GATEWAY_SECRET_KEY": new_key}):
+        call_command("rotate_secret_key", use_custom_key=True, stdout=out)
+
+    assert "re-encrypted" in out.getvalue()
+
+    with connection.cursor() as cur:
+        cur.execute(
+            "SELECT raw_value FROM aap_gateway_api_preference WHERE section = %s AND name = %s",
+            ["test_skip", "bad_pref"],
+        )
+        bad_after = cur.fetchone()[0]
+    assert bad_after == bad_cipher
+
+    with connection.cursor() as cur:
+        cur.execute(
+            "SELECT raw_value FROM aap_gateway_api_preference WHERE section = %s AND name = %s",
+            ["test_skip", "good_pref"],
+        )
+        good_after = cur.fetchone()[0]
+    assert good_after != good_cipher
+    assert decrypt_with_key(good_after, new_key) == "good-value"
+
+
 # ── Auto-generated key ──────────────────────────────────────────────────
 
 
@@ -151,7 +230,9 @@ def test_auto_generated_key_printed_once(settings):
     output = out.getvalue()
     lines = [ln for ln in output.splitlines() if ln.strip()]
     assert any("re-encrypted" in ln for ln in lines)
-    key_line = lines[-1]
+    key_candidates = [ln for ln in lines if not re.search(r"re-encrypted|cache", ln, re.IGNORECASE)]
+    assert len(key_candidates) == 1, f"Expected exactly one key line, got: {key_candidates}"
+    key_line = key_candidates[0]
     assert len(key_line) > 10
     assert output.count(key_line) == 1
 
@@ -159,13 +240,21 @@ def test_auto_generated_key_printed_once(settings):
 # ── Cache flush ──────────────────────────────────────────────────────────
 
 
-@pytest.mark.django_db
-def test_cache_flush_message(settings):
-    """The command reports cache flushing in both dry-run and normal modes."""
-    settings.SECRET_KEY = "test-cache-flush-key"
+@pytest.mark.django_db(transaction=True)
+def test_cache_flush_message_dry_run(settings):
+    """--dry-run reports that the preference cache would be flushed."""
     out = io.StringIO()
-    with patch.dict(os.environ, {"GATEWAY_SECRET_KEY": "new-key-cache"}):
+    with patch.dict(os.environ, {"GATEWAY_SECRET_KEY": "new-key-cache-dry"}):
         call_command("rotate_secret_key", use_custom_key=True, dry_run=True, stdout=out)
+    assert "cache" in out.getvalue().lower()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_cache_flush_message_normal(settings):
+    """Normal mode reports that the preference cache was flushed."""
+    out = io.StringIO()
+    with patch.dict(os.environ, {"GATEWAY_SECRET_KEY": "new-key-cache-normal"}):
+        call_command("rotate_secret_key", use_custom_key=True, stdout=out)
     assert "cache" in out.getvalue().lower()
 
 
@@ -173,24 +262,35 @@ def test_cache_flush_message(settings):
 
 
 class TestEncryptionHelpers:
+    """Unit tests for the gateway-local encryption helpers."""
+
     def test_round_trip(self):
+        """Encrypt then decrypt returns the original value."""
         key = "my-custom-key-material"
         encrypted = encrypt_with_key("hello-world", key)
         assert ENCRYPTED_STRING in encrypted
         assert decrypt_with_key(encrypted, key) == "hello-world"
 
     def test_different_keys_produce_different_ciphertext(self):
+        """Same plaintext encrypted with different keys yields different ciphertext."""
         val = "same-value"
         enc1 = encrypt_with_key(val, "key-one")
         enc2 = encrypt_with_key(val, "key-two")
         assert enc1 != enc2
 
     def test_wrong_key_fails(self):
+        """Decryption with the wrong key raises InvalidToken."""
         encrypted = encrypt_with_key("secret", "correct-key")
         with pytest.raises(InvalidToken):
             decrypt_with_key(encrypted, "wrong-key")
 
+    def test_decrypt_rejects_non_encrypted_input(self):
+        """decrypt_with_key raises ValueError for input without the encrypted marker."""
+        with pytest.raises(ValueError, match="does not start with"):
+            decrypt_with_key("plain-text-value", "any-key")
+
     def test_json_types_preserved(self):
+        """JSON-serialisable types survive an encrypt/decrypt round trip."""
         key = "test-json-key"
         for val in ["string", 42, True, None, {"nested": "dict"}, [1, 2, 3]]:
             encrypted = encrypt_with_key(val, key)

--- a/aap_gateway_api/tests/management/test_rotate_secret_key.py
+++ b/aap_gateway_api/tests/management/test_rotate_secret_key.py
@@ -287,6 +287,57 @@ def test_cache_flush_message_normal(settings):
     assert "cache" in out.getvalue().lower()
 
 
+# ── Defensive path coverage ──────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_parse_config_malformed_json():
+    """_parse_config returns None for malformed JSON strings."""
+    from aap_gateway_api.management.commands.rotate_secret_key import Command
+
+    assert Command._parse_config("not-valid-json{") is None
+    assert Command._parse_config("") is None
+    assert Command._parse_config(None) is None
+    assert Command._parse_config(42) is None
+    assert Command._parse_config({"key": "val"}) == {"key": "val"}
+    assert Command._parse_config('{"key": "val"}') == {"key": "val"}
+
+
+@pytest.mark.django_db
+def test_rotate_encrypted_fields_skips_missing_field(settings, caplog):
+    """Fields listed in encrypted_fields but missing from the model are skipped."""
+    from aap_gateway_api.management.commands.rotate_secret_key import Command
+    from aap_gateway_api.models import ServiceCluster
+
+    cmd = Command()
+    cmd.old_key = settings.SECRET_KEY
+    cmd.new_key = "test-field-not-exist-key"
+    cmd._skipped_count = 0
+
+    with patch(
+        "aap_gateway_api.management.commands.rotate_secret_key._iter_models_with_encrypted_fields",
+        return_value=[(ServiceCluster, ["nonexistent_field_xyz"])],
+    ):
+        total = cmd._rotate_encrypted_fields(dry_run=False)
+
+    assert total == 0
+    assert "nonexistent_field_xyz" in caplog.text
+
+
+@pytest.mark.django_db(transaction=True)
+def test_flush_preference_cache_failure_is_graceful(settings, caplog):
+    """_flush_preference_cache logs a warning instead of crashing when the cache is unavailable."""
+    from aap_gateway_api.management.commands.rotate_secret_key import Command
+
+    cmd = Command()
+
+    with patch("aap_gateway_api.preferences.gateway_preference_registry") as mock_registry:
+        mock_registry.manager.side_effect = RuntimeError("cache unavailable")
+        cmd._flush_preference_cache(dry_run=False)
+
+    assert "Could not clear preference cache" in caplog.text
+
+
 # ── Encryption helper unit tests ─────────────────────────────────────────
 
 

--- a/aap_gateway_api/tests/management/test_rotate_secret_key.py
+++ b/aap_gateway_api/tests/management/test_rotate_secret_key.py
@@ -217,10 +217,15 @@ def test_undecryptable_row_is_skipped(settings):
         )
 
     out = io.StringIO()
+    err = io.StringIO()
     with patch.dict(os.environ, {"GATEWAY_SECRET_KEY": new_key}):
-        call_command("rotate_secret_key", use_custom_key=True, stdout=out)
+        call_command("rotate_secret_key", use_custom_key=True, stdout=out, stderr=err)
 
     assert "re-encrypted" in out.getvalue()
+
+    warning = err.getvalue()
+    assert "could not be decrypted" in warning
+    assert "old SECRET_KEY must be preserved" in warning
 
     with connection.cursor() as cur:
         cur.execute(

--- a/aap_gateway_api/tests/management/test_rotate_secret_key.py
+++ b/aap_gateway_api/tests/management/test_rotate_secret_key.py
@@ -1,0 +1,215 @@
+import io
+import os
+from unittest.mock import patch
+
+import pytest
+from ansible_base.lib.utils.encryption import ENCRYPTED_STRING
+from cryptography.fernet import InvalidToken
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.db import connection
+
+from aap_gateway_api.utils.encryption import decrypt_with_key, encrypt_with_key
+
+# ── Argument validation ─────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_use_custom_key_requires_env_var():
+    """CommandError when --use-custom-key is set without GATEWAY_SECRET_KEY."""
+    with patch.dict(os.environ, {}, clear=True):
+        os.environ.pop("GATEWAY_SECRET_KEY", None)
+        with pytest.raises(CommandError, match="GATEWAY_SECRET_KEY"):
+            call_command("rotate_secret_key", use_custom_key=True)
+
+
+@pytest.mark.django_db
+def test_same_key_aborts(settings):
+    """CommandError when the new key equals the current SECRET_KEY."""
+    settings.SECRET_KEY = "identical-key"
+    with patch.dict(os.environ, {"GATEWAY_SECRET_KEY": "identical-key"}):
+        with pytest.raises(CommandError, match="identical"):
+            call_command("rotate_secret_key", use_custom_key=True)
+
+
+# ── Dry-run behaviour ───────────────────────────────────────────────────
+
+
+@pytest.mark.django_db(transaction=True)
+def test_dry_run_reports_without_writing(settings):
+    """--dry-run reports affected rows but leaves ciphertext unchanged."""
+    from aap_gateway_api.models import ServiceCluster, ServiceType
+
+    st, _ = ServiceType.objects.get_or_create(name="controller")
+    cluster = ServiceCluster.objects.create(name="dry-run-cluster", service_type=st)
+    sk = cluster.generate_key(name="dry-run-key")
+
+    with connection.cursor() as cur:
+        cur.execute("SELECT secret FROM aap_gateway_api_servicekey WHERE id = %s", [sk.pk])
+        old_cipher = cur.fetchone()[0]
+
+    out = io.StringIO()
+    with patch.dict(os.environ, {"GATEWAY_SECRET_KEY": "new-secret-for-dry-run"}):
+        call_command("rotate_secret_key", use_custom_key=True, dry_run=True, stdout=out)
+
+    assert "would be re-encrypted" in out.getvalue()
+
+    with connection.cursor() as cur:
+        cur.execute("SELECT secret FROM aap_gateway_api_servicekey WHERE id = %s", [sk.pk])
+        after_cipher = cur.fetchone()[0]
+    assert after_cipher == old_cipher
+
+
+@pytest.mark.django_db
+def test_dry_run_does_not_print_generated_key(settings):
+    """--dry-run must not emit a generated key to avoid operator confusion."""
+    settings.SECRET_KEY = "test-secret-dry-run-no-key"
+    out = io.StringIO()
+    call_command("rotate_secret_key", dry_run=True, stdout=out)
+
+    lines = [ln for ln in out.getvalue().splitlines() if ln.strip()]
+    for line in lines:
+        assert "would be" in line or "cache" in line.lower()
+
+
+# ── Full rotation ────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db(transaction=True)
+def test_service_key_rotation(settings):
+    """ServiceKey.secret is re-encrypted with the new key."""
+    new_key = "new-gw-rotation-key"
+
+    from aap_gateway_api.models import ServiceCluster, ServiceType
+
+    st, _ = ServiceType.objects.get_or_create(name="controller")
+    cluster = ServiceCluster.objects.create(name="test-rotate-cluster", service_type=st)
+    sk = cluster.generate_key(name="test-rotate-key")
+    original_secret = sk.secret
+
+    with connection.cursor() as cur:
+        cur.execute("SELECT secret FROM aap_gateway_api_servicekey WHERE id = %s", [sk.pk])
+        old_cipher = cur.fetchone()[0]
+
+    assert ENCRYPTED_STRING in old_cipher
+
+    out = io.StringIO()
+    with patch.dict(os.environ, {"GATEWAY_SECRET_KEY": new_key}):
+        call_command("rotate_secret_key", use_custom_key=True, stdout=out)
+
+    with connection.cursor() as cur:
+        cur.execute("SELECT secret FROM aap_gateway_api_servicekey WHERE id = %s", [sk.pk])
+        new_cipher = cur.fetchone()[0]
+
+    assert new_cipher != old_cipher
+    assert decrypt_with_key(new_cipher, new_key) == original_secret
+
+
+@pytest.mark.django_db(transaction=True)
+def test_preference_rotation(settings):
+    """Encrypted preference values are re-encrypted with the new key."""
+    old_key = settings.SECRET_KEY
+    new_key = "new-pref-rotation-key"
+
+    from aap_gateway_api.models import Preference
+
+    encrypted_val = encrypt_with_key("my-secret-pref-value", old_key)
+    Preference.objects.update_or_create(
+        section="analytics",
+        name="REDHAT_PASSWORD",
+        defaults={"raw_value": encrypted_val},
+    )
+
+    out = io.StringIO()
+    with patch.dict(os.environ, {"GATEWAY_SECRET_KEY": new_key}):
+        call_command("rotate_secret_key", use_custom_key=True, stdout=out)
+
+    assert "re-encrypted" in out.getvalue()
+
+    with connection.cursor() as cur:
+        cur.execute(
+            "SELECT raw_value FROM aap_gateway_api_preference WHERE section = %s AND name = %s",
+            ["analytics", "REDHAT_PASSWORD"],
+        )
+        new_cipher = cur.fetchone()[0]
+
+    assert new_cipher != encrypted_val
+    assert decrypt_with_key(new_cipher, new_key) == "my-secret-pref-value"
+
+
+# ── Auto-generated key ──────────────────────────────────────────────────
+
+
+@pytest.mark.django_db(transaction=True)
+def test_auto_generated_key_printed_once(settings):
+    """When no custom key is provided, a generated key is printed exactly once."""
+    settings.SECRET_KEY = "old-key-auto-gen"
+
+    out = io.StringIO()
+    call_command("rotate_secret_key", stdout=out)
+
+    output = out.getvalue()
+    lines = [ln for ln in output.splitlines() if ln.strip()]
+    assert any("re-encrypted" in ln for ln in lines)
+    key_line = lines[-1]
+    assert len(key_line) > 10
+    assert output.count(key_line) == 1
+
+
+# ── Cache flush ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_cache_flush_message(settings):
+    """The command reports cache flushing in both dry-run and normal modes."""
+    settings.SECRET_KEY = "test-cache-flush-key"
+    out = io.StringIO()
+    with patch.dict(os.environ, {"GATEWAY_SECRET_KEY": "new-key-cache"}):
+        call_command("rotate_secret_key", use_custom_key=True, dry_run=True, stdout=out)
+    assert "cache" in out.getvalue().lower()
+
+
+# ── Encryption helper unit tests ─────────────────────────────────────────
+
+
+class TestEncryptionHelpers:
+    def test_round_trip(self):
+        key = "my-custom-key-material"
+        encrypted = encrypt_with_key("hello-world", key)
+        assert ENCRYPTED_STRING in encrypted
+        assert decrypt_with_key(encrypted, key) == "hello-world"
+
+    def test_different_keys_produce_different_ciphertext(self):
+        val = "same-value"
+        enc1 = encrypt_with_key(val, "key-one")
+        enc2 = encrypt_with_key(val, "key-two")
+        assert enc1 != enc2
+
+    def test_wrong_key_fails(self):
+        encrypted = encrypt_with_key("secret", "correct-key")
+        with pytest.raises(InvalidToken):
+            decrypt_with_key(encrypted, "wrong-key")
+
+    def test_json_types_preserved(self):
+        key = "test-json-key"
+        for val in ["string", 42, True, None, {"nested": "dict"}, [1, 2, 3]]:
+            encrypted = encrypt_with_key(val, key)
+            assert decrypt_with_key(encrypted, key) == val
+
+    def test_rewrap_with_new_key(self):
+        """Decrypt with old key, re-encrypt with new key, verify both directions."""
+        old_k = "old-key-material"
+        new_k = "new-key-material"
+        value = "credential-payload"
+
+        ciphertext = encrypt_with_key(value, old_k)
+        assert decrypt_with_key(ciphertext, old_k) == value
+
+        with pytest.raises(InvalidToken):
+            decrypt_with_key(ciphertext, new_k)
+
+        rewrapped = encrypt_with_key(decrypt_with_key(ciphertext, old_k), new_k)
+        assert decrypt_with_key(rewrapped, new_k) == value
+
+        with pytest.raises(InvalidToken):
+            decrypt_with_key(rewrapped, old_k)

--- a/aap_gateway_api/tests/management/test_rotate_secret_key.py
+++ b/aap_gateway_api/tests/management/test_rotate_secret_key.py
@@ -1,4 +1,5 @@
 import io
+import logging
 import os
 import re
 from unittest.mock import patch
@@ -314,11 +315,12 @@ def test_rotate_encrypted_fields_skips_missing_field(settings, caplog):
     cmd.new_key = "test-field-not-exist-key"
     cmd._skipped_count = 0
 
-    with patch(
-        "aap_gateway_api.management.commands.rotate_secret_key._iter_models_with_encrypted_fields",
-        return_value=[(ServiceCluster, ["nonexistent_field_xyz"])],
-    ):
-        total = cmd._rotate_encrypted_fields(dry_run=False)
+    with caplog.at_level(logging.WARNING, logger="aap.gateway.management.rotate_secret_key"):
+        with patch(
+            "aap_gateway_api.management.commands.rotate_secret_key._iter_models_with_encrypted_fields",
+            return_value=[(ServiceCluster, ["nonexistent_field_xyz"])],
+        ):
+            total = cmd._rotate_encrypted_fields(dry_run=False)
 
     assert total == 0
     assert "nonexistent_field_xyz" in caplog.text
@@ -331,9 +333,10 @@ def test_flush_preference_cache_failure_is_graceful(settings, caplog):
 
     cmd = Command()
 
-    with patch("aap_gateway_api.preferences.gateway_preference_registry") as mock_registry:
-        mock_registry.manager.side_effect = RuntimeError("cache unavailable")
-        cmd._flush_preference_cache(dry_run=False)
+    with caplog.at_level(logging.WARNING, logger="aap.gateway.management.rotate_secret_key"):
+        with patch("aap_gateway_api.preferences.gateway_preference_registry") as mock_registry:
+            mock_registry.manager.side_effect = RuntimeError("cache unavailable")
+            cmd._flush_preference_cache(dry_run=False)
 
     assert "Could not clear preference cache" in caplog.text
 

--- a/aap_gateway_api/tests/management/test_rotate_secret_key.py
+++ b/aap_gateway_api/tests/management/test_rotate_secret_key.py
@@ -141,6 +141,8 @@ def test_preference_rotation(settings):
 @pytest.mark.django_db(transaction=True)
 def test_authenticator_config_rotation(settings):
     """Authenticator.configuration encrypted sub-fields are re-encrypted."""
+    import json
+
     from ansible_base.authentication.models import Authenticator
 
     old_key = settings.SECRET_KEY
@@ -166,12 +168,24 @@ def test_authenticator_config_rotation(settings):
 
     assert "re-encrypted" in out.getvalue()
 
-    authenticator.refresh_from_db()
-    new_secret = authenticator.configuration.get("SECRET", "")
+    qn = connection.ops.quote_name
+    with connection.cursor() as cur:
+        cur.execute(
+            "SELECT {config} FROM {table} WHERE {pk} = %s".format(
+                config=qn("configuration"),
+                table=qn(Authenticator._meta.db_table),
+                pk=qn(Authenticator._meta.pk.column),
+            ),
+            [authenticator.pk],
+        )
+        raw_config = cur.fetchone()[0]
+
+    config = json.loads(raw_config) if isinstance(raw_config, str) else raw_config
+    new_secret = config["SECRET"]
     assert ENCRYPTED_STRING in new_secret
     assert new_secret != secret_val
     assert decrypt_with_key(new_secret, new_key) == "my-oidc-secret"
-    assert authenticator.configuration["KEY"] == "my-client-id"
+    assert config["KEY"] == "my-client-id"
 
 
 # ── Graceful skip on decryption failure ──────────────────────────────────
@@ -180,8 +194,6 @@ def test_authenticator_config_rotation(settings):
 @pytest.mark.django_db(transaction=True)
 def test_undecryptable_row_is_skipped(settings):
     """Rows encrypted with a different key are skipped without aborting."""
-    from aap_gateway_api.models import Preference
-
     old_key = settings.SECRET_KEY
     new_key = "new-skip-test-key"
     wrong_key = "completely-different-key"
@@ -189,8 +201,17 @@ def test_undecryptable_row_is_skipped(settings):
     good_cipher = encrypt_with_key("good-value", old_key)
     bad_cipher = encrypt_with_key("bad-value", wrong_key)
 
-    Preference.objects.update_or_create(section="test_skip", name="good_pref", defaults={"raw_value": good_cipher})
-    Preference.objects.update_or_create(section="test_skip", name="bad_pref", defaults={"raw_value": bad_cipher})
+    with connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO aap_gateway_api_preference (section, name, raw_value) VALUES (%s, %s, %s)"
+            " ON CONFLICT (section, name) DO UPDATE SET raw_value = EXCLUDED.raw_value",
+            ["test_skip", "good_pref", good_cipher],
+        )
+        cur.execute(
+            "INSERT INTO aap_gateway_api_preference (section, name, raw_value) VALUES (%s, %s, %s)"
+            " ON CONFLICT (section, name) DO UPDATE SET raw_value = EXCLUDED.raw_value",
+            ["test_skip", "bad_pref", bad_cipher],
+        )
 
     out = io.StringIO()
     with patch.dict(os.environ, {"GATEWAY_SECRET_KEY": new_key}):

--- a/aap_gateway_api/tests/management/test_rotate_secret_key.py
+++ b/aap_gateway_api/tests/management/test_rotate_secret_key.py
@@ -145,10 +145,8 @@ def test_authenticator_config_rotation(settings):
 
     from ansible_base.authentication.models import Authenticator
 
-    old_key = settings.SECRET_KEY
     new_key = "new-auth-config-key"
 
-    secret_val = encrypt_with_key("my-oidc-secret", old_key)
     authenticator = Authenticator.objects.create(
         name="Test OIDC Rotator",
         enabled=True,
@@ -158,9 +156,23 @@ def test_authenticator_config_rotation(settings):
             "ACCESS_TOKEN_URL": "https://idp.example.com/token",
             "AUTHORIZATION_URL": "https://idp.example.com/auth",
             "KEY": "my-client-id",
-            "SECRET": secret_val,
+            "SECRET": "my-oidc-secret",
         },
     )
+
+    qn = connection.ops.quote_name
+    config_sql = "SELECT {config} FROM {table} WHERE {pk} = %s".format(
+        config=qn("configuration"),
+        table=qn(Authenticator._meta.db_table),
+        pk=qn(Authenticator._meta.pk.column),
+    )
+
+    with connection.cursor() as cur:
+        cur.execute(config_sql, [authenticator.pk])
+        raw_before = cur.fetchone()[0]
+    before = json.loads(raw_before) if isinstance(raw_before, str) else raw_before
+    old_secret = before["SECRET"]
+    assert ENCRYPTED_STRING in old_secret
 
     out = io.StringIO()
     with patch.dict(os.environ, {"GATEWAY_SECRET_KEY": new_key}):
@@ -168,24 +180,15 @@ def test_authenticator_config_rotation(settings):
 
     assert "re-encrypted" in out.getvalue()
 
-    qn = connection.ops.quote_name
     with connection.cursor() as cur:
-        cur.execute(
-            "SELECT {config} FROM {table} WHERE {pk} = %s".format(
-                config=qn("configuration"),
-                table=qn(Authenticator._meta.db_table),
-                pk=qn(Authenticator._meta.pk.column),
-            ),
-            [authenticator.pk],
-        )
-        raw_config = cur.fetchone()[0]
-
-    config = json.loads(raw_config) if isinstance(raw_config, str) else raw_config
-    new_secret = config["SECRET"]
+        cur.execute(config_sql, [authenticator.pk])
+        raw_after = cur.fetchone()[0]
+    after = json.loads(raw_after) if isinstance(raw_after, str) else raw_after
+    new_secret = after["SECRET"]
     assert ENCRYPTED_STRING in new_secret
-    assert new_secret != secret_val
+    assert new_secret != old_secret
     assert decrypt_with_key(new_secret, new_key) == "my-oidc-secret"
-    assert config["KEY"] == "my-client-id"
+    assert after["KEY"] == "my-client-id"
 
 
 # ── Graceful skip on decryption failure ──────────────────────────────────

--- a/aap_gateway_api/utils/encryption.py
+++ b/aap_gateway_api/utils/encryption.py
@@ -48,6 +48,8 @@ def encrypt_with_key(value: Any, key_material: str) -> str:
 
 def decrypt_with_key(value: str, key_material: str) -> Any:
     """Decrypt DAB-format ciphertext using *key_material*."""
+    if not value.startswith(ENCRYPTED_MARKER):
+        raise ValueError(f'Value does not start with {ENCRYPTED_MARKER!r}')
     raw = value[len(ENCRYPTED_MARKER) :]
     if raw.startswith('UTF8$'):
         raw = raw[len('UTF8$') :]

--- a/aap_gateway_api/utils/encryption.py
+++ b/aap_gateway_api/utils/encryption.py
@@ -1,0 +1,60 @@
+"""Encryption helpers that accept explicit key material.
+
+These mirror the behaviour of ``ansible_base.lib.utils.encryption.Fernet256``
+but allow the caller to supply a specific key rather than always reading
+``settings.SECRET_KEY``.  This is needed for secret-key rotation where
+we must decrypt with the old key and re-encrypt with the new key in the
+same process.
+
+The ciphertext format is fully compatible with DAB's format
+(``$encrypted$UTF8$AESCBC$<base64>``).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from typing import Any
+
+from cryptography.fernet import Fernet
+from cryptography.hazmat.backends import default_backend
+from django.utils.encoding import smart_bytes, smart_str
+
+ENCRYPTED_MARKER = '$encrypted$'
+ENCRYPTION_METHOD = 'AESCBC'
+
+
+class _Fernet256(Fernet):
+    """AES-256-CBC Fernet variant keyed from explicit material."""
+
+    def __init__(self, key_material: str):
+        h = hashlib.sha512()
+        h.update(smart_bytes(key_material))
+        key = h.digest()
+        self._signing_key = key[:32]
+        self._encryption_key = key[32:]
+        self._backend = default_backend()
+
+
+def encrypt_with_key(value: Any, key_material: str) -> str:
+    """Encrypt *value* using *key_material*, producing DAB-compatible ciphertext."""
+    f = _Fernet256(key_material)
+    payload = json.dumps(value)
+    encrypted = f.encrypt(smart_bytes(payload))
+    b64data = smart_str(base64.b64encode(encrypted))
+    return f'{ENCRYPTED_MARKER}UTF8${ENCRYPTION_METHOD}${b64data}'
+
+
+def decrypt_with_key(value: str, key_material: str) -> Any:
+    """Decrypt DAB-format ciphertext using *key_material*."""
+    raw = value[len(ENCRYPTED_MARKER) :]
+    if raw.startswith('UTF8$'):
+        raw = raw[len('UTF8$') :]
+    algo, b64data = raw.split('$', 1)
+    if algo != ENCRYPTION_METHOD:
+        raise ValueError(f'Unsupported algorithm: {algo}')
+    encrypted = base64.b64decode(b64data)
+    f = _Fernet256(key_material)
+    decrypted = smart_str(f.decrypt(encrypted))
+    return json.loads(decrypted)


### PR DESCRIPTION
## Description

- Adds a `rotate_secret_key` management command that re-encrypts all gateway database secrets after changing SECRET_KEY.
- Brings Gateway to feature parity with Controller (`awx-manage regenerate_secret_key`) and EDA Server (`aap-eda-manage rotate_db_encryption_key`).
- Includes self-contained encryption helpers (`aap_gateway_api/utils/encryption.py`) that are compatible with DAB's ciphertext format but accept explicit key material, avoiding any upstream DAB changes.

Closes #51

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Test update

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites
- PostgreSQL running (via podman or tox-docker)
- Python 3.12 venv with jewel dependencies installed

### Steps to Test
1. Install deps: `pip install -r requirements/requirements.txt -r requirements/requirements_git.txt -r requirements/requirements_test.txt && pip install -e . --no-deps`
2. Run the new tests: `pytest aap_gateway_api/tests/management/test_rotate_secret_key.py -v`
3. All 13 tests should pass (argument validation, dry-run, full rotation of ServiceKey and Preference, auto-generated key output, cache flush, encryption helper unit tests)

### Expected Results
- All 13 tests pass
- `gateway-manage rotate_secret_key` re-encrypts ServiceKey secrets, Authenticator config sub-fields, and encrypted Preferences
- `--dry-run` reports affected rows without writing
- Rows that cannot be decrypted with the current key are logged and skipped

## Additional Context

### Covered data types
- `AbstractCommonModel.encrypted_fields` columns (e.g. `ServiceKey.secret`)
- `Authenticator.configuration` sub-fields marked encrypted by each authenticator plugin
- `Preference` rows stored with `encrypted=True`
- Preference cache (flushed after rotation)

### Design decisions
- **Self-contained crypto helpers**: `aap_gateway_api/utils/encryption.py` mirrors DAB's `Fernet256` but accepts explicit `key_material`, so no upstream DAB changes are needed.
- **PK-window pagination**: Memory-bounded batching that works with any PK type (integer, UUID).
- **SQL identifier quoting**: All raw SQL uses `connection.ops.quote_name()` for database backend safety.
- **Atomic transaction**: The entire re-encryption runs in a single `@transaction.atomic` block.
- **Graceful skip on decryption failure**: Rows encrypted with a different key are logged and skipped rather than aborting the entire rotation.

### Required Actions
- [ ] Requires documentation updates

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New management command to rotate and re-encrypt stored secrets with dry-run, custom-key validation, reporting, and preference-cache flush behavior; supports phased rotation across service keys, authenticator configurations, and preferences.

* **Utilities**
  * Explicit-key encryption/decryption helpers with deterministic key derivation, interoperable ciphertext format, and validation.

* **Tests**
  * Comprehensive tests for rotation flows, dry-run semantics, argument validation, cache messages, graceful skip behavior, and encryption helper correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->