### PR TITLE
[AAP-76813] Make count validation tolerant of concurrent changes during pagination

### DIFF
--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -1435,6 +1435,6 @@ class Command(BaseCommand):
                 except Exception as e:
                     self.stderr.write(f"Error: Unable to give permission for role {assignment_actor.value} assignment, skipping: {str(e)}")
                     continue
-        except Exception:
-            self.stderr.write(f"Unable to fetch role {assignment_actor.value} assignments from {service_slug}, skipping...")
+        except Exception as e:
+            self.stderr.write(f"Unable to fetch role {assignment_actor.value} assignments from {service_slug}, skipping: {e}")
             return

--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -217,6 +217,7 @@ class Command(BaseCommand):
         migration_results = {}
         successful_services = []
         failed_services = []
+        self._services_with_count_drift = set()
 
         # Merge all partially migrated users before proceeding with migration
         self.stdout.write("\n=== Merging partially migrated users ===")
@@ -269,6 +270,16 @@ class Command(BaseCommand):
             self.stdout.write("✓ Migration flag updated: Service authentication is now enabled.")
 
             self.stdout.write("\nAll services migration completed successfully!")
+
+            if self._services_with_count_drift:
+                drift_list = ', '.join(sorted(self._services_with_count_drift))
+                self.stderr.write(
+                    self.style.WARNING(
+                        f"\nWARNING: The following services had count changes during role assignment migration: {drift_list}\n"
+                        f"This means concurrent modifications occurred while migrating. "
+                        f"Please re-run the migration to ensure all role assignments are migrated."
+                    )
+                )
 
     def load_types_and_permissions(self, service_apis, user):
         failed_services = []
@@ -1361,8 +1372,13 @@ class Command(BaseCommand):
             if total_count is None:
                 total_count = json_response.get('count', 0)
             elif total_count != json_response.get('count', 0):
-                self.stderr.write(f"Error: role {assignment_actor.value} assignment count changed from {total_count} to {json_response.get('count', 0)}")
-                raise RuntimeError(f"role {assignment_actor.value} assignment count changed during migration")
+                new_count = json_response.get('count', 0)
+                logger.warning(
+                    f"Role {assignment_actor.value} assignment count changed from {total_count} to {new_count}"
+                    " during pagination (concurrent modification); continuing but will need re-run"
+                )
+                total_count = new_count
+                self._services_with_count_drift.add(service_slug)
             for assignment in json_response.get('results', []):
                 yield assignment
             if not json_response.get('next'):
@@ -1384,39 +1400,41 @@ class Command(BaseCommand):
         4. Giving permission in gateway to the actor for the object (handling both Resources and RemoteObjects)
         """
 
-        self.stdout.write(f"Migrating {assignment_actor.value} role assignments for  from {service_slug} of type {service_type_name}")
+        self.stdout.write(f"Migrating {assignment_actor.value} role assignments from {service_slug} of type {service_type_name}")
         try:
             assignments = self._fetch_role_assignments(assignment_actor, service_slug, service_type_name)
+            for assignment in assignments:
+                log_detail = self._format_fetched_assignment_for_logging(assignment_actor, assignment)
+                self.stdout.write(f"Processing assignment in service {service_slug}: {log_detail}")
+
+                role_definition_name = assignment.get('role_definition')
+                service_actor_ansible_id = assignment.get(f'{assignment_actor.value}_ansible_id')
+
+                try:
+                    gateway_role_definition = self._resolve_role_definition(role_definition_name)
+                    if gateway_role_definition is None:
+                        continue
+
+                    gateway_actor = self._resolve_gateway_actor(assignment_actor, service_actor_ansible_id)
+                    if gateway_actor is None:
+                        continue
+
+                    gateway_content_object = self._resolve_content_object(assignment)
+                    if gateway_content_object is Command._SKIP:
+                        continue
+                except Exception as e:
+                    self.stderr.write(f"Error: Unable to process role {assignment_actor.value} assignment, skipping: {str(e)}")
+                    continue
+
+                try:
+                    if gateway_content_object:
+                        role_assignment = gateway_role_definition.give_permission(gateway_actor, gateway_content_object)
+                    else:
+                        role_assignment = gateway_role_definition.give_global_permission(gateway_actor)
+                    self.stdout.write(f"Gave permission: {self._format_migrated_assignment_for_logging(role_assignment)}")  # type: ignore
+                except Exception as e:
+                    self.stderr.write(f"Error: Unable to give permission for role {assignment_actor.value} assignment, skipping: {str(e)}")
+                    continue
         except Exception:
             self.stderr.write(f"Unable to fetch role {assignment_actor.value} assignments from {service_slug}, skipping...")
             return
-
-        for assignment in assignments:
-            self.stdout.write(f"Processing assignment in service {service_slug}: {self._format_fetched_assignment_for_logging(assignment_actor, assignment)}")
-
-            role_definition_name = assignment.get('role_definition')
-            service_actor_ansible_id = assignment.get(f'{assignment_actor.value}_ansible_id')
-
-            try:
-                gateway_role_definition = self._resolve_role_definition(role_definition_name)
-                if gateway_role_definition is None:
-                    continue
-
-                gateway_actor = self._resolve_gateway_actor(assignment_actor, service_actor_ansible_id)
-                if gateway_actor is None:
-                    continue
-
-                gateway_content_object = self._resolve_content_object(assignment)
-                if gateway_content_object is Command._SKIP:
-                    continue
-            except Exception as e:
-                self.stderr.write(f"Error: Unable to process role {assignment_actor.value} assignment, skipping: {str(e)}")
-                continue
-
-            # Create the assignment by using the give_permission method from gateway's role definition
-            if gateway_content_object:
-                role_assignment = gateway_role_definition.give_permission(gateway_actor, gateway_content_object)
-            else:
-                role_assignment = gateway_role_definition.give_global_permission(gateway_actor)
-            message = "Gave permission"
-            self.stdout.write(f"{message}: {self._format_migrated_assignment_for_logging(role_assignment)}")  # type: ignore

--- a/aap_gateway_api/tests/management/test_migrate_resources.py
+++ b/aap_gateway_api/tests/management/test_migrate_resources.py
@@ -2303,3 +2303,220 @@ def test_resolve_content_object_skip_on_missing_content_type(capsys):
     assert result is MigrateCommand._SKIP
     captured = capsys.readouterr()
     assert "Unable to find content type 'nonexistent.model'" in captured.err
+
+
+# =============================================================================
+# Tests for _fetch_role_assignments count tolerance (AAP-76813)
+# =============================================================================
+
+
+@pytest.mark.django_db
+def test_fetch_role_assignments_tolerates_count_change(capsys):
+    """Test that _fetch_role_assignments logs a warning instead of raising when count changes between pages."""
+    cmd = MigrateCommand()
+    cmd._services_with_count_drift = set()
+    mock_client = Mock()
+    cmd.client = mock_client
+
+    page1_response = Mock()
+    page1_response.json.return_value = {
+        "count": 100,
+        "results": [{"id": 1}],
+        "next": "http://example.com/page=2",
+    }
+    page2_response = Mock()
+    page2_response.json.return_value = {
+        "count": 105,
+        "results": [{"id": 2}],
+        "next": None,
+    }
+    mock_client.list_user_assignments.side_effect = [page1_response, page2_response]
+
+    results = list(cmd._fetch_role_assignments(AssignmentActorType.USER, "controller", "controller"))
+
+    assert len(results) == 2
+    assert results == [{"id": 1}, {"id": 2}]
+
+
+@pytest.mark.django_db
+def test_fetch_role_assignments_updates_total_count_on_change():
+    """Test that total_count is updated after a count change so subsequent pages compare against the new value."""
+    cmd = MigrateCommand()
+    cmd._services_with_count_drift = set()
+    mock_client = Mock()
+    cmd.client = mock_client
+
+    page1_response = Mock()
+    page1_response.json.return_value = {"count": 50, "results": [{"id": 1}], "next": "http://example.com/page=2"}
+    page2_response = Mock()
+    page2_response.json.return_value = {"count": 55, "results": [{"id": 2}], "next": "http://example.com/page=3"}
+    page3_response = Mock()
+    page3_response.json.return_value = {"count": 55, "results": [{"id": 3}], "next": None}
+
+    mock_client.list_user_assignments.side_effect = [page1_response, page2_response, page3_response]
+
+    results = list(cmd._fetch_role_assignments(AssignmentActorType.USER, "controller", "controller"))
+
+    assert len(results) == 3
+
+
+@pytest.mark.django_db
+def test_fetch_role_assignments_tracks_drift_services():
+    """Test that services with count drift are tracked in _services_with_count_drift."""
+    cmd = MigrateCommand()
+    cmd._services_with_count_drift = set()
+    mock_client = Mock()
+    cmd.client = mock_client
+
+    page1_response = Mock()
+    page1_response.json.return_value = {"count": 10, "results": [{"id": 1}], "next": "http://example.com/page=2"}
+    page2_response = Mock()
+    page2_response.json.return_value = {"count": 11, "results": [{"id": 2}], "next": None}
+
+    mock_client.list_user_assignments.side_effect = [page1_response, page2_response]
+
+    list(cmd._fetch_role_assignments(AssignmentActorType.USER, "controller", "controller"))
+
+    assert "controller" in cmd._services_with_count_drift
+
+
+@pytest.mark.django_db
+def test_fetch_role_assignments_no_drift_not_tracked():
+    """Test that services without count drift are not added to _services_with_count_drift."""
+    cmd = MigrateCommand()
+    cmd._services_with_count_drift = set()
+    mock_client = Mock()
+    cmd.client = mock_client
+
+    page1_response = Mock()
+    page1_response.json.return_value = {"count": 10, "results": [{"id": 1}], "next": "http://example.com/page=2"}
+    page2_response = Mock()
+    page2_response.json.return_value = {"count": 10, "results": [{"id": 2}], "next": None}
+
+    mock_client.list_user_assignments.side_effect = [page1_response, page2_response]
+
+    list(cmd._fetch_role_assignments(AssignmentActorType.USER, "controller", "controller"))
+
+    assert "controller" not in cmd._services_with_count_drift
+
+
+# =============================================================================
+# Tests for migrate_role_assignments try/except structure (AAP-76813)
+# =============================================================================
+
+
+@pytest.mark.django_db
+def test_migrate_role_assignments_catches_fetch_error(capsys):
+    """Test that errors during generator iteration are caught by the outer try/except."""
+    cmd = MigrateCommand()
+    cmd._services_with_count_drift = set()
+    cmd.stdout = Mock()
+    cmd.stderr = Mock()
+    mock_client = Mock()
+    cmd.client = mock_client
+
+    mock_response = Mock()
+    mock_response.json.side_effect = RuntimeError("connection lost")
+    mock_client.list_user_assignments.return_value = mock_response
+
+    cmd.migrate_role_assignments(AssignmentActorType.USER, "controller", "controller")
+
+    cmd.stderr.write.assert_any_call("Unable to fetch role user assignments from controller, skipping...")
+
+
+@pytest.mark.django_db
+def test_migrate_role_assignments_catches_give_permission_error(admin_user, capsys):
+    """Test that errors in give_permission are caught separately from fetch errors."""
+    cmd = MigrateCommand()
+    cmd._services_with_count_drift = set()
+    mock_client = Mock()
+    cmd.client = mock_client
+
+    test_user = User.objects.create(username="perm-error-user")
+    rd = RoleDefinition.objects.create(name="Test Permission Role", content_type=None)
+
+    mock_response = Mock()
+    mock_response.json.return_value = {
+        "count": 1,
+        "results": [
+            {
+                "object_ansible_id": None,
+                "object_id": None,
+                "content_type": "",
+                "role_definition": "Test Permission Role",
+                "user_ansible_id": str(test_user.resource.ansible_id),
+            }
+        ],
+        "next": None,
+    }
+    mock_client.list_user_assignments.return_value = mock_response
+
+    with patch.object(rd, 'give_global_permission', side_effect=RuntimeError("permission denied")):
+        with patch.object(MigrateCommand, '_resolve_role_definition', return_value=rd):
+            cmd.migrate_role_assignments(AssignmentActorType.USER, "controller", "controller")
+
+    captured = capsys.readouterr()
+    assert "Unable to give permission for role user assignment" in captured.err
+    assert "Unable to fetch" not in captured.err
+
+
+@pytest.mark.django_db(transaction=True)
+def test_drift_summary_warning_displayed(admin_user, capsys, service_api_route_controller, patched_resource_client, system_user):
+    """Test that services with count drift are reported in the migration summary."""
+    with (
+        patch('aap_gateway_api.utils.resources_client.GWResourceAPIClient') as mock_client_class,
+        patch('aap_gateway_api.utils.jwt_token.create_signed_jwt') as mock_jwt,
+        patch('aap_gateway_api.utils.jwt_token.get_jwt_rsa_key') as mock_key,
+        patch('aap_gateway_api.management.commands.migrate_service_data.Command._ensure_superuser_consistency') as mock_consistency_check,
+        patch('aap_gateway_api.management.commands.migrate_service_data.Command.load_types_and_permissions'),
+    ):
+        mock_jwt.return_value = 'fake-jwt-token'
+        mock_key.return_value = 'fake-key'
+        mock_consistency_check.return_value = None
+
+        mock_client = Mock()
+        _setup_basic_service_client_mocks(mock_client, service_api_route_controller, admin_user)
+        mock_client.list_resources.return_value.json.return_value = {"count": 0, "results": []}
+
+        # Simulate count drift: page 1 has count=2, page 2 has count=3
+        page1 = Mock()
+        page1.json.return_value = {"count": 2, "results": [{"id": 1}], "next": "http://example.com/page=2"}
+        page2 = Mock()
+        page2.json.return_value = {"count": 3, "results": [{"id": 2}], "next": None}
+        mock_client.list_user_assignments.side_effect = [page1, page2]
+        mock_client.list_team_assignments.return_value.json.return_value = {"count": 0, "results": [], "next": None}
+        mock_client_class.return_value = mock_client
+
+        call_command("migrate_service_data", username=admin_user.username)
+
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "count changes during role assignment migration" in captured.err
+        assert "re-run the migration" in captured.err
+
+
+@pytest.mark.django_db(transaction=True)
+def test_no_drift_summary_when_counts_stable(admin_user, capsys, service_api_route_controller, patched_resource_client, system_user):
+    """Test that no drift warning is shown when counts are stable."""
+    with (
+        patch('aap_gateway_api.utils.resources_client.GWResourceAPIClient') as mock_client_class,
+        patch('aap_gateway_api.utils.jwt_token.create_signed_jwt') as mock_jwt,
+        patch('aap_gateway_api.utils.jwt_token.get_jwt_rsa_key') as mock_key,
+        patch('aap_gateway_api.management.commands.migrate_service_data.Command._ensure_superuser_consistency') as mock_consistency_check,
+        patch('aap_gateway_api.management.commands.migrate_service_data.Command.load_types_and_permissions'),
+    ):
+        mock_jwt.return_value = 'fake-jwt-token'
+        mock_key.return_value = 'fake-key'
+        mock_consistency_check.return_value = None
+
+        mock_client = Mock()
+        _setup_basic_service_client_mocks(mock_client, service_api_route_controller, admin_user)
+        mock_client.list_resources.return_value.json.return_value = {"count": 0, "results": []}
+        mock_client.list_user_assignments.return_value.json.return_value = {"count": 0, "results": [], "next": None}
+        mock_client.list_team_assignments.return_value.json.return_value = {"count": 0, "results": [], "next": None}
+        mock_client_class.return_value = mock_client
+
+        call_command("migrate_service_data", username=admin_user.username)
+
+        captured = capsys.readouterr()
+        assert "count changes during role assignment migration" not in captured.err

--- a/aap_gateway_api/tests/management/test_migrate_resources.py
+++ b/aap_gateway_api/tests/management/test_migrate_resources.py
@@ -2311,7 +2311,7 @@ def test_resolve_content_object_skip_on_missing_content_type(capsys):
 
 
 @pytest.mark.django_db
-def test_fetch_role_assignments_tolerates_count_change(capsys):
+def test_fetch_role_assignments_tolerates_count_change(caplog):
     """Test that _fetch_role_assignments logs a warning instead of raising when count changes between pages."""
     cmd = MigrateCommand()
     cmd._services_with_count_drift = set()
@@ -2332,14 +2332,16 @@ def test_fetch_role_assignments_tolerates_count_change(capsys):
     }
     mock_client.list_user_assignments.side_effect = [page1_response, page2_response]
 
-    results = list(cmd._fetch_role_assignments(AssignmentActorType.USER, "controller", "controller"))
+    with caplog.at_level("WARNING", logger="aap.gateway.management.commands.migrate_service_data"):
+        results = list(cmd._fetch_role_assignments(AssignmentActorType.USER, "controller", "controller"))
 
     assert len(results) == 2
     assert results == [{"id": 1}, {"id": 2}]
+    assert any("assignment count changed from 100 to 105" in msg for msg in caplog.messages)
 
 
 @pytest.mark.django_db
-def test_fetch_role_assignments_updates_total_count_on_change():
+def test_fetch_role_assignments_updates_total_count_on_change(caplog):
     """Test that total_count is updated after a count change so subsequent pages compare against the new value."""
     cmd = MigrateCommand()
     cmd._services_with_count_drift = set()
@@ -2355,9 +2357,14 @@ def test_fetch_role_assignments_updates_total_count_on_change():
 
     mock_client.list_user_assignments.side_effect = [page1_response, page2_response, page3_response]
 
-    results = list(cmd._fetch_role_assignments(AssignmentActorType.USER, "controller", "controller"))
+    with caplog.at_level("WARNING", logger="aap.gateway.management.commands.migrate_service_data"):
+        results = list(cmd._fetch_role_assignments(AssignmentActorType.USER, "controller", "controller"))
 
     assert len(results) == 3
+    # Warning should fire only once (page 2 drift), not again on page 3 (count matches updated total)
+    warning_msgs = [msg for msg in caplog.messages if "assignment count changed" in msg]
+    assert len(warning_msgs) == 1
+    assert "from 50 to 55" in warning_msgs[0]
 
 
 @pytest.mark.django_db

--- a/aap_gateway_api/tests/management/test_migrate_resources.py
+++ b/aap_gateway_api/tests/management/test_migrate_resources.py
@@ -2428,7 +2428,9 @@ def test_migrate_role_assignments_catches_fetch_error(capsys):
 
     cmd.migrate_role_assignments(AssignmentActorType.USER, "controller", "controller")
 
-    cmd.stderr.write.assert_any_call("Unable to fetch role user assignments from controller, skipping...")
+    cmd.stderr.write.assert_called()
+    error_msg = str(cmd.stderr.write.call_args_list)
+    assert "Unable to fetch role user assignments from controller, skipping: connection lost" in error_msg
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- Replace `RuntimeError` with a warning log when role assignment count changes between pagination pages, so concurrent modifications no longer crash the migration
- Move the generator iteration inside the `try/except` block so errors raised during pagination are caught instead of propagating uncaught
- Fix minor typo in stdout log message

## Test plan
- [ ] Verify existing unit tests pass
- [ ] Manual test: simulate count change between pages and confirm warning is logged instead of crash
- [ ] Verify `MigrateServiceDataHasRan` flag is set after successful migration even with count drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Migration pagination now tolerates changing counts mid-run, logs affected services, and continues instead of aborting.
  * Improved migration error handling: fetch/iteration failures emit a single "Unable to fetch… skipping" and per-assignment permission failures emit "Unable to give permission…" while skipping only that assignment.
  * Permission success output standardized to "Gave permission: …" and per-assignment processing is logged.

* **Tests**
  * Added unit tests for pagination resilience, drift reporting, and the updated fetch/permission error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->