### PR TITLE
[AAP-77439] DO NOT MERGE: demo required ATF tier 1 status check

### DIFF
--- a/aap_gateway_api/views/api/v1/ping.py
+++ b/aap_gateway_api/views/api/v1/ping.py
@@ -1,15 +1,6 @@
 import logging
-from datetime import datetime
 
-import requests
-from ansible_base.lib.constants import STATUS_DEGRADED, STATUS_GOOD
-from django.conf import settings
-from django.db import close_old_connections, connections
-from rest_framework.response import Response
-
-from aap_gateway_api.models import HTTPPort
 from aap_gateway_api.serializers.status import PingSerializer
-from aap_gateway_api.version import get_aap_version
 from aap_gateway_api.views.api.v1.common import AnsibleBaseView
 
 logger = logging.getLogger('aap.gateway.views.api.v1.ping')
@@ -19,64 +10,5 @@ class PingView(AnsibleBaseView):
     permission_classes = []
     serializer_class = PingSerializer
 
-    def _check_db(self):
-        close_old_connections()
-        with connections["healthcheck"].cursor() as cursor:
-            cursor.execute("SELECT 1")
-
-    def _check_dispatcherd(self):
-        """Returns True if dispatcherd responds to alive, False if no reply, or raises on error."""
-        from dispatcherd.factories import get_control_from_settings
-
-        reply = get_control_from_settings().control_with_reply("alive", timeout=getattr(settings, "DISPATCHERD_HEALTH_CHECK_TIMEOUT", 0.25))
-        return bool(reply)
-
     def get(self, request):
-        timeout = getattr(settings, "PING_PAGE_CHECK_TIMEOUT", 5)
-        ignore_cert = getattr(settings, "PING_PAGE_CHECK_IGNORE_CERT", False)
-
-        current_time = datetime.now()
-        response = {
-            "version": get_aap_version(),
-            "pong": str(current_time),
-            "status": STATUS_GOOD,
-        }
-
-        try:
-            self._check_db()
-
-            response['db_connected'] = True
-
-            # Check the proxy (skip for unit tests) (skip if DB is not working)
-            http_port = HTTPPort.objects.filter(is_api_port=True).first()
-            if http_port:
-                ping_url = f"{'https' if http_port.use_https else 'http'}://{settings.ENVOY_HOSTNAME}:{http_port.number}/up"
-                try:
-                    proxy_response = requests.request("GET", ping_url, verify=(not ignore_cert), timeout=timeout)
-                    if proxy_response.status_code == 200:
-                        connected = True
-                    else:
-                        connected = False
-                        response['proxy_status_code'] = proxy_response.status_code
-                        response['status'] = STATUS_DEGRADED
-                except Exception as e:
-                    # Exception might expose the host names so we don't want to add a reason for the exception
-                    connected = False
-                    # We only log the exception type because the message could contain sensitive information
-                    response['proxy_exception_type'] = type(e).__name__
-                    response['status'] = STATUS_DEGRADED
-                response['proxy_connected'] = connected
-        except Exception as e:
-            response.update(
-                {'status': STATUS_DEGRADED, 'db_connected': False, 'db_exception': type(e).__name__, 'proxy_exception_type': 'Skipped, DB unavailable.'}
-            )
-
-        # Dispatcherd check is informational only — does not affect overall status
-        try:
-            response['dispatcherd_connected'] = self._check_dispatcherd()
-        except Exception:
-            logger.warning("Dispatcherd health check failed", exc_info=True)
-            response['dispatcherd_connected'] = False
-
-        serialized = self.serializer_class(response)
-        return Response(serialized.data)
+        raise RuntimeError("AAP-77439: intentional failure to demo required status check")


### PR DESCRIPTION
## Summary

- Intentionally breaks the `/ping/` endpoint to demonstrate that the ATF tier 1 CI check blocks PR merges

## Context

This PR exists solely to validate that `jewel-atf-tests-pull-request` is correctly configured as a **required status check** in branch protection rules (AAP-77439, Phase 2).

The `/ping/` endpoint raises a `RuntimeError` so the ATF tests will fail, and the merge button should be blocked.

**Close this PR without merging once the demo is complete.**

## Test plan

- [ ] Observe that the `jewel-atf-tests-pull-request` check runs and fails
- [ ] Confirm the "Merge" button is blocked with "Required status check has not passed"
- [ ] Close the PR without merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Assisted-by: Claude Code (claude-opus-4-6) [aap-sdlc]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * The health check endpoint behavior has been modified and will no longer provide service status information. Applications relying on this endpoint for monitoring should be updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->