### PR TITLE
[AAP-75696] fix(ci): fix PR label workflow for chained workflows and cross-fork PRs

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -4,6 +4,9 @@ name: PR Labels
 on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review, converted_to_draft, edited, reopened, closed]
+  # check_suite fires on the base repo for all PRs, including cross-fork PRs
+  # where workflow_run doesn't trigger. Filter to non-GitHub-Actions suites to
+  # avoid duplicating runs already handled by workflow_run.
   check_suite:
     types: [completed]
   workflow_run:
@@ -18,6 +21,12 @@ permissions:
 
 jobs:
   label:
+    if: >-
+      github.event_name != 'check_suite'
+      || github.event.check_suite.app.slug != 'github-actions'
+    concurrency:
+      group: pr-labels-${{ github.event.check_suite.head_sha || github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.run_id }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
@@ -42,16 +51,23 @@ jobs:
             let prNumber;
 
             if (context.eventName === 'check_suite') {
-              const headSha = context.payload.check_suite.head_sha;
-              const pulls = await github.paginate(github.rest.pulls.list, {
-                owner, repo, state: 'open', per_page: 100,
-              });
-              const matched = pulls.filter(p => p.head.sha === headSha);
-              if (matched.length === 0) {
-                core.info('No open PR found for this check suite');
-                return;
+              // check_suite.pull_requests is populated for same-repo PRs (fast path);
+              // for fork PRs it's empty, so fall back to paginating all open PRs.
+              const csPulls = context.payload.check_suite.pull_requests || [];
+              if (csPulls.length > 0) {
+                prNumber = csPulls[0].number;
+              } else {
+                const headSha = context.payload.check_suite.head_sha;
+                const pulls = await github.paginate(github.rest.pulls.list, {
+                  owner, repo, state: 'open', per_page: 100,
+                });
+                const matched = pulls.filter(p => p.head.sha === headSha);
+                if (matched.length === 0) {
+                  core.info('No open PR found for this check suite');
+                  return;
+                }
+                prNumber = matched[0].number;
               }
-              prNumber = matched[0].number;
             } else if (context.eventName === 'workflow_run') {
               const sourceEvent = context.payload.workflow_run.event;
               if (!['pull_request', 'pull_request_review', 'workflow_run'].includes(sourceEvent)) {

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -43,7 +43,7 @@ jobs:
 
             if (context.eventName === 'check_suite') {
               const headSha = context.payload.check_suite.head_sha;
-              const { data: pulls } = await github.rest.pulls.list({
+              const pulls = await github.paginate(github.rest.pulls.list, {
                 owner, repo, state: 'open', per_page: 100,
               });
               const matched = pulls.filter(p => p.head.sha === headSha);

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -4,6 +4,8 @@ name: PR Labels
 on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review, converted_to_draft, edited, reopened, closed]
+  check_suite:
+    types: [completed]
   workflow_run:
     workflows: ["Linting", "Unit Tests", "Sanity", "PR Review Trigger", "Codecov", "SonarCloud"]
     types: [completed]
@@ -39,7 +41,18 @@ jobs:
             // --- Determine PR number ---
             let prNumber;
 
-            if (context.eventName === 'workflow_run') {
+            if (context.eventName === 'check_suite') {
+              const headSha = context.payload.check_suite.head_sha;
+              const { data: pulls } = await github.rest.pulls.list({
+                owner, repo, state: 'open', per_page: 100,
+              });
+              const matched = pulls.filter(p => p.head.sha === headSha);
+              if (matched.length === 0) {
+                core.info('No open PR found for this check suite');
+                return;
+              }
+              prNumber = matched[0].number;
+            } else if (context.eventName === 'workflow_run') {
               const sourceEvent = context.payload.workflow_run.event;
               if (!['pull_request', 'pull_request_review', 'workflow_run'].includes(sourceEvent)) {
                 core.info(`Ignoring workflow_run from ${sourceEvent}`);

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -5,7 +5,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review, converted_to_draft, edited, reopened, closed]
   workflow_run:
-    workflows: ["Linting", "Unit Tests", "Sanity", "PR Review Trigger"]
+    workflows: ["Linting", "Unit Tests", "Sanity", "PR Review Trigger", "Codecov", "SonarCloud"]
     types: [completed]
 
 permissions:
@@ -41,7 +41,7 @@ jobs:
 
             if (context.eventName === 'workflow_run') {
               const sourceEvent = context.payload.workflow_run.event;
-              if (!['pull_request', 'pull_request_review'].includes(sourceEvent)) {
+              if (!['pull_request', 'pull_request_review', 'workflow_run'].includes(sourceEvent)) {
                 core.info(`Ignoring workflow_run from ${sourceEvent}`);
                 return;
               }


### PR DESCRIPTION
## Description

- **What is being changed?** Three fixes to the PR label workflow triggers and PR resolution logic.
- **Why is this change needed?** Two issues discovered during testing:
  1. **Chained workflows**: Codecov and SonarCloud run as `workflow_run` off Unit Tests. By the time they post failing checks, the labeler has already evaluated CI as passing.
  2. **Cross-fork PRs**: `workflow_run` only fires for runs in the same repo. Fork PR CI runs on the fork, so the upstream labeler never gets notified when CI completes.
- **How does this change address the issue?**
  1. Adds `Codecov` and `SonarCloud` to the `workflow_run` triggers (same-repo PRs)
  2. Adds `workflow_run` to the source-event allow-list (Codecov/SonarCloud are triggered by `workflow_run`)
  3. Adds `check_suite: completed` trigger — fires on the base repo for ALL PRs including forks, resolves PR by matching `head_sha`

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions

### Steps to Test
1. Open a PR from a fork — verify labels are applied after CI completes
2. Open a PR with Codecov coverage failures — verify `fix-ci` + `blocked` labels appear
3. Open a draft PR — verify `WIP` label is applied immediately

### Expected Results
- Fork PRs get labeled correctly via `check_suite` events
- Codecov/SonarCloud failures produce `fix-ci` + `blocked` labels
- Same-repo PRs continue to work via `workflow_run`

Assisted-by: Claude Code / Opus 4.6 (Anthropic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow expanded to include Codecov and SonarCloud.
  * Workflow-run trigger allowlist broadened to accept additional workflow_run events.
  * PR resolution improved to map check-suite events to their corresponding open pull requests.
  * Labeling job strengthened with event-specific guards and refined concurrency handling to avoid conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->