### PR TITLE
[AAP-75136] feat(codecov): coverage targets, PR comments, badges, and self-hosted URL support

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Upload to Codecov
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
+          url: ${{ vars.CODECOV_URL }}
           files: ${{ steps.coverage.outputs.file_list }}
           flags: unit-tests
           fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+[![codecov](https://codecov.io/github/ansible/jewel/graph/badge.svg?token=F4wilI4Cwj)](https://codecov.io/github/ansible/jewel)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ansible_jewel&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ansible_jewel)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=ansible_jewel&metric=coverage)](https://sonarcloud.io/summary/new_code?id=ansible_jewel)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=ansible_jewel&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=ansible_jewel)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=ansible_jewel&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=ansible_jewel)
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=ansible_jewel&metric=bugs)](https://sonarcloud.io/summary/new_code?id=ansible_jewel)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=ansible_jewel&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=ansible_jewel)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ansible_jewel&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=ansible_jewel)
+[![Unit Tests](https://github.com/ansible/jewel/workflows/Unit%20Tests/badge.svg)](https://github.com/ansible/jewel/actions/workflows/unit-tests.yml)
+[![Linting](https://github.com/ansible/jewel/workflows/Linting/badge.svg)](https://github.com/ansible/jewel/actions/workflows/linting.yml)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
 # Jewel
 
 Jewel provides the source code for the Gateway that connects Ansible services and provides common resources.

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,7 @@ coverage:
   status:
     project:
       default:
-        target: 90%
+        target: auto
     patch:
       default:
         target: 90%

--- a/codecov.yml
+++ b/codecov.yml
@@ -29,6 +29,14 @@ ignore:
   - "aap-dev/**"
   - "tools/scripts/**"
 
+comment:
+  layout: "diff, flags, files"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true
+  hide_project_coverage: false
+
 flags:
   unit-tests:
     paths:

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,10 +6,10 @@ coverage:
   status:
     project:
       default:
-        target: auto
+        target: 90%
     patch:
       default:
-        target: auto
+        target: 90%
 
 ignore:
   - "**/tests/**"


### PR DESCRIPTION
## Summary

- Adds `url: ${{ vars.CODECOV_URL }}` to the Codecov workflow so it works for both public (jewel) and self-hosted (aap-gateway) Codecov instances
- Adds Codecov, SonarCloud, CI, and license badges to README.md
- Sets `auto` project target (no-regression) and 90% patch target for new code
- Enables PR coverage comments by overriding the ansible org-level `comment: false` (precedent: awx, eda-server, backstage-plugins, and others already do this)

## Test plan

- [ ] Verify Codecov workflow still uploads successfully when `CODECOV_URL` is not set
- [ ] Verify README badges render correctly on the repo page
- [ ] Verify Codecov PR comment appears on a test PR
- [ ] Confirm coverage targets are enforced on status checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added project status badges to README displaying coverage, quality gate, security metrics, and license information

* **Chores**
  * Updated Codecov configuration to set coverage targets at 90% and enhanced pull request comment formatting with improved metrics reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->