### PR TITLE
[AAP-76815] Replace per-resource GETs with bulk paginated list fetches

### DIFF
--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple, Type
 
 from ansible_base.authentication.models import AuthenticatorUser
 from ansible_base.authentication.models.authenticator import Authenticator
+from ansible_base.lib.utils.settings import get_setting
 from ansible_base.rbac.models import DABContentType, DABPermission, RoleDefinition, RoleTeamAssignment, RoleUserAssignment
 from ansible_base.rbac.remote import RemoteObject
 from ansible_base.resource_registry.constants import (
@@ -16,6 +17,7 @@ from ansible_base.resource_registry.constants import (
 )
 from ansible_base.resource_registry.models import Resource, ResourceType, service_id
 from ansible_base.resource_registry.rest_client import ResourceRequestBody
+from ansible_base.rest_pagination.default_paginator import DEFAULT_MAX_PAGE_SIZE
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AbstractUser
@@ -58,6 +60,9 @@ class Command(BaseCommand):
     Important: Users are never fully migrated - only the admin user is merged,
     while other users are partially migrated to preserve authentication state.
     """
+
+    RESOURCE_DATA_FILTERS = {"extra_fields": "resource_data"}
+    BIG_PAGE_FILTERS = {"page_size": str(get_setting('RESOURCE_LIST_MAX_PAGE_SIZE', DEFAULT_MAX_PAGE_SIZE))}
 
     # Service processing order - Controller first to establish priority for user merging
     SERVICE_TYPE_ORDER = [
@@ -271,7 +276,7 @@ class Command(BaseCommand):
             service_slug = service_api.api_slug
             try:
                 client = resources_client.GWResourceAPIClient(service_api, raise_if_bad_request=True, user=user)
-                big_page_filter = {"page_size": "200"}
+                big_page_filter = self.BIG_PAGE_FILTERS
 
                 # Load types into system
                 response = client.list_role_types(filters=big_page_filter)
@@ -686,6 +691,9 @@ class Command(BaseCommand):
         """
         Retrieves and filters resources for a given resource type.
         """
+        # Use default page_size here; resource_data triggers per-item content_object
+        # serialization that cannot be prefetched, so larger pages risk timeouts.
+        filters = {**filters, **self.RESOURCE_DATA_FILTERS}
         data = self.client.list_resources(filters=filters).json()
         self.stdout.write(f"Items remaining: {data['count']}")
         results = data['results']
@@ -726,16 +734,13 @@ class Command(BaseCommand):
         resource_ansible_id = upstream_resource_item["ansible_id"]
         resource_type = resource_context["type"]
 
-        # Currently, we're making a GET request to the upstream service for every single resource
-        # This implementation is non-optimal. However, we can leave this as is for now
-        # since there is an ongoing initiative to rework the migration process
+        if "resource_data" not in upstream_resource_item:
+            raise RuntimeError(
+                f"Resource {resource_ansible_id} is missing 'resource_data'. Ensure all services are running a version of DAB that supports extra_fields."
+            )
 
-        # Fetch the complete resource data from the upstream service (Controller/Hub/EDA)
-        # This contains the full API response structure with metadata, ansible_id, service_id, resource_data, additional_data, etc.
-        upstream_resource = self.client.get_resource(resource_ansible_id).json()
+        upstream_resource = upstream_resource_item
 
-        # Extract and validate the core resource data from the upstream response
-        # This is the clean, validated resource data ready for Gateway use
         validated_resource_data = self._deserialize_and_validate_resource_data(upstream_resource, resource_context["type_serializer"])
 
         # Sync superuser flags for user resources
@@ -985,12 +990,12 @@ class Command(BaseCommand):
         page = 1
 
         while True:
-            data = client.list_resources(filters={**filters, "page": page}).json()
+            # No page_size override; resource_data serialization is expensive per item
+            data = client.list_resources(filters={**filters, **self.RESOURCE_DATA_FILTERS, "page": page}).json()
 
             for user_item in data["results"]:
-                user_detail = client.get_resource(user_item["ansible_id"]).json()
-                username = user_detail["resource_data"]["username"]
-                resource_data = user_detail["resource_data"]
+                resource_data = user_item["resource_data"]
+                username = resource_data["username"]
 
                 if resource_data.get("is_superuser", False):
                     controller_superusers.add(username)
@@ -1058,16 +1063,16 @@ class Command(BaseCommand):
         demoted_users = []
         page = 1
         while True:
-            data = client.list_resources(filters={**filters, "page": page}).json()
+            # No page_size override; resource_data serialization is expensive per item
+            data = client.list_resources(filters={**filters, **self.RESOURCE_DATA_FILTERS, "page": page}).json()
 
             for user_item in data["results"]:
-                user_detail = client.get_resource(user_item["ansible_id"]).json()
-                username = user_detail["resource_data"]["username"]
-                is_superuser = user_detail["resource_data"].get("is_superuser", False)
+                resource_data = user_item["resource_data"]
+                username = resource_data["username"]
+                is_superuser = resource_data.get("is_superuser", False)
 
-                # If user is superuser in service but not in Gateway, demote them
                 if is_superuser and username not in gateway_superusers:
-                    updated_resource_data = user_detail["resource_data"].copy()
+                    updated_resource_data = resource_data.copy()
                     updated_resource_data["is_superuser"] = False
 
                     update_payload = {"resource_data": updated_resource_data}
@@ -1343,7 +1348,7 @@ class Command(BaseCommand):
         total_count = None  # we will check this on each page to see if anything changed
         while True:
             logger.info(f"Fetching page {page} of role {assignment_actor.value} assignments from {service_slug}")
-            filters: Dict[str, int | str] = {'page': page}
+            filters: Dict[str, int | str] = {'page': page, **self.BIG_PAGE_FILTERS}
             if role_definitions_to_exclude:
                 filters['not__role_definition__name__in'] = ','.join(role_definitions_to_exclude)
             if assignment_actor == AssignmentActorType.USER:

--- a/aap_gateway_api/tests/management/test_migrate_resources.py
+++ b/aap_gateway_api/tests/management/test_migrate_resources.py
@@ -675,6 +675,62 @@ def test_migration_proceeds_when_not_synced(admin_user, capsys, service_api_rout
 
 
 @pytest.mark.django_db(transaction=True)
+def test_migration_uses_bulk_fetch(admin_user, capsys, service_api_route_controller, patched_resource_client, system_user):
+    """Test that migration uses list_resources with extra_fields instead of individual get_resource calls."""
+
+    with (
+        patch('aap_gateway_api.utils.resources_client.GWResourceAPIClient') as mock_client_class,
+        patch('aap_gateway_api.management.commands.migrate_service_data.Command.load_types_and_permissions'),
+    ):
+        created_clients = []
+
+        def mock_client_factory(service_api, *args, **kwargs):
+            mock_client = Mock()
+            mock_client.service = service_api
+            mock_client.user = admin_user
+            mock_client.get_service_metadata.return_value.json.return_value = {
+                "service_id": str(uuid.uuid4()),
+                "service_type": "controller",
+            }
+            # First call returns count=1 so _is_service_already_synced() returns False
+            # and migration proceeds. Subsequent calls return count=0 so the
+            # migrate_resource loop exits immediately.
+            responses = [Mock(json=Mock(return_value={"count": 1, "results": []}))]
+            responses += [Mock(json=Mock(return_value={"count": 0, "results": []}))] * 20
+            mock_client.list_resources.side_effect = responses
+            mock_client.list_user_assignments.return_value.json.return_value = {"count": 0, "results": [], "next": None}
+            mock_client.list_team_assignments.return_value.json.return_value = {"count": 0, "results": [], "next": None}
+            created_clients.append(mock_client)
+            return mock_client
+
+        mock_client_class.side_effect = mock_client_factory
+
+        call_command("migrate_service_data", username=admin_user.username)
+
+        assert created_clients, "Expected GWResourceAPIClient to be instantiated"
+        for mock_instance in created_clients:
+            mock_instance.get_resource.assert_not_called()
+            assert any(call.kwargs.get("filters", {}).get("extra_fields") == "resource_data" for call in mock_instance.list_resources.call_args_list), (
+                "Expected list_resources to be called with extra_fields=resource_data"
+            )
+
+        captured = capsys.readouterr()
+        assert "Migration Summary" in captured.out
+        assert "Migrating data for" in captured.out
+
+
+@pytest.mark.django_db
+def test_process_migrate_resource_item_raises_on_missing_resource_data():
+    """Test that _process_and_migrate_resource_item raises when resource_data is missing."""
+    cmd = MigrateCommand()
+    resource_item = {"ansible_id": "test-id-123", "name": "test"}
+    resource_context = {"type": Mock()}
+
+    with pytest.raises(RuntimeError, match="missing 'resource_data'"):
+        cmd._process_and_migrate_resource_item(resource_item, resource_context)
+
+
+@pytest.mark.django_db(transaction=True)
 def test_no_services_found_error(admin_user):
     """Test error when no DefaultServiceType services are found"""
     # In a clean test environment with no service fixtures, the command should fail
@@ -1699,25 +1755,14 @@ def test_ensure_controller_gateway_superusers_scenarios(
     # Mock client with Controller superusers
     mock_client = Mock()
 
-    # Mock list_resources response (returns items with ansible_id)
+    # Mock list_resources response with resource_data included (bulk fetch)
     list_results = []
-    get_resource_responses = {}
 
     for i, (username, is_superuser) in enumerate(controller_users):
         ansible_id = f"ansible-id-{i}"
-        list_results.append({"ansible_id": ansible_id})
-        # Mock get_resource response for each user
-        get_resource_responses[ansible_id] = {"resource_data": {"username": username, "is_superuser": is_superuser}}
+        list_results.append({"ansible_id": ansible_id, "resource_data": {"username": username, "is_superuser": is_superuser}})
 
-    mock_client.list_resources.return_value.json.return_value = {"count": len(controller_users), "results": list_results, "next": None}  # No pagination
-
-    # Mock get_resource to return the appropriate response for each ansible_id
-    def mock_get_resource(ansible_id):
-        mock_response = Mock()
-        mock_response.json.return_value = get_resource_responses[ansible_id]
-        return mock_response
-
-    mock_client.get_resource.side_effect = mock_get_resource
+    mock_client.list_resources.return_value.json.return_value = {"count": len(controller_users), "results": list_results, "next": None}
 
     with patch('aap_gateway_api.utils.resources_client.GWResourceAPIClient', return_value=mock_client):
         if expected_errors:
@@ -1769,18 +1814,14 @@ def mock_controller_client(service_api_route_controller):
     def run(page_data, resource_data, admin_user):
         def mock_list_resources(filters=None):
             page = filters["page"]
+            response = page_data[page].copy()
+            # Merge resource_data into list results so the bulk-fetch path works
+            response["results"] = [{**item, **resource_data.get(item["ansible_id"], {})} for item in response["results"]]
             mock_response = Mock()
-            mock_response.json.return_value = page_data[page]
+            mock_response.json.return_value = response
             return mock_response
 
         mock_client.list_resources.side_effect = mock_list_resources
-
-        def mock_get_resource(ansible_id):
-            mock_response = Mock()
-            mock_response.json.return_value = resource_data[ansible_id]
-            return mock_response
-
-        mock_client.get_resource.side_effect = mock_get_resource
 
         cmd = MigrateCommand()
         with patch('aap_gateway_api.utils.resources_client.GWResourceAPIClient', return_value=mock_client):
@@ -1825,8 +1866,8 @@ def test_collect_controller_superusers_pagination(admin_user, mock_controller_cl
     result = run(page_data, resource_data, admin_user)
 
     assert result == {"super1", "super2"}
-    mock_client.list_resources.assert_any_call(filters={"content_type__resource_type__name": "shared.user", "page": 1})
-    mock_client.list_resources.assert_any_call(filters={"content_type__resource_type__name": "shared.user", "page": 2})
+    mock_client.list_resources.assert_any_call(filters={"content_type__resource_type__name": "shared.user", "extra_fields": "resource_data", "page": 1})
+    mock_client.list_resources.assert_any_call(filters={"content_type__resource_type__name": "shared.user", "extra_fields": "resource_data", "page": 2})
     assert mock_client.list_resources.call_count == 2
 
 
@@ -1860,6 +1901,53 @@ def test_collect_controller_superusers_empty_results(admin_user, mock_controller
     result = run(page_data, {}, admin_user)
 
     assert result == set()
+
+
+# =============================================================================
+# Tests for _demote_extra_superusers pagination
+# =============================================================================
+
+
+@pytest.mark.django_db
+def test_demote_extra_superusers_pagination(admin_user, service_api_route_hub, capsys):
+    """Test _demote_extra_superusers handles paginated results and demotes correctly."""
+    cmd = MigrateCommand()
+    mock_client = Mock()
+
+    page_data = {
+        1: {
+            "results": [
+                {"ansible_id": "id-1", "resource_data": {"username": "extra_super", "is_superuser": True}},
+            ],
+            "next": "http://example.com/page=2",
+        },
+        2: {
+            "results": [
+                {"ansible_id": "id-2", "resource_data": {"username": "normal_user", "is_superuser": False}},
+            ],
+            "next": None,
+        },
+    }
+
+    def mock_list_resources(filters=None):
+        page = filters["page"]
+        mock_response = Mock()
+        mock_response.json.return_value = page_data[page]
+        return mock_response
+
+    mock_client.list_resources.side_effect = mock_list_resources
+    mock_client.update_resource.return_value = Mock()
+
+    gateway_superusers = {"admin"}
+
+    with patch('aap_gateway_api.utils.resources_client.GWResourceAPIClient', return_value=mock_client):
+        cmd._demote_extra_superusers(service_api_route_hub, gateway_superusers, admin_user)
+
+    mock_client.update_resource.assert_called_once()
+    assert mock_client.list_resources.call_count == 2
+
+    captured = capsys.readouterr()
+    assert "Demoted user 'extra_super'" in captured.out
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Replace individual `get_resource()` calls with `list_resources(extra_fields=resource_data)` in `_process_and_migrate_resource_item()`, `_collect_controller_superusers()`, and `_demote_extra_superusers()`
- Use default page size (50) for `resource_data` requests to avoid timeouts from `content_object` serialization cost per item
- Use `DEFAULT_MAX_PAGE_SIZE` for role assignment and type/permission fetches where serialization overhead is not a concern
- Replace hardcoded `"200"` in `load_types_and_permissions()` with `DEFAULT_MAX_PAGE_SIZE`

## Context

Depends on DAB PR [ansible/django-ansible-base#1021](https://github.com/ansible/django-ansible-base/pull/1021) which adds the `extra_fields` query parameter to the resource list endpoint.

`migrate_service_data` currently makes an individual GET for every resource because the list endpoint doesn't return `resource_data`. At production scale (~71K resources at ~170ms each), this takes ~3.5 hours. This change uses the list endpoint with `extra_fields=resource_data` to get resource data in bulk.

Page size is intentionally kept at the default (50) for `resource_data` requests because each item triggers a `content_object` generic FK lookup that cannot be prefetched. Larger pages would concentrate DB load and risk timeouts.

## Test plan
- [x] `test_migration_uses_bulk_fetch` — verifies `get_resource` is not called during migration
- [x] Existing AAP-76814 tests continue to pass (rebased on top of merged #107)
- [ ] End-to-end validation on aap-dev with seeded data (requires DAB PR to be deployed on all services)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migration now uses bulk fetching with full resource payloads in list responses, eliminating per-item detail requests and improving performance.
  * Pagination standardized across resource loading, role types/permissions, and role assignments.
  * Superuser consistency enforcement now uses data from bulk listings instead of individual detail calls.

* **Tests**
  * Added test verifying bulk fetch usage and migration output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->