### PR TITLE
[AAP-76814] Short-circuit migrate_service_data when data is already synchronized

### DIFF
--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -134,6 +134,10 @@ class Command(BaseCommand):
         """
         self._warn_ignored_flags(options)
 
+        if MigrateServiceDataHasRan.has_migration_completed():
+            self.stdout.write("Migration has already completed. Skipping.")
+            return
+
         # Force merge options to True as per requirements
         merge_teams = True
         merge_organizations = True
@@ -303,6 +307,19 @@ class Command(BaseCommand):
                 continue
         return failed_services
 
+    def _is_service_already_synced(self) -> bool:
+        """Check if all resource types for the current service have already been migrated."""
+        for resource_type_name in self.resource_types_to_migrate:
+            filters = {
+                "service_id": self.upstream_service_id,
+                "is_partially_migrated": "false",
+                "content_type__resource_type__name": resource_type_name,
+            }
+            data = self.client.list_resources(filters=filters).json()
+            if data["count"] > 0:
+                return False
+        return True
+
     def _migrate_single_service(
         self,
         service_api: ServiceAPIRoute,
@@ -349,6 +366,10 @@ class Command(BaseCommand):
 
         service_api.service_cluster.service_id = self.upstream_service_id
         service_api.service_cluster.save()
+
+        if self._is_service_already_synced():
+            self.stdout.write(f"Service {service_slug} is already synchronized — no unmigrated resources found. Skipping migration.")
+            return True, None
 
         self.stdout.write(
             f"Migrating {', '.join(self.resource_types_to_migrate.keys())} from {upstream_service_type}, id: {self.upstream_service_id} into Gateway"

--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -367,19 +367,18 @@ class Command(BaseCommand):
         service_api.service_cluster.service_id = self.upstream_service_id
         service_api.service_cluster.save()
 
-        if self._is_service_already_synced():
-            self.stdout.write(f"Service {service_slug} is already synchronized — no unmigrated resources found. Skipping migration.")
-            return True, None
-
-        self.stdout.write(
-            f"Migrating {', '.join(self.resource_types_to_migrate.keys())} from {upstream_service_type}, id: {self.upstream_service_id} into Gateway"
-        )
-
-        # Delete the legacy authenticators after migration, along with their associated authenticatorusers
+        # No-op if legacy authenticators were already deleted on a previous run
         self.delete_legacy_authenticators()
 
-        for r_type in self.resource_types_to_migrate.keys():
-            self.migrate_resource(r_type)
+        if self._is_service_already_synced():
+            self.stdout.write(f"Service {service_slug} is already synchronized — skipping resource migration.")
+        else:
+            self.stdout.write(
+                f"Migrating {', '.join(self.resource_types_to_migrate.keys())} from {upstream_service_type}, id: {self.upstream_service_id} into Gateway"
+            )
+
+            for r_type in self.resource_types_to_migrate.keys():
+                self.migrate_resource(r_type)
 
         self.migrate_role_assignments(AssignmentActorType.USER, service_slug, service_type_name)
         self.migrate_role_assignments(AssignmentActorType.TEAM, service_slug, service_type_name)

--- a/aap_gateway_api/tests/management/test_migrate_resources.py
+++ b/aap_gateway_api/tests/management/test_migrate_resources.py
@@ -18,6 +18,14 @@ from aap_gateway_api.tests.service_test_app.launch import launch_service
 SEP_CHAR = "_"
 
 
+@pytest.fixture(autouse=True)
+def reset_migration_flag():
+    """Ensure the MigrateServiceDataHasRan flag is False before each test."""
+    from aap_gateway_api.models.migrate_data import MigrateServiceDataHasRan
+
+    MigrateServiceDataHasRan.mark_migration_not_completed()
+
+
 # Friendly reminder to all who come after me, this test file uses test fixtures defined
 # in module: aap_gateway_api/tests/service_test_app/fixtures/migration_tests.py
 # It might not be obvious because the test fixtures are not imported, the name of the
@@ -619,6 +627,8 @@ def test_migration_skips_when_already_synced(admin_user, capsys, service_api_rou
                 "service_type": "controller",
             }
             mock_client.list_resources.return_value.json.return_value = {"count": 0, "results": []}
+            mock_client.list_user_assignments.return_value.json.return_value = {"count": 0, "results": [], "next": None}
+            mock_client.list_team_assignments.return_value.json.return_value = {"count": 0, "results": [], "next": None}
             return mock_client
 
         mock_client_class.side_effect = mock_client_factory
@@ -627,8 +637,10 @@ def test_migration_skips_when_already_synced(admin_user, capsys, service_api_rou
 
         captured = capsys.readouterr()
         assert "already synchronized" in captured.out
-        assert "Skipping migration" in captured.out
-        assert "Migrating" not in captured.out
+        assert "skipping resource migration" in captured.out
+        # Resource migration is skipped but role assignments still run
+        assert "Migrating data for" not in captured.out
+        assert "role assignments" in captured.out
 
 
 @pytest.mark.django_db(transaction=True)
@@ -648,8 +660,6 @@ def test_migration_proceeds_when_not_synced(admin_user, capsys, service_api_rout
                 "service_id": str(uuid.uuid4()),
                 "service_type": "controller",
             }
-            # First call returns count > 0 (for sync check on first resource type),
-            # subsequent calls return count 0 (for the migrate_resource loop exit)
             mock_client.list_resources.return_value.json.return_value = {"count": 1, "results": []}
             mock_client.list_user_assignments.return_value.json.return_value = {"count": 0, "results": [], "next": None}
             mock_client.list_team_assignments.return_value.json.return_value = {"count": 0, "results": [], "next": None}
@@ -657,15 +667,11 @@ def test_migration_proceeds_when_not_synced(admin_user, capsys, service_api_rout
 
         mock_client_class.side_effect = mock_client_factory
 
-        # Migration will attempt to proceed (and may hit errors on the mock data,
-        # but the point is it should NOT short-circuit)
-        try:
-            call_command("migrate_service_data", username=admin_user.username)
-        except Exception:
-            pass
+        call_command("migrate_service_data", username=admin_user.username)
 
         captured = capsys.readouterr()
         assert "already synchronized" not in captured.out
+        assert "Migrating data for" in captured.out
 
 
 @pytest.mark.django_db(transaction=True)
@@ -1106,8 +1112,8 @@ def test_delete_legacy_authenticators_integration_with_migration(admin_user, cap
             "service_type": "controller",
         }
         mock_client.list_resources.return_value.json.return_value = {"count": 0, "results": []}
-        mock_client.list_user_assignments.return_value.json.return_value = {"count": 0, "results": []}
-        mock_client.list_team_assignments.return_value.json.return_value = {"count": 0, "results": []}
+        mock_client.list_user_assignments.return_value.json.return_value = {"count": 0, "results": [], "next": None}
+        mock_client.list_team_assignments.return_value.json.return_value = {"count": 0, "results": [], "next": None}
         mock_client_class.return_value = mock_client
 
         # Run migration

--- a/aap_gateway_api/tests/management/test_migrate_resources.py
+++ b/aap_gateway_api/tests/management/test_migrate_resources.py
@@ -602,6 +602,73 @@ def test_migration_error_handling_and_summary(admin_user, capsys, service_api_ro
 
 
 @pytest.mark.django_db(transaction=True)
+def test_migration_skips_when_already_synced(admin_user, capsys, service_api_route_controller, patched_resource_client, system_user):
+    """Test that migration short-circuits when all resources are already migrated."""
+
+    with (
+        patch('aap_gateway_api.utils.resources_client.GWResourceAPIClient') as mock_client_class,
+        patch('aap_gateway_api.management.commands.migrate_service_data.Command.load_types_and_permissions'),
+    ):
+
+        def mock_client_factory(service_api, *args, **kwargs):
+            mock_client = Mock()
+            mock_client.service = service_api
+            mock_client.user = admin_user
+            mock_client.get_service_metadata.return_value.json.return_value = {
+                "service_id": str(uuid.uuid4()),
+                "service_type": "controller",
+            }
+            mock_client.list_resources.return_value.json.return_value = {"count": 0, "results": []}
+            return mock_client
+
+        mock_client_class.side_effect = mock_client_factory
+
+        call_command("migrate_service_data", username=admin_user.username)
+
+        captured = capsys.readouterr()
+        assert "already synchronized" in captured.out
+        assert "Skipping migration" in captured.out
+        assert "Migrating" not in captured.out
+
+
+@pytest.mark.django_db(transaction=True)
+def test_migration_proceeds_when_not_synced(admin_user, capsys, service_api_route_controller, patched_resource_client, system_user):
+    """Test that migration proceeds normally when unmigrated resources exist."""
+
+    with (
+        patch('aap_gateway_api.utils.resources_client.GWResourceAPIClient') as mock_client_class,
+        patch('aap_gateway_api.management.commands.migrate_service_data.Command.load_types_and_permissions'),
+    ):
+
+        def mock_client_factory(service_api, *args, **kwargs):
+            mock_client = Mock()
+            mock_client.service = service_api
+            mock_client.user = admin_user
+            mock_client.get_service_metadata.return_value.json.return_value = {
+                "service_id": str(uuid.uuid4()),
+                "service_type": "controller",
+            }
+            # First call returns count > 0 (for sync check on first resource type),
+            # subsequent calls return count 0 (for the migrate_resource loop exit)
+            mock_client.list_resources.return_value.json.return_value = {"count": 1, "results": []}
+            mock_client.list_user_assignments.return_value.json.return_value = {"count": 0, "results": [], "next": None}
+            mock_client.list_team_assignments.return_value.json.return_value = {"count": 0, "results": [], "next": None}
+            return mock_client
+
+        mock_client_class.side_effect = mock_client_factory
+
+        # Migration will attempt to proceed (and may hit errors on the mock data,
+        # but the point is it should NOT short-circuit)
+        try:
+            call_command("migrate_service_data", username=admin_user.username)
+        except Exception:
+            pass
+
+        captured = capsys.readouterr()
+        assert "already synchronized" not in captured.out
+
+
+@pytest.mark.django_db(transaction=True)
 def test_no_services_found_error(admin_user):
     """Test error when no DefaultServiceType services are found"""
     # In a clean test environment with no service fixtures, the command should fail


### PR DESCRIPTION
## Summary
- Add early-exit check in `handle()` using `MigrateServiceDataHasRan` flag to skip the entire command when migration has previously completed (also addresses AAP-77663)
- Add per-service unmigrated resource count check in `_migrate_single_service()` to skip services where all resources have already been migrated, handling the crash-before-flag-set edge case
- Add tests for both short-circuit and proceed-normally paths

## Context

The `migrate_service_data` command runs on every operator reconcile loop with no guard for whether migration has already completed. At scale (100k+ resources), this causes hours of unnecessary API calls and DB load on every reconcile. Related to AAP-77588 (Kyndryl escalation).

Two defense-in-depth layers:
1. **`MigrateServiceDataHasRan` check** — instant bail if the flag is set (covers the normal case)
2. **Per-service unmigrated count check** — queries each resource type filtered by upstream `service_id`; if all return count=0, the service is already synced (covers the crash-before-flag-set case)

## Test plan
- [ ] Existing tests pass (`test_migrate_resources.py`)
- [ ] New test: `test_migration_skips_when_already_synced` — verifies short-circuit fires when count=0
- [ ] New test: `test_migration_proceeds_when_not_synced` — verifies migration proceeds when count>0
- [ ] Manual: verified on aap-dev cluster — second run drops from 4m11s to 5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Migration now detects and skips services already synchronized, avoiding redundant resource migration steps
  * Command exits early if the overall migration flag indicates completion
  * Role-assignment migration for users and teams continues to run regardless of resource sync state

* **Tests**
  * Added tests and an autouse fixture to verify skip behavior when services are synchronized and normal execution when not
<!-- end of auto-generated comment: release notes by coderabbit.ai -->