### PR TITLE
[AAP-76813] Fall back to devel when feature branch not found in dependency repos

### DIFF
--- a/tools/scripts/get_pr_checkout.py
+++ b/tools/scripts/get_pr_checkout.py
@@ -41,7 +41,6 @@ Repository Specification Format:
     - Tries each org in order until finding one with the target branch
     - All variants share the same repo name (and thus target directory)
     - For devel: falls back to default branch if no match found
-    
 
     Example: ansible/django-ansible-base
     - Tries ansible/django-ansible-base first
@@ -342,7 +341,6 @@ def process_explicit_requirements(pr_body: str, token: Optional[str]) -> list:
 def process_always_clone_repos(always_clone_repos: list, target_branch: str, token: Optional[str], repos_to_clone: list) -> None:
     """Process always-clone repos and add them to repos_to_clone list."""
     print(f"\nProcessing {len(always_clone_repos)} always-clone repo(s):")
-    errors = False
 
     for repo_variants in always_clone_repos:
         primary_repo = repo_variants[0]
@@ -375,14 +373,18 @@ def process_always_clone_repos(always_clone_repos: list, target_branch: str, tok
                 }
             )
         else:
-            print(f"##[error]❌ FATAL: No branch {target_branch} found in {repo_variants}")
-            errors = True
-
-    if errors:
-        print("##[error]")
-        print("##[error]Cannot proceed without knowing the target branch to avoid")
-        print("##[error]cloning incorrect dependency versions.")
-        sys.exit(1)
+            # Fall back to devel if the target branch doesn't exist in any variant
+            fallback_branch = "devel"
+            fallback_repo = primary_repo
+            print(f"  ⚠️  Branch '{target_branch}' not found in any variant, falling back to '{fallback_branch}' from '{fallback_repo}'")
+            repos_to_clone.append(
+                {
+                    'target_dir': target_dir,
+                    'branch': fallback_branch,
+                    'clone_url': build_clone_url(fallback_repo, token),
+                    'repo': fallback_repo,
+                }
+            )
 
 
 def validate_no_duplicate_directories(repos_to_clone: list) -> dict:

--- a/tools/scripts/tests/test_get_pr_checkout.py
+++ b/tools/scripts/tests/test_get_pr_checkout.py
@@ -354,50 +354,60 @@ class TestMainScenarios:
         assert exc_info.value.code == 0
         mock_clone.assert_called_once()
 
+    @patch("get_pr_checkout.execute_git_clone")
     @patch("get_pr_checkout.branch_exists")
-    def test_devel_fails_without_matching_branch(self, mock_branch_exists, monkeypatch):
-        """Test devel fails when no matching branch exists (no fallback)"""
+    def test_devel_fallback_when_branch_not_found(self, mock_branch_exists, mock_clone, monkeypatch):
+        """Test that when no matching branch exists, it falls back to devel"""
         monkeypatch.setenv("PR_BODY", "No requirements")
         monkeypatch.setenv("GH_TOKEN", "test_token")
         monkeypatch.setenv("GITHUB_BASE_REF", "devel")
         _set_cli_args("ansible/django-ansible-base")
 
-        # Branch doesn't exist
+        # Branch doesn't exist in any variant
         mock_branch_exists.return_value = False
+        mock_clone.return_value = True
 
         with pytest.raises(SystemExit) as exc_info:
             get_pr_checkout.main()
 
-        # Should fail - no fallback for devel
-        assert exc_info.value.code == 1
+        # Should succeed with fallback to devel
+        assert exc_info.value.code == 0
+        mock_clone.assert_called_once()
+        clone_url = mock_clone.call_args[0][0]
+        assert "ansible/django-ansible-base" in clone_url
+        assert mock_clone.call_args[0][1] == "devel"
 
+    @patch("get_pr_checkout.execute_git_clone")
     @patch("get_pr_checkout.branch_exists")
-    def test_stable_fails_without_matching_branch(self, mock_branch_exists, monkeypatch):
-        """Test stable branch fails when no matching branch exists"""
+    def test_feature_branch_fallback_to_devel(self, mock_branch_exists, mock_clone, monkeypatch):
+        """Test that feature branches fall back to devel when not found in dependency repos"""
         monkeypatch.setenv("PR_BODY", "No requirements")
         monkeypatch.setenv("GH_TOKEN", "test_token")
-        monkeypatch.setenv("GITHUB_BASE_REF", "devel")
+        monkeypatch.setenv("GITHUB_BASE_REF", "feature-sprint-2026-24-migrate_service_data")
         _set_cli_args("ansible/django-ansible-base")
 
-        # Branch doesn't exist
+        # Feature branch doesn't exist in DAB
         mock_branch_exists.return_value = False
+        mock_clone.return_value = True
 
         with pytest.raises(SystemExit) as exc_info:
             get_pr_checkout.main()
 
-        # Should fail
-        assert exc_info.value.code == 1
+        # Should succeed with fallback to devel
+        assert exc_info.value.code == 0
+        mock_clone.assert_called_once()
+        assert mock_clone.call_args[0][1] == "devel"
 
     @patch("get_pr_checkout.execute_git_clone")
     @patch("get_pr_checkout.branch_exists")
     def test_enterprise_fallback(self, mock_branch_exists, mock_clone, monkeypatch):
-        """Test enterprise repo fallback when first variant doesn't have branch"""
+        """Test enterprise repo fallback when first variant doesn't have branch but second does"""
         monkeypatch.setenv("PR_BODY", "No requirements")
         monkeypatch.setenv("GH_TOKEN", "test_token")
         monkeypatch.setenv("GITHUB_BASE_REF", "devel")
-        _set_cli_args("ansible/django-ansible-base")
+        _set_cli_args("[ansible-tower|ansible]/django-ansible-base")
 
-        # First call (enterprise) returns False, second call (public) returns True
+        # First variant (ansible-tower) returns False, second (ansible) returns True
         mock_branch_exists.side_effect = [False, True]
         mock_clone.return_value = True
 


### PR DESCRIPTION
## Summary
- When `get_pr_checkout.py` looks for a matching branch in always-clone repos (e.g., `django-ansible-base`), fall back to `devel` instead of failing if the branch doesn't exist
- Feature branches like `feature-sprint-2026-24-migrate_service_data` are gateway-specific and don't always have corresponding branches in dependency repos
- Fixes CI failures for PRs targeting feature branches that don't exist in DAB

## Test plan
- [ ] PR targeting a feature branch that doesn't exist in DAB should pass CI
- [ ] PR targeting `devel` should continue to work as before
- [ ] PR with explicit `Requires:` directive should still take priority over fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkout behavior: when the expected target branch isn’t found in any provided repository variant, the process now falls back to cloning the development branch instead of failing.

* **Tests**
  * Updated the checkout test scenarios to cover the new development-branch fallback behavior for both `devel` and feature base refs, and adjusted the enterprise fallback setup accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->