### PR TITLE
[AAP-75137] fix(ci): support self-hosted Codecov via CODECOV_URL variable

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Upload to Codecov
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
+          url: ${{ vars.CODECOV_URL }}
           files: ${{ steps.coverage.outputs.file_list }}
           flags: unit-tests
           fail_ci_if_error: true


### PR DESCRIPTION
## Summary

- Adds `url: ${{ vars.CODECOV_URL }}` to the `codecov-action` upload step so the same workflow supports both public and self-hosted Codecov instances.
- When `CODECOV_URL` is **unset**: the action defaults to public Codecov — no change in behavior.
- When `CODECOV_URL` is **set**: uploads are directed to the configured self-hosted instance.

## Context

Some consumers of this workflow run against a self-hosted Codecov instance. Without a configurable URL, the workflow always uploads to public Codecov, which doesn't work for those environments. Using a repo-level Actions variable keeps the workflow generic and avoids repo-specific forks of the file.

Related ticket: AAP-75137

## Test plan

- [ ] Verify Codecov workflow still uploads successfully when `CODECOV_URL` is not set
- [ ] Verify uploads go to the correct self-hosted instance when `CODECOV_URL` is configured