### PR TITLE
[AAP-76431] Fix AllServicesClient crash on services without service_index_path

### DIFF
--- a/aap_gateway_api/tests/conftest.py
+++ b/aap_gateway_api/tests/conftest.py
@@ -459,15 +459,24 @@ ServiceHierarchy = namedtuple("ServiceHierarchy", ["service_cluster", "service_n
 #   - service_node_<service_type>
 #   - additional_route_<service_type>
 #   - service_api_route_<service_type>
+_service_index_paths = {
+    DefaultServiceType.GATEWAY.value: "",
+    DefaultServiceType.CONTROLLER.value: "/v2/service-index/",
+    DefaultServiceType.HUB.value: "/service-index/",
+    DefaultServiceType.EDA.value: "/v1/service-index/",
+}
+
 for name in [x.value for x in DefaultServiceType]:
 
     def _service_type(name=name):
-        st, _ = ServiceType.objects.get_or_create(name=name)
+        defaults = {"service_index_path": _service_index_paths.get(name)}
+        st, _ = ServiceType.objects.get_or_create(name=name, defaults=defaults)
         yield st
         # Don't delete these
 
     def _service_cluster(name=name):
-        st, _ = ServiceType.objects.get_or_create(name=name)
+        defaults = {"service_index_path": _service_index_paths.get(name)}
+        st, _ = ServiceType.objects.get_or_create(name=name, defaults=defaults)
         cluster = ServiceCluster.objects.create(name=name, service_type=st)
         yield cluster
         cluster.delete()

--- a/aap_gateway_api/utils/resources_client.py
+++ b/aap_gateway_api/utils/resources_client.py
@@ -148,7 +148,14 @@ class AllServicesClient(GWResourceAPIClient):
         from aap_gateway_api.models import ServiceAPIRoute
 
         responses = {}
-        svc_qs = ServiceAPIRoute.objects.exclude(service_cluster__service_type__name=DefaultServiceType.GATEWAY.value)
+        # Exclude gateway (not a downstream service) and services without a
+        # service-index endpoint (e.g. metrics) to avoid AttributeError in
+        # get_url_for_service when service_index_path is None or empty.
+        svc_qs = (
+            ServiceAPIRoute.objects.exclude(service_cluster__service_type__name=DefaultServiceType.GATEWAY.value)
+            .exclude(service_cluster__service_type__service_index_path__isnull=True)
+            .exclude(service_cluster__service_type__service_index_path='')
+        )
         if self.service_filter:
             svc_qs = svc_qs.filter(**self.service_filter)
 


### PR DESCRIPTION
## Summary
- Exclude services with null or empty `service_index_path` from `AllServicesClient._make_request` queryset
- Services like metrics don't have a service-index endpoint; including them caused `AttributeError: 'NoneType' object has no attribute 'strip'` in `get_url_for_service`
- The exception was caught and logged but produced noisy error tracebacks on every resource sync operation

## Test plan
- [ ] Verify metrics service no longer produces `AttributeError` tracebacks during resource sync
- [ ] Verify resource sync to controller/hub/eda services still works normally

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented failures when constructing service URLs for services that lack a service-index endpoint, improving reliability when discovering downstream services.

* **Tests**
  * Enhanced test fixtures to ensure service types include default service-index path values during test setup, reducing flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->