### PR TITLE
[AAP-75136] Fix flaky JWT key failures in transaction tests

### DIFF
--- a/aap_gateway_api/tests/utils/test_crud_resource_in_services.py
+++ b/aap_gateway_api/tests/utils/test_crud_resource_in_services.py
@@ -88,6 +88,7 @@ def test_users_are_updated(
     admin_api_client,
     patched_resource_client,
     patched_all_services_resource_client,
+    ensure_jwt_keys,
 ):
     username = "my_username"
 
@@ -121,6 +122,7 @@ def test_teams_are_updated(
     admin_api_client,
     patched_resource_client,
     patched_all_services_resource_client,
+    ensure_jwt_keys,
 ):
     url = get_relative_url("organization-list")
     response = admin_api_client.post(url, data={"name": "my_org_name"})

--- a/aap_gateway_api/tests/utils/test_crud_resource_in_services.py
+++ b/aap_gateway_api/tests/utils/test_crud_resource_in_services.py
@@ -55,7 +55,7 @@ def test_organizations_are_updated(
     admin_api_client,
     patched_resource_client,
     patched_all_services_resource_client,
-    ensure_jwt_keys,
+    ensure_jwt_keys,  # Required for side effect: restores JWT keys after DB flush from transaction=True
 ):
     org_name = "My test org"
     url = get_relative_url("organization-list")
@@ -88,7 +88,7 @@ def test_users_are_updated(
     admin_api_client,
     patched_resource_client,
     patched_all_services_resource_client,
-    ensure_jwt_keys,
+    ensure_jwt_keys,  # Required for side effect: restores JWT keys after DB flush from transaction=True
 ):
     username = "my_username"
 
@@ -122,7 +122,7 @@ def test_teams_are_updated(
     admin_api_client,
     patched_resource_client,
     patched_all_services_resource_client,
-    ensure_jwt_keys,
+    ensure_jwt_keys,  # Required for side effect: restores JWT keys after DB flush from transaction=True
 ):
     url = get_relative_url("organization-list")
     response = admin_api_client.post(url, data={"name": "my_org_name"})


### PR DESCRIPTION
## Summary
- Add missing `ensure_jwt_keys` fixture to `test_users_are_updated` and `test_teams_are_updated`
- Both tests use `django_db(transaction=True)` which flushes the DB, but were missing the fixture that restores JWT keys after a flush
- `test_organizations_are_updated` already had this fixture; the other two were accidentally omitted
- Root cause of intermittent `jwt.exceptions.InvalidKeyError: Could not parse the provided public key` failures where `get_jwt_rsa_key()` returns an empty string

## Test plan
- [ ] Verify `Views S-Z` job passes consistently (this test file runs in that split)
- [ ] No other changes needed — the fixture already exists, it just wasn't being used

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a fixture to relevant CRUD tests to ensure JWT key handling, improving reliability and consistency of tests that interact with authentication.
  * Added an inline comment to an existing test clarifying a side-effect observed after a database flush, improving test clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->