### PR TITLE
[NO_JIRA] Upgrade Keycloak from 15.0.2 to 26.0 for arm64 support

### DIFF
--- a/tools/ansible/roles/keycloak/defaults/main.yml
+++ b/tools/ansible/roles/keycloak/defaults/main.yml
@@ -1,7 +1,8 @@
 ---
-private_key_file: ../generated/keycloak.key
-public_key_file: ../generated/keycloak.cert
-public_key_cert: ../generated/keycloak.pub
+keycloak_certs_dir: ../generated/keycloak_certs
+private_key_file: "{{ keycloak_certs_dir }}/tls.key"
+public_key_file: "{{ keycloak_certs_dir }}/tls.crt"
+public_key_cert: "{{ keycloak_certs_dir }}/tls.pub"
 keycloak_realm_template: ../generated/keycloak.gateway.realm.json
 oidc_adapter_name: "Dev Keycloak OIDC"
 oidc_slug: "keycloak_oidc_dev"

--- a/tools/ansible/roles/keycloak/tasks/initialize.yml
+++ b/tools/ansible/roles/keycloak/tasks/initialize.yml
@@ -39,9 +39,11 @@
       register: pg_initialization
       when: "'0 rows' in db_check.stdout"
 
-    - name: Start keycloak
-      shell:
-        cmd: "{{ docker_compose_cmd }} up keycloak -d --wait"
+    - name: Create keycloak certs directory
+      file:
+        path: "{{ keycloak_certs_dir }}"
+        state: directory
+        mode: '0755'
 
     - name: Generate certificates for keycloak
       command: 'openssl req -new -x509 -days 365 -nodes -out {{ public_key_file }} -keyout {{ private_key_file }} -subj "{{ cert_subject }}"'
@@ -52,6 +54,10 @@
       command: 'openssl x509 -pubkey -noout -in {{ public_key_file }} -out {{ public_key_cert }}'
       args:
         creates: "{{ public_key_cert }}"
+
+    - name: Start keycloak
+      shell:
+        cmd: "{{ docker_compose_cmd }} up keycloak -d --wait"
 
     - name: Load certs, existing and new SAML settings
       set_fact:
@@ -108,6 +114,27 @@
       when: "'0 rows' in realm_check.stdout"
       register: realm_status
       changed_when: realm_status.status == 201
+
+    - name: Set passwords for gateway realm users
+      uri:
+        url: "https://localhost:{{ keycloak_exposed_port }}/auth/admin/realms/gateway/users/{{ item.id }}/reset-password"
+        method: PUT
+        body_format: json
+        body:
+          type: password
+          value: "{{ keycloak_password }}"
+          temporary: false
+        validate_certs: False
+        headers:
+          Authorization: "Bearer {{ keycloak_response.json.access_token }}"
+        status_code: [204]
+      loop:
+        - { id: "667ec049-cdf3-45d0-a4dc-0465f7505954", name: "gateway_admin" }
+        - { id: "32559338-d619-47e5-839c-cd8c70e4221e", name: "gateway_unpriv" }
+        - { id: "cbe48149-3bc5-49a1-a616-c8a5c8a3a88f", name: "gateway_auditor" }
+      loop_control:
+        label: "{{ item.name }}"
+      when: realm_status is changed
 
   always:
     - name: Shutdown containers we started

--- a/tools/ansible/roles/keycloak/templates/keycloak.gateway.realm.json.j2
+++ b/tools/ansible/roles/keycloak/templates/keycloak.gateway.realm.json.j2
@@ -1858,7 +1858,7 @@
     "clientOfflineSessionIdleTimeout": "0",
     "cibaInterval": "5"
   },
-  "keycloakVersion": "15.0.2",
+  "keycloakVersion": "26.0",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []
@@ -1868,32 +1868,23 @@
   },
   "users" : [ {
     "id" : "32559338-d619-47e5-839c-cd8c70e4221e",
-    "createdTimestamp" : 1638304914519,
     "username" : "gateway_unpriv",
     "enabled" : true,
-    "totp" : false,
     "emailVerified" : true,
     "firstName" : "Gateway",
     "lastName" : "Unpriv",
     "email" : "noone@nowhere.com",
     "credentials" : [ {
-      "id" : "724329fd-66af-4973-ac17-02b7e7b6d33b",
       "type" : "password",
-      "createdDate" : 1639095379005,
-      "secretData" : "{\"value\":\"mV1b4nP7BC1G4pY9wlo3IWArn3a5y7w96WpivmMdQaSYENBZF/vz0dMvz8cx4mVPahH/tzScb2vZnN/GzEL0gg==\",\"salt\":\"QN6A8ckQ0o02eUl4crwgxQ==\",\"additionalParameters\":{}}",
-      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+      "value" : "{{ keycloak_password }}",
+      "temporary" : false
     } ],
-    "disableableCredentialTypes" : [ ],
-    "requiredActions" : [ ],
     "realmRoles" : [ "default-roles-gateway realm" ],
-    "notBefore" : 0,
     "groups" : [ ]
   }, {
     "id" : "667ec049-cdf3-45d0-a4dc-0465f7505954",
-    "createdTimestamp" : 1638394966440,
     "username" : "gateway_admin",
     "enabled" : true,
-    "totp" : false,
     "emailVerified" : true,
     "firstName" : "Gateway",
     "lastName" : "Admin",
@@ -1902,23 +1893,16 @@
       "is_superuser" : [ "true" ]
     },
     "credentials" : [ {
-      "id" : "51bcbebe-f17e-43c1-a549-8ab13c906bff",
       "type" : "password",
-      "createdDate" : 1639095348459,
-      "secretData" : "{\"value\":\"kIzb+2QOUGmdPPntBYrdcjQYPYUH5Hd1o9x/23aBiF4o/zhQDKhikCwc8dnXjwZu0oQ8zR6EPfRET8P79IS8Nw==\",\"salt\":\"dDs/XM3LZj4agFeD/EFDTw==\",\"additionalParameters\":{}}",
-      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+      "value" : "{{ keycloak_password }}",
+      "temporary" : false
     } ],
-    "disableableCredentialTypes" : [ ],
-    "requiredActions" : [ ],
     "realmRoles" : [ "default-roles-gateway realm" ],
-    "notBefore" : 0,
     "groups" : [ "admins" ]
   }, {
     "id" : "cbe48149-3bc5-49a1-a616-c8a5c8a3a88f",
-    "createdTimestamp" : 1638394708362,
     "username" : "gateway_auditor",
     "enabled" : true,
-    "totp" : false,
     "emailVerified" : true,
     "firstName" : "Gateway",
     "lastName" : "Auditor",
@@ -1927,16 +1911,11 @@
       "is_system_auditor" : [ "true" ]
     },
     "credentials" : [ {
-      "id" : "f94e759e-ddcf-41b4-b088-8f00d481eae4",
       "type" : "password",
-      "createdDate" : 1639095365091,
-      "secretData" : "{\"value\":\"lr+KxXSfE42YGDgqN/PLukyUXAwD3+RjFW/RmqrGJ+N3B/+zuAYuxGJ7tfjb7U74CAxuimGNoaZoy3Gj7ObB/w==\",\"salt\":\"6PXPj4PMJ7iA2SS5N+r08g==\",\"additionalParameters\":{}}",
-      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+      "value" : "{{ keycloak_password }}",
+      "temporary" : false
     } ],
-    "disableableCredentialTypes" : [ ],
-    "requiredActions" : [ ],
     "realmRoles" : [ "default-roles-gateway realm" ],
-    "notBefore" : 0,
     "groups" : [ "auditors" ]
   } ]
 }

--- a/tools/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -302,15 +302,28 @@ services:
     user: "${UID:-1000}"
     ports:
       - "{{ keycloak_exposed_port }}:8443"
+    command: start-dev
     environment:
-      KEYCLOAK_USER: "{{ keycloak_username }}"
-      KEYCLOAK_PASSWORD: "{{ keycloak_password }}"
-      DB_VENDOR: postgres
-      DB_ADDR: db
-      DB_DATABASE: keycloak
-      DB_USER: {{ db_username }}
-      DB_PASSWORD: {{ db_password }}
-      DB_PORT: 5432
+      KC_BOOTSTRAP_ADMIN_USERNAME: "{{ keycloak_username }}"
+      KC_BOOTSTRAP_ADMIN_PASSWORD: "{{ keycloak_password }}"
+      KC_DB: postgres
+      KC_DB_URL_HOST: db
+      KC_DB_URL_DATABASE: keycloak
+      KC_DB_USERNAME: {{ db_username }}
+      KC_DB_PASSWORD: {{ db_password }}
+      KC_DB_URL_PORT: "5432"
+      KC_HTTPS_CERTIFICATE_FILE: /opt/keycloak/certs/tls.crt
+      KC_HTTPS_CERTIFICATE_KEY_FILE: /opt/keycloak/certs/tls.key
+      KC_HTTP_RELATIVE_PATH: /auth
+      KC_HEALTH_ENABLED: "true"
+    volumes:
+      - {{ sources_dest }}/keycloak_certs:/opt/keycloak/certs:ro,z
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/9000"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 15s
     depends_on:
       - db
     networks:

--- a/tools/ansible/vars/container_config.yml
+++ b/tools/ansible/vars/container_config.yml
@@ -46,7 +46,7 @@ cache_key_prefix: 'gateway'
 # Keycloak settings
 keycloak_exposed_port: 8443
 keycloak_image: quay.io/keycloak/keycloak
-keycloak_image_version: 15.0.2
+keycloak_image_version: 26.0
 keycloak_username: admin
 keycloak_password: admin
 cert_subject: "/C=US/ST=NC/L=Durham/O=gateway/CN=devenv"


### PR DESCRIPTION
## Summary

- **Upgrade Keycloak from 15.0.2 to 26.0** -- the old image is amd64-only. On Apple Silicon Macs, QEMU emulation causes JGroups/multicast failures that break WildFly clustering (48+ failed services), leaving the `/auth/` webapp unable to serve requests and `make docker-compose` failing with `TLS/SSL connection has been closed (EOF)` after 50 retries.
- **Migrate docker-compose configuration to the Quarkus-based distribution** -- environment variables (`KEYCLOAK_USER` to `KC_BOOTSTRAP_ADMIN_USERNAME`, `DB_VENDOR` to `KC_DB`, etc.), `start-dev` command, TLS certificate volume mount, and a management-port healthcheck so `docker compose up --wait` blocks until Keycloak is actually ready.
- **Fix gateway realm user credentials** -- the old realm template contained pre-hashed `pbkdf2-sha256` passwords from a Keycloak 15 export that Keycloak 26's REST API import does not apply. Replaced with plaintext `value` credentials (hashed by Keycloak at import time) and added a `reset-password` API call as a safety net.

## Changes

| File | What changed |
|------|-------------|
| `tools/ansible/vars/container_config.yml` | `keycloak_image_version`: `15.0.2` to `26.0` |
| `tools/ansible/roles/sources/templates/docker-compose.yml.j2` | Quarkus env vars, `start-dev` command, TLS cert volume mount, healthcheck |
| `tools/ansible/roles/keycloak/defaults/main.yml` | Cert paths moved into `keycloak_certs/` directory (bind-mount friendly) |
| `tools/ansible/roles/keycloak/tasks/initialize.yml` | Cert generation before container start; password reset step after realm creation |
| `tools/ansible/roles/keycloak/templates/keycloak.gateway.realm.json.j2` | Replaced pre-hashed credentials with plaintext; updated `keycloakVersion` |

## Why Keycloak 26.0

- **Native arm64 image** -- no more QEMU emulation; startup drops from 40s+ to ~6s
- **No clustering failures** -- `start-dev` mode uses local caches, no JGroups multicast required
- **`KC_HTTP_RELATIVE_PATH=/auth`** preserves all existing `/auth/...` URL patterns -- no downstream changes needed for OIDC/SAML configuration

## Test plan

- [x] Verified `quay.io/keycloak/keycloak:26.0` manifest includes `arm64/linux`
- [x] Smoke-tested Keycloak 26 container starts in ~6s on arm64 with TLS certs
- [x] Verified token endpoint works via both `curl` and Python `urllib` (same library Ansible uses)
- [x] Verified gateway realm creation and user login (`gateway_admin`/`admin`) succeeds
- [x] Verified all OIDC/SAML URLs remain compatible with `/auth` relative path
- [ ] Full `make docker-compose` from clean state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Upgraded Keycloak to version 26.0 with modernized configuration
  * Reorganized certificate management directory structure
  * Added service health monitoring for Keycloak
  * Enhanced realm user password management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->