### PR TITLE
[AAP-73866] feat: add OpenTelemetry tracing to gateway

### DIFF
--- a/aap_gateway_api/common/envoy.py
+++ b/aap_gateway_api/common/envoy.py
@@ -1,3 +1,4 @@
+from envoy.config.trace.v3 import opentelemetry_pb2
 from envoy.extensions.access_loggers.stream.v3 import stream_pb2
 from envoy.extensions.filters.http.ext_authz.v3 import ext_authz_pb2
 from envoy.extensions.filters.http.lua.v3 import lua_pb2
@@ -25,3 +26,4 @@ EXT_AUTHZ_FILTER = _type_url(ext_authz_pb2.ExtAuthz.DESCRIPTOR)
 HTTP_ROUTER = _type_url(router_pb2.Router.DESCRIPTOR)
 HTTP_CONNECTION_MANAGER = _type_url(http_connection_manager_pb2.HttpConnectionManager.DESCRIPTOR)
 STDOUT_ACCESS_LOG = _type_url(stream_pb2.StdoutAccessLog.DESCRIPTOR)
+OPENTELEMETRY_CONFIG = _type_url(opentelemetry_pb2.OpenTelemetryConfig.DESCRIPTOR)

--- a/aap_gateway_api/management/commands/start_grpc_server.py
+++ b/aap_gateway_api/management/commands/start_grpc_server.py
@@ -5,6 +5,7 @@ import sys
 from concurrent import futures
 
 import grpc
+from ansible_base.observability import setup_observability
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from envoy.service.auth.v3 import external_auth_pb2_grpc
@@ -22,6 +23,7 @@ os.environ["GRPC_VERBOSITY"] = getattr(settings, "GRPC_VERBOSITY", "ERROR")
 
 
 def _run_server(bind_address, debug):
+    setup_observability(service_name="gateway-grpc")
     if debug:
         _THREAD_CONCURRENCY = 1
         try:

--- a/aap_gateway_api/tests/conftest.py
+++ b/aap_gateway_api/tests/conftest.py
@@ -4,11 +4,18 @@ import multiprocessing
 import os
 import random
 import re
+import sys
 import uuid
 from collections import namedtuple
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
+
+# Mock ansible_base.observability for tests
+# Production code uses setup_observability() but tests shouldn't initialize real OTEL
+if 'ansible_base.observability' not in sys.modules:
+    sys.modules['ansible_base.observability'] = Mock()
+    sys.modules['ansible_base.observability'].setup_observability = Mock()
 
 # If we pull in individual fixtures and then reuse them in the new fixtures they have linting errors
 #  around redefinition. Instead we will just import * here and noqa this one line instead of multiple places

--- a/aap_gateway_api/tests/management/test_start_grpc_server.py
+++ b/aap_gateway_api/tests/management/test_start_grpc_server.py
@@ -1,0 +1,52 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.django_db
+@patch('envoy.service.auth.v3.external_auth_pb2_grpc.add_AuthorizationServicer_to_server')
+@patch('grpc.server')
+def test_run_server_setup_observability(mock_server_factory, mock_add_servicer):
+    """Test that _run_server calls setup_observability."""
+    from ansible_base.observability import setup_observability
+
+    from aap_gateway_api.management.commands.start_grpc_server import _run_server
+
+    # Reset mock from conftest to track calls in this test
+    setup_observability.reset_mock()
+
+    # Mock gRPC server
+    mock_grpc_server = MagicMock()
+    mock_server_factory.return_value = mock_grpc_server
+    mock_grpc_server.wait_for_termination.side_effect = KeyboardInterrupt()
+
+    try:
+        _run_server(bind_address="[::]:50051", debug=False)
+    except KeyboardInterrupt:
+        pass
+
+    # Verify setup_observability was called
+    setup_observability.assert_called_once_with(service_name="gateway-grpc")
+
+
+@pytest.mark.django_db
+@patch('envoy.service.auth.v3.external_auth_pb2_grpc.add_AuthorizationServicer_to_server')
+@patch('grpc.server')
+def test_run_server_debug_mode(mock_server_factory, mock_add_servicer):
+    """Test that _run_server handles debug mode correctly."""
+    from aap_gateway_api.management.commands.start_grpc_server import _run_server
+
+    mock_grpc_server = MagicMock()
+    mock_server_factory.return_value = mock_grpc_server
+    mock_grpc_server.wait_for_termination.side_effect = KeyboardInterrupt()
+
+    # Mock debugpy in sys.modules before it's imported
+    mock_debugpy = MagicMock()
+    with patch.dict('sys.modules', {'debugpy': mock_debugpy}):
+        try:
+            _run_server(bind_address="[::]:50051", debug=True)
+        except KeyboardInterrupt:
+            pass
+
+        # Verify debugpy.listen was called in debug mode
+        mock_debugpy.listen.assert_called_once_with(("0.0.0.0", 3001))

--- a/aap_gateway_api/tests/test_wsgi.py
+++ b/aap_gateway_api/tests/test_wsgi.py
@@ -1,0 +1,23 @@
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.mark.django_db
+@patch('django.core.wsgi.get_wsgi_application')
+def test_wsgi_module_setup_observability(mock_get_wsgi):
+    """Test that wsgi module calls setup_observability on import."""
+    from ansible_base.observability import setup_observability
+
+    # Reset mock from conftest to track calls in this test
+    setup_observability.reset_mock()
+
+    # Reload module to trigger module-level code
+    import importlib
+
+    import aap_gateway_api.wsgi
+
+    importlib.reload(aap_gateway_api.wsgi)
+
+    # Verify setup_observability was called
+    setup_observability.assert_called_with(service_name="gateway-uwsgi")

--- a/aap_gateway_api/utils/xds_configs.py
+++ b/aap_gateway_api/utils/xds_configs.py
@@ -1,6 +1,14 @@
 from django.conf import settings
 
-from aap_gateway_api.common.envoy import DOWNSTREAM_TLS_CONTEXT, EXT_AUTHZ_FILTER, HTTP_CONNECTION_MANAGER, HTTP_ROUTER, LUA_FILTER, STDOUT_ACCESS_LOG
+from aap_gateway_api.common.envoy import (
+    DOWNSTREAM_TLS_CONTEXT,
+    EXT_AUTHZ_FILTER,
+    HTTP_CONNECTION_MANAGER,
+    HTTP_ROUTER,
+    LUA_FILTER,
+    OPENTELEMETRY_CONFIG,
+    STDOUT_ACCESS_LOG,
+)
 
 SDS_SECRET_CONFIG_NAME = "validation_context_sds"
 
@@ -67,6 +75,16 @@ def network_manager_filter(http_filters=[], routes=[]):
                         "routes": routes,
                     }
                 ],
+            },
+            "tracing": {
+                "provider": {
+                    "name": "envoy.tracers.opentelemetry",
+                    "typed_config": {
+                        "@type": OPENTELEMETRY_CONFIG,
+                        "grpc_service": {"envoy_grpc": {"cluster_name": "otel_collector"}},
+                        "service_name": "gateway-envoy",
+                    },
+                }
             },
             "use_remote_address": True,
             "xff_num_trusted_hops": settings.XDS_XFF_NUM_TRUSTED_HOPS,

--- a/aap_gateway_api/wsgi.py
+++ b/aap_gateway_api/wsgi.py
@@ -9,8 +9,10 @@ https://docs.djangoproject.com/en/5.2/howto/deployment/wsgi/
 
 import os
 
+from ansible_base.observability import setup_observability
 from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'project.settings')
 
+setup_observability(service_name="gateway-uwsgi")
 application = get_wsgi_application()

--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -1,1 +1,1 @@
-django-ansible-base[activitystream,api-documentation,authentication,redis-client,rest-filters,rbac,oauth2-provider,feature-flags] @ git+https://github.com/ansible/django-ansible-base@devel
+django-ansible-base[activitystream,api-documentation,authentication,redis-client,rest-filters,rbac,oauth2-provider,feature-flags,observability] @ git+https://github.com/ansible/django-ansible-base@devel

--- a/tools/ansible/roles/grafana/defaults/main.yml
+++ b/tools/ansible/roles/grafana/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+grafana_image: docker.io/grafana/grafana
+grafana_image_version: latest
+grafana_http_port: 3000
+grafana_provisioning_dir: "{{ sources_dest }}/grafana/provisioning"

--- a/tools/ansible/roles/grafana/tasks/initialize.yml
+++ b/tools/ansible/roles/grafana/tasks/initialize.yml
@@ -1,0 +1,10 @@
+---
+- name: Create Grafana datasources provisioning directory
+  file:
+    path: "{{ grafana_provisioning_dir }}/datasources"
+    state: directory
+
+- name: Template Grafana datasources
+  template:
+    src: datasources.yml.j2
+    dest: "{{ grafana_provisioning_dir }}/datasources/datasources.yml"

--- a/tools/ansible/roles/grafana/tasks/plumb.yml
+++ b/tools/ansible/roles/grafana/tasks/plumb.yml
@@ -1,0 +1,2 @@
+---
+# Nothing required for plumbing

--- a/tools/ansible/roles/grafana/templates/datasources.yml.j2
+++ b/tools/ansible/roles/grafana/templates/datasources.yml.j2
@@ -1,0 +1,18 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    url: http://loki:{{ loki_http_port }}
+    access: proxy
+    isDefault: true
+
+  - name: Tempo
+    type: tempo
+    url: http://tempo:{{ tempo_http_port }}
+    access: proxy
+
+  - name: Prometheus
+    type: prometheus
+    url: http://otel-collector:{{ otel_collector_prometheus_port }}
+    access: proxy

--- a/tools/ansible/roles/loki/defaults/main.yml
+++ b/tools/ansible/roles/loki/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+loki_image: docker.io/grafana/loki
+loki_image_version: latest
+loki_http_port: 3100
+loki_config_dir: "{{ sources_dest }}/loki"
+loki_config_file: loki-config.yml

--- a/tools/ansible/roles/loki/tasks/initialize.yml
+++ b/tools/ansible/roles/loki/tasks/initialize.yml
@@ -1,0 +1,10 @@
+---
+- name: Create Loki config directory
+  file:
+    path: "{{ loki_config_dir }}"
+    state: directory
+
+- name: Template Loki config
+  template:
+    src: "{{ loki_config_file }}.j2"
+    dest: "{{ loki_config_dir }}/{{ loki_config_file }}"

--- a/tools/ansible/roles/loki/tasks/plumb.yml
+++ b/tools/ansible/roles/loki/tasks/plumb.yml
@@ -1,0 +1,2 @@
+---
+# Nothing required for plumbing

--- a/tools/ansible/roles/loki/templates/loki-config.yml.j2
+++ b/tools/ansible/roles/loki/templates/loki-config.yml.j2
@@ -1,0 +1,25 @@
+auth_enabled: false
+
+server:
+  http_listen_port: {{ loki_http_port }}
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h

--- a/tools/ansible/roles/otel_collector/defaults/main.yml
+++ b/tools/ansible/roles/otel_collector/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+otel_collector_image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+otel_collector_image_version: latest
+otel_collector_grpc_port: 4317
+otel_collector_http_port: 4318
+otel_collector_prometheus_port: 8889
+otel_collector_host: otel-collector
+otel_collector_config_dir: "{{ sources_dest }}/otel_collector"
+otel_collector_config_file: otel-collector-config.yml

--- a/tools/ansible/roles/otel_collector/tasks/initialize.yml
+++ b/tools/ansible/roles/otel_collector/tasks/initialize.yml
@@ -1,0 +1,10 @@
+---
+- name: Create OTEL collector config directory
+  file:
+    path: "{{ otel_collector_config_dir }}"
+    state: directory
+
+- name: Template OTEL collector config
+  template:
+    src: "{{ otel_collector_config_file }}.j2"
+    dest: "{{ otel_collector_config_dir }}/{{ otel_collector_config_file }}"

--- a/tools/ansible/roles/otel_collector/tasks/plumb.yml
+++ b/tools/ansible/roles/otel_collector/tasks/plumb.yml
@@ -1,0 +1,2 @@
+---
+# Nothing required for plumbing

--- a/tools/ansible/roles/otel_collector/templates/otel-collector-config.yml.j2
+++ b/tools/ansible/roles/otel_collector/templates/otel-collector-config.yml.j2
@@ -1,0 +1,37 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:{{ otel_collector_grpc_port }}
+      http:
+        endpoint: 0.0.0.0:{{ otel_collector_http_port }}
+
+processors:
+  batch:
+
+exporters:
+  otlphttp/loki:
+    endpoint: http://loki:{{ loki_http_port }}/otlp
+    tls:
+      insecure: true
+  otlp/tempo:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+  prometheus:
+    endpoint: 0.0.0.0:{{ otel_collector_prometheus_port }}
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/tempo]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp/loki]

--- a/tools/ansible/roles/proxy-config/templates/envoy.yml.j2
+++ b/tools/ansible/roles/proxy-config/templates/envoy.yml.j2
@@ -69,6 +69,26 @@ static_resources:
                 port_value: 50051
 {% endfor %}
 
+  - name: otel_collector
+    type: LOGICAL_DNS
+    dns_lookup_family: V4_ONLY
+    connect_timeout: 3s
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: otel_collector
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: {{ otel_collector_host }}
+                port_value: {{ otel_collector_grpc_port }}
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options: {}
+
 admin:
   address:
     socket_address:

--- a/tools/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -41,6 +41,10 @@ services:
       - ENVOY_VERIFY_HTTPS_CERTIFICATES=false
       - DJANGO_DEBUG_TOOL_BAR={{ ddt_enabled }}
       - CONTAINER_NUMBER={{ container_id }}
+{% if enabled_containers['otel_collector'] | bool %}
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:{{ otel_collector_grpc_port }}
+      - OTEL_SERVICE_NAME=aap-gateway
+{% endif %}
 {% if container_engine == 'docker' %}
     links:
       - db
@@ -402,6 +406,83 @@ services:
       - dbnet
 {% endif %}
 
+{% if enabled_containers['otel_collector'] | bool %}
+  otel_collector:
+    image: {{ otel_collector_image }}:{{ otel_collector_image_version }}
+    container_name: aap_gw_otel_collector_1
+    hostname: otel-collector
+    command: ["--config=/etc/otel/otel-collector-config.yml"]
+    ports:
+      - "{{ otel_collector_grpc_port }}:{{ otel_collector_grpc_port }}"
+      - "{{ otel_collector_http_port }}:{{ otel_collector_http_port }}"
+      - "{{ otel_collector_prometheus_port }}:{{ otel_collector_prometheus_port }}"
+    volumes:
+      - '$PWD/tools/generated/otel_collector/otel-collector-config.yml:/etc/otel/otel-collector-config.yml:ro,z'
+    networks:
+      - service-mesh
+    depends_on:
+{% if enabled_containers['loki'] | bool %}
+      - loki
+{% endif %}
+{% if enabled_containers['tempo'] | bool %}
+      - tempo
+{% endif %}
+{% endif %}
+
+{% if enabled_containers['loki'] | bool %}
+  loki:
+    image: {{ loki_image }}:{{ loki_image_version }}
+    container_name: aap_gw_loki_1
+    hostname: loki
+    command: ["-config.file=/etc/loki/loki-config.yml"]
+    ports:
+      - "{{ loki_http_port }}:{{ loki_http_port }}"
+    volumes:
+      - '$PWD/tools/generated/loki/loki-config.yml:/etc/loki/loki-config.yml:ro,z'
+      - 'aap_gw_loki:/loki:z'
+    networks:
+      - service-mesh
+{% endif %}
+
+{% if enabled_containers['tempo'] | bool %}
+  tempo:
+    image: {{ tempo_image }}:{{ tempo_image_version }}
+    container_name: aap_gw_tempo_1
+    hostname: tempo
+    command: ["-config.file=/etc/tempo/tempo-config.yml"]
+    ports:
+      - "{{ tempo_http_port }}:{{ tempo_http_port }}"
+    volumes:
+      - '$PWD/tools/generated/tempo/tempo-config.yml:/etc/tempo/tempo-config.yml:ro,z'
+      - 'aap_gw_tempo:/var/tempo:z'
+    networks:
+      - service-mesh
+{% endif %}
+
+{% if enabled_containers['grafana'] | bool %}
+  grafana:
+    image: {{ grafana_image }}:{{ grafana_image_version }}
+    container_name: aap_gw_grafana_1
+    hostname: grafana
+    ports:
+      - "{{ grafana_http_port }}:{{ grafana_http_port }}"
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    volumes:
+      - '$PWD/tools/generated/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro,z'
+      - 'aap_gw_grafana:/var/lib/grafana:z'
+    networks:
+      - service-mesh
+    depends_on:
+{% if enabled_containers['loki'] | bool %}
+      - loki
+{% endif %}
+{% if enabled_containers['tempo'] | bool %}
+      - tempo
+{% endif %}
+{% endif %}
+
 networks:
   dbnet:
   service-mesh:
@@ -423,4 +504,16 @@ volumes:
   aap_gw_openldap_data:
     name: aap_gw_ldap_1
     driver: local
+{% endif %}
+{% if enabled_containers['loki'] | bool %}
+  aap_gw_loki:
+    name: aap_gw_loki
+{% endif %}
+{% if enabled_containers['tempo'] | bool %}
+  aap_gw_tempo:
+    name: aap_gw_tempo
+{% endif %}
+{% if enabled_containers['grafana'] | bool %}
+  aap_gw_grafana:
+    name: aap_gw_grafana
 {% endif %}

--- a/tools/ansible/roles/tempo/defaults/main.yml
+++ b/tools/ansible/roles/tempo/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+tempo_image: docker.io/grafana/tempo
+tempo_image_version: latest
+tempo_http_port: 3200
+tempo_config_dir: "{{ sources_dest }}/tempo"
+tempo_config_file: tempo-config.yml

--- a/tools/ansible/roles/tempo/tasks/initialize.yml
+++ b/tools/ansible/roles/tempo/tasks/initialize.yml
@@ -1,0 +1,10 @@
+---
+- name: Create Tempo config directory
+  file:
+    path: "{{ tempo_config_dir }}"
+    state: directory
+
+- name: Template Tempo config
+  template:
+    src: "{{ tempo_config_file }}.j2"
+    dest: "{{ tempo_config_dir }}/{{ tempo_config_file }}"

--- a/tools/ansible/roles/tempo/tasks/plumb.yml
+++ b/tools/ansible/roles/tempo/tasks/plumb.yml
@@ -1,0 +1,2 @@
+---
+# Nothing required for plumbing

--- a/tools/ansible/roles/tempo/templates/tempo-config.yml.j2
+++ b/tools/ansible/roles/tempo/templates/tempo-config.yml.j2
@@ -1,0 +1,19 @@
+server:
+  http_listen_port: {{ tempo_http_port }}
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/blocks
+    wal:
+      path: /var/tempo/wal

--- a/tools/ansible/vars/container_config.yml
+++ b/tools/ansible/vars/container_config.yml
@@ -25,6 +25,10 @@ enabled_containers:
   tacacs: "{{ tacacs_enabled | default(False) }}"
   radius: "{{ radius_enabled | default(False) }}"
   haproxy: "{{ haproxy_enabled | default(False) }}"
+  otel_collector: "{{ otel_enabled | default(False) }}"
+  loki: "{{ otel_enabled | default(False) }}"
+  tempo: "{{ otel_enabled | default(False) }}"
+  grafana: "{{ otel_enabled | default(False) }}"
 
 # Redis settings
 redis_mode_options:
@@ -85,3 +89,26 @@ envoy_proxy_version: v1.36.6
 
 # HAProxy
 proxy_container_version: latest
+
+# OTEL Collector
+otel_collector_image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+otel_collector_image_version: latest
+otel_collector_grpc_port: 4317
+otel_collector_http_port: 4318
+otel_collector_prometheus_port: 8889
+otel_collector_host: otel-collector
+
+# Loki
+loki_image: docker.io/grafana/loki
+loki_image_version: latest
+loki_http_port: 3100
+
+# Tempo
+tempo_image: docker.io/grafana/tempo
+tempo_image_version: latest
+tempo_http_port: 3200
+
+# Grafana
+grafana_image: docker.io/grafana/grafana
+grafana_image_version: latest
+grafana_http_port: 3000

--- a/tools/configs/container-startup-podman.yml
+++ b/tools/configs/container-startup-podman.yml
@@ -28,3 +28,4 @@ gateway_preferences:
 # ldap_enabled: True
 # tacacs_enabled: True
 # radius_enabled: True
+# otel_enabled: True

--- a/tools/configs/container-startup.yml
+++ b/tools/configs/container-startup.yml
@@ -29,6 +29,7 @@ redis_tls_enabled: True
 # ldap_enabled: True
 # tacacs_enabled: True
 # radius_enabled: True
+# otel_enabled: True
 
 ### Gateway preferences that will be set
 gateway_preferences:


### PR DESCRIPTION
## Description

**Related Issue:** [AAP-73866](https://redhat.atlassian.net/browse/AAP-73866) - Enable observability in aap-gateway component

- **What is being changed?** Add OpenTelemetry distributed tracing to gateway uwsgi, grpc server, and Envoy proxy
- **Why is this change needed?** Enable end-to-end request tracing across AAP services for debugging and performance analysis
- **How does this change address the issue?** 
  - Instrument uwsgi and grpc with `setup_observability()` from django-ansible-base
  - Configure Envoy HCM with OTLP tracing to OTEL collector
  - Add observability stack sidecars (OTEL collector, Tempo, Loki, Grafana)
  - Make feature opt-in via `otel_enabled: True` config flag


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [x] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites
- Docker or Podman
- Gateway dev environment set up

### Steps to Test
1. Uncomment `otel_enabled: True` in `tools/configs/container-startup.yml`
2. Run container startup playbook: `make up` or equivalent
3. Generate traffic to gateway (API requests, gRPC calls)
4. Open Grafana: http://localhost:3000
5. Navigate to Explore → Tempo datasource
6. Query for service traces: `{service.name="gateway-uwsgi"}` or `{service.name="gateway-grpc"}`

### Expected Results
- OTEL collector, Tempo, Loki, Grafana containers running
- Traces visible in Grafana Tempo showing gateway-uwsgi, gateway-grpc, gateway-envoy spans
- Logs correlated with trace IDs in Loki
- End-to-end request flow traceable across components

## Additional Context

### Required Actions
- [ ] Requires downstream repository changes
  <!-- django-ansible-base observability module already published -->
- [ ] Requires documentation updates
  <!-- Future work to document OTEL setup in operator docs -->


[AAP-73866]: https://redhat.atlassian.net/browse/AAP-73866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Observability is initialized at WSGI and gRPC startup; optional OpenTelemetry exporter support for gateways.
  * Optional monitoring stack can be enabled: OpenTelemetry Collector, Loki, Tempo, Grafana, and provisioning for them.

* **Chores**
  * Add Ansible roles, templates, defaults and Docker Compose options to provision/configure the monitoring stack.

* **Tests**
  * Improve test bootstrap for minimal environments; add tests validating observability initialization and debug startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->