### PR TITLE
[AAP-78372] Fix ping endpoint hang during DB outage

### DIFF
--- a/aap_gateway_api/settings.py
+++ b/aap_gateway_api/settings.py
@@ -2,7 +2,14 @@ import os
 
 from ansible_base.lib.dynamic_config import export, factory, load_envvars, load_python_file_with_injected_context, load_standard_settings_files
 
-from .settings_utils import _GATEWAY_ETC_DIRECTORY, load_custom_envvars, load_grpc_settings, load_oidc_provider_settings, set_secret_key
+from .settings_utils import (
+    _GATEWAY_ETC_DIRECTORY,
+    load_custom_envvars,
+    load_grpc_settings,
+    load_healthcheck_settings,
+    load_oidc_provider_settings,
+    set_secret_key,
+)
 
 DYNACONF = factory(
     __name__,
@@ -23,6 +30,7 @@ load_standard_settings_files(DYNACONF)  # /etc/ansible-automation-platform/*.yam
 load_custom_envvars(DYNACONF)  # load custom unprefixed envvars
 load_envvars(DYNACONF)  # load envvars prefixed with GATEWAY_
 set_secret_key(DYNACONF)  # set secret key based on secret key file
+load_healthcheck_settings(DYNACONF)  # create healthcheck DB alias from default
 
 load_oidc_provider_settings(DYNACONF)  # conditionally enable Gateway as OIDC Provider
 

--- a/aap_gateway_api/settings_utils.py
+++ b/aap_gateway_api/settings_utils.py
@@ -102,6 +102,25 @@ def load_grpc_settings(settings: Dynaconf) -> None:
     load_python_file_with_injected_context(settings_file_path, settings=settings)
 
 
+def load_healthcheck_settings(settings: Dynaconf) -> None:
+    """Create a 'healthcheck' DATABASES alias derived from 'default'.
+
+    Deep-copies the full default DB config via ``to_dict()`` so every key
+    (including any installer-added ones) is preserved, then overlays an
+    aggressive connect_timeout so PingView._check_db() fails fast instead
+    of blocking for ~130 s on unreachable hosts.
+    """
+    default_db = settings.DATABASES.get("default")
+    if not default_db:
+        return
+    healthcheck_db = default_db.to_dict()
+    healthcheck_db.setdefault("OPTIONS", {})["connect_timeout"] = 3
+    healthcheck_db["CONN_MAX_AGE"] = 0
+    healthcheck_db["CONN_HEALTH_CHECKS"] = True
+    healthcheck_db["TEST"] = {"MIRROR": "default"}
+    settings.set("DATABASES__healthcheck", healthcheck_db)
+
+
 def load_oidc_provider_settings(settings: Dynaconf) -> None:
     """Load OIDC provider settings.
 

--- a/aap_gateway_api/tests/views/api/v1/ping/test_ping.py
+++ b/aap_gateway_api/tests/views/api/v1/ping/test_ping.py
@@ -9,6 +9,25 @@ from aap_gateway_api.models import HTTPPort, ServiceAPIRoute
 from aap_gateway_api.version import get_aap_version
 
 
+@pytest.fixture(autouse=True)
+def _mock_ping_db_access():
+    """Mock close_old_connections and redirect healthcheck alias to the default connection.
+
+    close_old_connections would close the test DB connection, so we mock it away
+    (same pattern as test_proxy.py).  The healthcheck DATABASES alias is a separate
+    connection that @pytest.mark.django_db does not grant access to, so we redirect
+    it to the default connection which the test framework manages.
+    """
+    from django.db import connection
+
+    with (
+        mock.patch("aap_gateway_api.views.api.v1.ping.close_old_connections"),
+        mock.patch("aap_gateway_api.views.api.v1.ping.connections") as mock_conns,
+    ):
+        mock_conns.__getitem__.return_value = connection
+        yield
+
+
 @pytest.mark.django_db
 @mock.patch("aap_gateway_api.views.api.v1.ping.PingView._check_dispatcherd", return_value=True)
 @mock.patch("aap_gateway_api.views.api.v1.ping.requests.request")
@@ -80,6 +99,27 @@ def test_ping_proxy_non_200(request, mock_dispatcherd, unauthenticated_api_clien
     assert response.status_code == 200
     assert response.data['status'] == STATUS_DEGRADED
     assert response.data['proxy_status_code'] == 500
+
+
+@pytest.mark.django_db
+@mock.patch("aap_gateway_api.views.api.v1.ping.PingView._check_dispatcherd", return_value=True)
+@mock.patch("aap_gateway_api.views.api.v1.ping.requests.request")
+@mock.patch("aap_gateway_api.views.api.v1.ping.connections")
+@mock.patch("aap_gateway_api.views.api.v1.ping.close_old_connections")
+def test_ping_db_check_flushes_stale_connections(mock_close, mock_conns, request, mock_dispatcherd, unauthenticated_api_client):
+    """close_old_connections must run before the healthcheck cursor (AAP-78372)."""
+    request.return_value = mock.Mock(status_code=200, json=lambda: {"test": "test"})
+    call_order = []
+    mock_close.side_effect = lambda: call_order.append("close")
+    cursor_cm = mock.MagicMock()
+    cursor_cm.__enter__ = mock.Mock(side_effect=lambda: (call_order.append("cursor") or mock.Mock()))
+    cursor_cm.__exit__ = mock.Mock(return_value=False)
+    mock_conns.__getitem__.return_value.cursor.return_value = cursor_cm
+
+    url = get_relative_url("ping-view")
+    response = unauthenticated_api_client.get(url)
+    assert response.status_code == 200
+    assert call_order == ["close", "cursor"]
 
 
 @pytest.mark.django_db

--- a/aap_gateway_api/views/api/v1/ping.py
+++ b/aap_gateway_api/views/api/v1/ping.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import requests
 from ansible_base.lib.constants import STATUS_DEGRADED, STATUS_GOOD
 from django.conf import settings
-from django.db import connection
+from django.db import close_old_connections, connections
 from rest_framework.response import Response
 
 from aap_gateway_api.models import HTTPPort
@@ -20,7 +20,8 @@ class PingView(AnsibleBaseView):
     serializer_class = PingSerializer
 
     def _check_db(self):
-        with connection.cursor() as cursor:
+        close_old_connections()
+        with connections["healthcheck"].cursor() as cursor:
             cursor.execute("SELECT 1")
 
     def _check_dispatcherd(self):


### PR DESCRIPTION
## Description

* **What:** Introduce a dedicated `healthcheck` DATABASES alias with `connect_timeout=3` and call `close_old_connections()` before the health-check query in `PingView._check_db()`.
* **Why:** During a database restart, `PingView._check_db()` calls `connection.cursor()` which attempts a new TCP connection. If the DB host is network-unreachable, the TCP `connect()` blocks for ~130s (default Linux SYN retransmission timeout), far exceeding the K8s liveness probe's 5s `timeoutSeconds`. The `try/except` never fires because the code is stuck inside the connection attempt. After 5 consecutive probe timeouts (75s), Kubernetes kills the pod, triggering a crashloop with exponential backoff that extends the outage to 10-15 minutes.
* **How:** Two changes:
  1. A `healthcheck` DATABASES alias is created in `load_healthcheck_settings()` (called from `settings.py` after all installer overrides are applied). It deep-copies the `default` DB config via `to_dict()` and overlays `connect_timeout=3`, `CONN_MAX_AGE=0`, and `CONN_HEALTH_CHECKS=True`.
  2. `PingView._check_db()` calls `close_old_connections()` then runs `SELECT 1` on the `healthcheck` alias. This matches the existing pattern in `proxy/control_plane.py:_ensure_db_availability` (added in AAP-42378). Single attempt caps worst-case at ~3s, within the 5s probe budget.

## Type of Change

- Bug fix (non-breaking change which fixes an issue)
- Test update

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites

* Operator-based deployment with an external PostgreSQL database

### Steps to Test

1. Deploy and verify gateway is healthy via `/api/gateway/v1/ping/`
2. Trigger a DB restart (e.g. `pg_ctl restart` or cloud provider restart)
3. Monitor gateway pod behavior during and after the outage

### Expected Results

* During DB outage: ping returns HTTP 200 with `{"status": "degraded", "db_connected": false}` within 3 seconds (instead of hanging)
* Liveness probe continues passing (pod is NOT killed)
* Readiness probe fails (pod removed from endpoints — correct behavior)
* After DB recovers: gateway reconnects and becomes Ready within 1-2 minutes (no manual pod restart needed)

### Unit Tests

* `test_ping_db_check_flushes_stale_connections` verifies ordering: `close_old_connections()` is called before `connections["healthcheck"].cursor()`
* All existing ping tests pass with the autouse mock fixture (matching the `test_proxy.py` pattern)

## Additional Context

### Required Actions

* Requires downstream repository changes
  * Longer term: The operator should separate liveness from readiness probes. Liveness should not check DB at all — it should only verify the WSGI process can respond.

### Related Issues

* Fixes AAP-78372
* Related: AAP-42378 (previous partial fix — gRPC path only)

---

**Note:** This PR was developed with assistance from Claude AI assistant.