### PR TITLE
[AAP-75136] Override org-level Codecov status check disabling

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,17 +2,25 @@
 # Coverage exclusions mirror sonar.coverage.exclusions in sonar-project.properties
 # Keep both in sync when adding or removing patterns.
 
+# Explicitly override org-level config that disables all checks:
+# Org config has: comment: false, changes: false, patch: false,
+#                 flag_coverage_not_uploaded_behavior: exclude, annotations: false
+# This config flips everything to the opposite to enable status checks
+
 github_checks:
-  annotations: true
+  annotations: true  # Org has: false
 
 coverage:
   status:
     project:
       default:
         target: auto
+        flag_coverage_not_uploaded_behavior: include  # Org has: exclude
     patch:
       default:
         target: 90%
+        flag_coverage_not_uploaded_behavior: include  # Org has: exclude
+    changes: true  # Org has: false
 
 ignore:
   - "**/tests/**"
@@ -33,11 +41,11 @@ ignore:
   - "tools/scripts/**"
 
 comment:
-  layout: "diff, flags, files"
-  behavior: default
-  require_changes: false
+  require_changes: false  # Org has: comment: false (entire section disabled)
   require_base: false
   require_head: true
+  layout: "diff, flags, files"
+  behavior: default
   hide_project_coverage: false
 
 flags:


### PR DESCRIPTION
## Summary
- The org-level Codecov YAML explicitly disables status checks: `patch: false`, `changes: false`
- The repo-level config had `patch.default.target: 90%` but this may not override the org-level `patch: false`
- Add explicit `changes: true` override and rely on the patch section's default definition to re-enable patch status

## Context
The org-level config:
```yaml
coverage:
  status:
    changes: false
    patch: false
    project:
      default:
        flag_coverage_not_uploaded_behavior: exclude
```

This is why `codecov/patch` and `codecov/project` commit statuses never appeared on PRs despite the repo config defining targets.

## Test plan
- [ ] After unit tests + codecov upload, check if `codecov/patch`, `codecov/project`, or `codecov/changes` commit statuses appear on this PR
- [ ] If status checks appear, they can be added as required checks in branch protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated coverage configuration to report patch-level change coverage in addition to the existing overall target, improving visibility into test coverage for incremental changes.
  * Adjusted coverage report comment behavior and ordering to clarify status output (no changes to enforcement thresholds).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->