### PR TITLE
[AAP-75136] Enable Codecov GitHub check annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,9 @@
 # Coverage exclusions mirror sonar.coverage.exclusions in sonar-project.properties
 # Keep both in sync when adding or removing patterns.
 
+github_checks:
+  annotations: true
+
 coverage:
   status:
     project:


### PR DESCRIPTION
## Summary
- Overrides the org-level `github_checks.annotations: false` setting at the repo level to enable Codecov status checks (`codecov/patch`, `codecov/project`) on PRs
- Without this, Codecov posts PR comments but no GitHub status checks, making it impossible to use Codecov as a required CI check

## Test plan
- [ ] Verify `codecov/patch` and `codecov/project` status checks appear on this PR after unit tests complete
- [ ] Confirm Codecov comment still posts normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code coverage configuration to enable GitHub Checks annotations. This enhances coverage reporting by surfacing annotated feedback directly in GitHub Checks during CI runs, improving visibility of coverage changes and making it easier to review test coverage impacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->