### PR TITLE
[AAP-75696] feat: add Debuggernaut label for CI/CD bot PRs

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -43,6 +43,7 @@ jobs:
               'Review-provided': { color: '1d76db', description: 'Review has been submitted' },
               'Community': { color: '5319e7', description: 'Community contribution' },
               'Ready-to-merge': { color: '0e8a16', description: 'PR is approved and CI is passing' },
+              'Debuggernaut': { color: 'e6007a', description: 'PR created by the CI/CD bot' },
             };
 
             const { owner, repo } = context.repo;
@@ -239,6 +240,14 @@ jobs:
               await addLabel('Community');
             } else {
               await removeLabel('Community');
+            }
+
+            // --- Debuggernaut (CI/CD bot PRs) ---
+            const botLogin = 'aap-platform-services-cicd-bot-sa';
+            if (pr.user.login.toLowerCase() === botLogin.toLowerCase()) {
+              await addLabel('Debuggernaut');
+            } else {
+              await removeLabel('Debuggernaut');
             }
 
             // --- Reviews (latest state per reviewer) ---

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -43,7 +43,7 @@ jobs:
               'Review-provided': { color: '1d76db', description: 'Review has been submitted' },
               'Community': { color: '5319e7', description: 'Community contribution' },
               'Ready-to-merge': { color: '0e8a16', description: 'PR is approved and CI is passing' },
-              'Debuggernaut': { color: 'e6007a', description: 'PR created by the CI/CD bot' },
+              'Debuggernaut': { color: '00008b', description: 'PR created by the CI/CD bot' },
             };
 
             const { owner, repo } = context.repo;


### PR DESCRIPTION
## Summary

- Adds a new `Debuggernaut` label (color: dark blue `#00008b`) to the PR label workflow
- Automatically applied to all PRs created by `aap-platform-services-cicd-bot-sa`
- Removed if the PR author is anyone else (handles label consistency on re-runs)

## Test plan

- [ ] Verify the label is created in the repo on first workflow run
- [ ] Confirm a PR from `aap-platform-services-cicd-bot-sa` gets the `Debuggernaut` label
- [ ] Confirm PRs from other users do not get the label

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * PR labeling workflow updated to automatically add or remove a new "Debuggernaut" label when a PR is authored by the configured CI/CD bot, ensuring consistent CI/CD labeling across PR events. No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->