### PR TITLE
[AAP-75696] fix(ci): exclude Konflux ATF from PR label CI evaluation

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -4,6 +4,9 @@ name: PR Labels
 on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review, converted_to_draft, edited, reopened, closed]
+  # check_suite fires on the base repo for all PRs, including cross-fork PRs
+  # where workflow_run doesn't trigger. Filter to non-GitHub-Actions suites to
+  # avoid duplicating runs already handled by workflow_run.
   check_suite:
     types: [completed]
   workflow_run:
@@ -18,6 +21,12 @@ permissions:
 
 jobs:
   label:
+    if: >-
+      github.event_name != 'check_suite'
+      || github.event.check_suite.app.slug != 'github-actions'
+    concurrency:
+      group: pr-labels-${{ github.event.check_suite.head_sha || github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.run_id }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
@@ -42,16 +51,23 @@ jobs:
             let prNumber;
 
             if (context.eventName === 'check_suite') {
-              const headSha = context.payload.check_suite.head_sha;
-              const pulls = await github.paginate(github.rest.pulls.list, {
-                owner, repo, state: 'open', per_page: 100,
-              });
-              const matched = pulls.filter(p => p.head.sha === headSha);
-              if (matched.length === 0) {
-                core.info('No open PR found for this check suite');
-                return;
+              // check_suite.pull_requests is populated for same-repo PRs (fast path);
+              // for fork PRs it's empty, so fall back to paginating all open PRs.
+              const csPulls = context.payload.check_suite.pull_requests || [];
+              if (csPulls.length > 0) {
+                prNumber = csPulls[0].number;
+              } else {
+                const headSha = context.payload.check_suite.head_sha;
+                const pulls = await github.paginate(github.rest.pulls.list, {
+                  owner, repo, state: 'open', per_page: 100,
+                });
+                const matched = pulls.filter(p => p.head.sha === headSha);
+                if (matched.length === 0) {
+                  core.info('No open PR found for this check suite');
+                  return;
+                }
+                prNumber = matched[0].number;
               }
-              prNumber = matched[0].number;
             } else if (context.eventName === 'workflow_run') {
               const sourceEvent = context.payload.workflow_run.event;
               if (!['pull_request', 'pull_request_review', 'workflow_run'].includes(sourceEvent)) {

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -43,7 +43,7 @@ jobs:
 
             if (context.eventName === 'check_suite') {
               const headSha = context.payload.check_suite.head_sha;
-              const { data: pulls } = await github.rest.pulls.list({
+              const pulls = await github.paginate(github.rest.pulls.list, {
                 owner, repo, state: 'open', per_page: 100,
               });
               const matched = pulls.filter(p => p.head.sha === headSha);

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -4,6 +4,8 @@ name: PR Labels
 on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review, converted_to_draft, edited, reopened, closed]
+  check_suite:
+    types: [completed]
   workflow_run:
     workflows: ["Linting", "Unit Tests", "Sanity", "PR Review Trigger", "Codecov", "SonarCloud"]
     types: [completed]
@@ -39,7 +41,18 @@ jobs:
             // --- Determine PR number ---
             let prNumber;
 
-            if (context.eventName === 'workflow_run') {
+            if (context.eventName === 'check_suite') {
+              const headSha = context.payload.check_suite.head_sha;
+              const { data: pulls } = await github.rest.pulls.list({
+                owner, repo, state: 'open', per_page: 100,
+              });
+              const matched = pulls.filter(p => p.head.sha === headSha);
+              if (matched.length === 0) {
+                core.info('No open PR found for this check suite');
+                return;
+              }
+              prNumber = matched[0].number;
+            } else if (context.eventName === 'workflow_run') {
               const sourceEvent = context.payload.workflow_run.event;
               if (!['pull_request', 'pull_request_review', 'workflow_run'].includes(sourceEvent)) {
                 core.info(`Ignoring workflow_run from ${sourceEvent}`);

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -288,9 +288,11 @@ jobs:
                 owner, repo, ref: pr.head.sha, per_page: 100,
               });
 
-              const ignoredChecks = new Set(['label', 'Konflux kflux-prd-rh02 / jewel-atf-tests-pull-request']);
+              const ignoredChecks = new Set(['label']);
+              const ignoredSuffixes = ['jewel-atf-tests-pull-request'];
               const ciChecks = checkRuns.check_runs.filter(
                 cr => !ignoredChecks.has(cr.name)
+                  && !ignoredSuffixes.some(s => cr.name.endsWith(s))
               );
 
               const allCompleted = ciChecks.length > 0

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -5,7 +5,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review, converted_to_draft, edited, reopened, closed]
   workflow_run:
-    workflows: ["Linting", "Unit Tests", "Sanity", "PR Review Trigger"]
+    workflows: ["Linting", "Unit Tests", "Sanity", "PR Review Trigger", "Codecov", "SonarCloud"]
     types: [completed]
 
 permissions:
@@ -41,7 +41,7 @@ jobs:
 
             if (context.eventName === 'workflow_run') {
               const sourceEvent = context.payload.workflow_run.event;
-              if (!['pull_request', 'pull_request_review'].includes(sourceEvent)) {
+              if (!['pull_request', 'pull_request_review', 'workflow_run'].includes(sourceEvent)) {
                 core.info(`Ignoring workflow_run from ${sourceEvent}`);
                 return;
               }

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -279,8 +279,9 @@ jobs:
                 owner, repo, ref: pr.head.sha, per_page: 100,
               });
 
+              const ignoredChecks = new Set(['label', 'Konflux kflux-prd-rh02 / jewel-atf-tests-pull-request']);
               const ciChecks = checkRuns.check_runs.filter(
-                cr => cr.name !== 'label'
+                cr => !ignoredChecks.has(cr.name)
               );
 
               const allCompleted = ciChecks.length > 0


### PR DESCRIPTION
## Summary
- Exclude Konflux ATF integration test from the PR label CI evaluation
- Konflux ATF is not a CI gate — its frequent infrastructure failures were blocking `Ready-for-review` labels on otherwise clean PRs

## Test plan
- [ ] Verify PR #92 gets `Ready-for-review` label after CI passes
- [ ] Verify PR #91 still gets `fix-ci` + `blocked` (broken lint, not Konflux)
- [ ] Verify PR #90 keeps `WIP` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration workflow to handle additional check suites and broaden support for multiple CI systems.
  * Improved concurrent execution management with better deduplication for more reliable pull request processing.
  * Refined CI check filtering to explicitly ignore specific check names and name patterns/suffixes, reducing false positives in PR automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->