### PR TITLE
Fix Codecov status check not reporting on PR commits

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -24,6 +24,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      statuses: write
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       !github.event.repository.fork
@@ -72,6 +73,7 @@ jobs:
           fi
 
       - name: Upload to Codecov
+        id: codecov
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           url: ${{ vars.CODECOV_URL }}
@@ -83,3 +85,23 @@ jobs:
           override_pr: ${{ steps.coverage.outputs.pr_number }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      # workflow_run check runs are associated with the default branch, not the
+      # PR commit, so required status checks on PRs never see them. Post an
+      # explicit commit status on the original head SHA to close that gap.
+      - name: Set commit status
+        if: always()
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const sha = '${{ github.event.workflow_run.head_sha }}';
+            const state = '${{ steps.codecov.outcome }}' === 'success' ? 'success' : 'failure';
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha,
+              state,
+              context: 'Upload coverage to Codecov',
+              description: state === 'success' ? 'Coverage uploaded' : 'Coverage upload failed',
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });


### PR DESCRIPTION
## Summary
- `workflow_run`-triggered workflows associate their check runs with the default branch HEAD, not the PR's head commit. This causes the "Upload coverage to Codecov" required status check to remain in "Expected — Waiting for status to be reported" state indefinitely on PRs.
- Adds a step that posts an explicit commit status on the PR's actual head SHA after the Codecov upload, so branch protection requirements are satisfied.
- Adds `statuses: write` permission to support posting the commit status.

## Test plan
- [ ] Merge this PR and open a test PR with a code change that triggers Unit Tests
- [ ] Verify the "Upload coverage to Codecov" status check transitions from "Expected" to "Success" on the test PR
- [ ] Verify a failed Codecov upload posts a "failure" status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration workflow to explicitly report code coverage verification results as commit statuses on GitHub, providing improved visibility into coverage outcomes across pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->