### PR TITLE
[AAP-75136] Add slug and disable_search to Codecov upload

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -75,6 +75,8 @@ jobs:
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           url: ${{ vars.CODECOV_URL }}
+          slug: ${{ github.repository }}
+          disable_search: true
           files: ${{ steps.coverage.outputs.file_list }}
           flags: unit-tests
           fail_ci_if_error: true


### PR DESCRIPTION
## Summary
- Adds `slug: ${{ github.repository }}` for explicit repository identification
- Adds `disable_search: true` to only upload explicitly specified coverage files
- Both settings are required for private repos using self-hosted Codecov per the [CoverPort onboarding guide](https://docs.google.com/document/d/1630DepyDhcODXfONEsSfQT5s18BdG59eML0lZ_3sWpA/edit)

## Context
The `ansible/jewel:devel` branch is auto-synced to `ansible-automation-platform/aap-gateway:devel` and cherry-picked to stable branches. When this workflow runs in `aap-gateway` (a private repo), it will use the self-hosted Codecov instance which requires:
- `slug` to be explicitly set (doesn't rely on git remote auto-detection)
- `disable_search: true` to prevent auto-discovery of coverage files

Adding these now:
- ✅ Makes the workflow portable across repos
- ✅ Doesn't change behavior for `ansible/jewel` (public repo)
- ✅ Prepares for `aap-gateway` sync without requiring workflow changes

## Test plan
- [ ] Verify Codecov upload succeeds on a test PR
- [ ] Confirm coverage data appears in Codecov dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage workflow configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->