### PR TITLE
[AAP-77128] Pin urllib3>=2.7.0 for CVE-2026-44431 / CVE-2026-44432

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -18,7 +18,7 @@ uwsgi
 xds-protos>=1.58
 PyYAML
 # Not directly imported but pinned per dependabot alerts
-urllib3>=2.6.3   # CVE-2025-66471 / AAP-62077
+urllib3>=2.7.0   # CVE-2026-44431 / CVE-2026-44432
 argon2-cffi
 dynaconf>=3.2.13,<4.0.0  # CVE-2026-33154
 referencing<0.37.0  # consistent with DAB pin from jsonschema-path

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -106,7 +106,7 @@ typing-extensions==4.12.2
     #   referencing
 uritemplate==4.2.0
     # via drf-spectacular
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/requirements.in
     #   requests


### PR DESCRIPTION
## Description

Update `urllib3` from `>=2.6.3` to `>=2.7.0` to address two security vulnerabilities:

- **CVE-2026-44431**: Information disclosure via cross-origin redirects forwarding sensitive headers (urllib3 1.23 to <2.7.0)
- **CVE-2026-44432**: Denial of Service due to excessive HTTP response decompression (urllib3 2.6.0 to <2.7.0)

Both CVEs are fixed in urllib3 2.7.0. The `aap-gateway` codebase pins `urllib3` in `requirements/requirements.in` as a security-driven dependency (not directly imported). After merge, MintMaker will propagate the bump to the `automation-gateway-container` image automatically.

JIRA: AAP-76260, AAP-76512

```yaml
release: "devel"
backport:
needs_feature_branch: false
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have considered the security impact of these changes
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites
None

### Steps to Test
1. `pip install -r requirements/requirements.txt`
2. `pip show urllib3`

### Expected Results
urllib3 version should be >= 2.7.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated urllib3 dependency to version 2.7.0.
  * Updated inline vulnerability references from CVE-2025-66471 / AAP-62077 to CVE-2026-44431 / CVE-2026-44432.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->