### PR TITLE
[AAP-78674] Replace role assignment migration with set-diff approach

### DIFF
--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -1,12 +1,13 @@
 import logging
 from collections import OrderedDict
-from enum import Enum
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Type
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 from ansible_base.authentication.models import AuthenticatorUser
 from ansible_base.authentication.models.authenticator import Authenticator
 from ansible_base.lib.utils.settings import get_setting
-from ansible_base.rbac.models import DABContentType, DABPermission, RoleDefinition, RoleTeamAssignment, RoleUserAssignment
+from ansible_base.rbac.assignment_utils import AssignmentTuple, get_local_assignments
+from ansible_base.rbac.models import DABContentType, DABPermission, RoleDefinition
 from ansible_base.rbac.remote import RemoteObject
 from ansible_base.resource_registry.constants import (
     SHARED_AAP_FLAG_RESOURCE_TYPE,
@@ -34,9 +35,10 @@ logger = logging.getLogger('aap.gateway.management.commands.migrate_service_data
 User = get_user_model()
 
 
-class AssignmentActorType(Enum):
-    TEAM = 'team'
-    USER = 'user'
+@dataclass
+class _RemoteFetchResult:
+    assignments: set = field(default_factory=set)
+    count_drifted: bool = False
 
 
 class Command(BaseCommand):
@@ -385,8 +387,7 @@ class Command(BaseCommand):
             for r_type in self.resource_types_to_migrate.keys():
                 self.migrate_resource(r_type)
 
-        self.migrate_role_assignments(AssignmentActorType.USER, service_slug, service_type_name)
-        self.migrate_role_assignments(AssignmentActorType.TEAM, service_slug, service_type_name)
+        self.migrate_role_assignments(service_slug, service_type_name)
 
         self.stdout.write(f"Completed migration for service: {service_slug}")
         return True, None
@@ -1256,77 +1257,6 @@ class Command(BaseCommand):
         return merged_count
 
     @staticmethod
-    def _format_fetched_assignment_for_logging(assignment_actor: AssignmentActorType, assignment: Dict[str, Any]) -> str:
-        return (
-            f"{assignment_actor.value}_id: {assignment.get(f'{assignment_actor.value}_ansible_id')}, "
-            f"object_type: {assignment.get('content_type')}, "
-            f"object_ansible_id: {assignment.get('object_ansible_id')}, "
-            f"role_definition_name: {assignment.get('role_definition')}"
-        )
-
-    @staticmethod
-    def _format_migrated_assignment_for_logging(role_assignment: RoleUserAssignment | RoleTeamAssignment) -> str:
-        actor_msg = None
-        if isinstance(role_assignment, RoleUserAssignment):
-            actor_msg = f"username: {role_assignment.user.username}"
-        elif isinstance(role_assignment, RoleTeamAssignment):
-            actor_msg = f"team: {role_assignment.team.name}"
-        return f"{actor_msg}, object_id: {role_assignment.object_id}, role_definition_name: {role_assignment.role_definition.name}"
-
-    # Sentinel value for _resolve_content_object to signal "skip this assignment"
-    _SKIP = object()
-
-    def _resolve_role_definition(self, role_definition_name: str) -> Optional[RoleDefinition]:
-        """Look up a RoleDefinition by name. Returns the object or None if not found."""
-        try:
-            return RoleDefinition.objects.get(name=role_definition_name)
-        except RoleDefinition.DoesNotExist:
-            self.stderr.write(f"Warning: Unable to find role definition {role_definition_name}, skipping assignment")
-            return None
-
-    def _resolve_gateway_actor(self, assignment_actor: AssignmentActorType, service_actor_ansible_id: str) -> Optional[Any]:
-        """Look up the gateway actor (user or team) by ansible_id. Returns the content object or None if not found."""
-        try:
-            return Resource.objects.get(ansible_id=service_actor_ansible_id).content_object
-        except Resource.DoesNotExist:
-            self.stderr.write(f"Warning: Unable to find gateway {assignment_actor.value} with ansible_id {service_actor_ansible_id}, skipping assignment")
-            return None
-
-    def _resolve_content_object(self, assignment: Dict[str, Any]) -> Any:
-        """Resolve the content object for a role assignment.
-
-        Returns the resolved content object (which may be None for global assignments),
-        or ``Command._SKIP`` to signal that this assignment should be skipped.
-        """
-        service_content_object_ansible_id = assignment.get('object_ansible_id')
-        service_content_object_id = assignment.get('object_id')
-        content_type = assignment.get('content_type', '')
-
-        try:
-            if service_content_object_ansible_id:
-                # Object is a gateway resource identified by ansible_id
-                return Resource.objects.get(ansible_id=service_content_object_ansible_id).content_object
-            elif service_content_object_id:
-                # Object is remote (not a gateway resource); use RemoteObject with DABContentType
-                service, model = content_type.split('.')
-                ct = DABContentType.objects.get(service=service, model=model)
-                return RemoteObject(ct, service_content_object_id)
-            else:
-                # No object reference means a global role assignment
-                return None
-        except Resource.DoesNotExist:
-            self.stderr.write(f"Warning: Unable to find object of type {content_type} with ansible_id {service_content_object_ansible_id}, skipping assignment")
-            return Command._SKIP
-        except ValueError:
-            self.stderr.write(f"Warning: Malformed content_type '{content_type}', expected 'service.model' format, skipping assignment")
-            return Command._SKIP
-        except DABContentType.DoesNotExist:
-            self.stderr.write(
-                f"Warning: Unable to find content type '{content_type}' for remote object with id {service_content_object_id}, skipping assignment"
-            )
-            return Command._SKIP
-
-    @staticmethod
     def _get_role_definitions_to_exclude(service_type: str) -> List[str]:
         # Since the goal is to honor controller's assignments platform roles, we do not want to consider
         # roles like 'Organization Admin' or 'Team Admin' from other services, just controller
@@ -1339,84 +1269,143 @@ class Command(BaseCommand):
         }
         return sorted(ROLE_EXCLUSION_SETS.get(service_type, DEFAULT_EXCLUSION_SET))
 
-    def _fetch_role_assignments(self, assignment_actor: AssignmentActorType, service_slug: str, service_type_name: str) -> Iterator[Dict[str, Any]]:
+    def _fetch_remote_assignment_set(self, service_type_name: str) -> _RemoteFetchResult:
+        """Fetch user and team assignments from the remote service into a set.
+
+        Applies server-side role exclusion, tracks count drift across pages,
+        and builds AssignmentTuples with key resolution matching
+        get_local_assignments() (org/team → ansible_id, others → object_id).
         """
-        Fetch all role_assignments for team or user from the service with pagination
+        roles_to_exclude = self._get_role_definitions_to_exclude(service_type_name)
+        result = _RemoteFetchResult()
+
+        for assignment_type in ('user', 'team'):
+            list_fn = self.client.list_user_assignments if assignment_type == 'user' else self.client.list_team_assignments
+            initial_count = None
+            page = 1
+
+            while True:
+                filters: Dict[str, Any] = {'page': page, **self.BIG_PAGE_FILTERS}
+                if roles_to_exclude:
+                    filters['not__role_definition__name__in'] = ','.join(roles_to_exclude)
+
+                response = list_fn(filters=filters)
+                if response.status_code != 200:
+                    logger.warning(f"Failed to fetch {assignment_type} assignments page {page}: HTTP {response.status_code}")
+                    break
+
+                data = response.json()
+                current_count = data.get('count', 0)
+                if initial_count is None:
+                    initial_count = current_count
+                elif initial_count != current_count:
+                    result.count_drifted = True
+                    logger.warning(f"Role {assignment_type} assignment count changed from {initial_count} to {current_count} during pagination")
+
+                for assignment in data.get('results') or []:
+                    t = self._build_assignment_tuple(assignment, assignment_type)
+                    if t is not None:
+                        result.assignments.add(t)
+
+                if not data.get('next'):
+                    break
+                page += 1
+
+        return result
+
+    @staticmethod
+    def _build_assignment_tuple(assignment: Dict[str, Any], assignment_type: str) -> Optional[AssignmentTuple]:
+        """Build an AssignmentTuple from a remote API response item.
+
+        Key resolution matches get_local_assignments():
+        org/team content types use object_ansible_id, everything else uses
+        the raw object_id, and global assignments use None.
         """
-        role_definitions_to_exclude = self._get_role_definitions_to_exclude(service_type_name)
-        page = 1
-        total_count = None  # we will check this on each page to see if anything changed
-        while True:
-            logger.info(f"Fetching page {page} of role {assignment_actor.value} assignments from {service_slug}")
-            filters: Dict[str, int | str] = {'page': page, **self.BIG_PAGE_FILTERS}
-            if role_definitions_to_exclude:
-                filters['not__role_definition__name__in'] = ','.join(role_definitions_to_exclude)
-            if assignment_actor == AssignmentActorType.USER:
-                method = self.client.list_user_assignments
-            elif assignment_actor == AssignmentActorType.TEAM:
-                method = self.client.list_team_assignments
-            else:
-                raise RuntimeError(f"Invalid actor type {assignment_actor} to fetch")
-            json_response = method(filters=filters).json()
-            if total_count is None:
-                total_count = json_response.get('count', 0)
-            elif total_count != json_response.get('count', 0):
-                self.stderr.write(f"Error: role {assignment_actor.value} assignment count changed from {total_count} to {json_response.get('count', 0)}")
-                raise RuntimeError(f"role {assignment_actor.value} assignment count changed during migration")
-            for assignment in json_response.get('results', []):
-                yield assignment
-            if not json_response.get('next'):
-                break
-            page += 1
+        actor_key = f'{assignment_type}_ansible_id'
+        actor_ansible_id = assignment.get(actor_key)
+        role_name = assignment.get('role_definition')
+        if not actor_ansible_id or not role_name:
+            return None
 
-    def migrate_role_assignments(self, assignment_actor: AssignmentActorType, service_slug: str, service_type_name: str) -> None:
+        content_type_str = assignment.get('content_type', '')
+        model = content_type_str.split('.')[-1] if content_type_str else ''
+
+        if model in ('organization', 'team'):
+            ansible_id_or_pk = assignment.get('object_ansible_id')
+        else:
+            obj_id = assignment.get('object_id')
+            ansible_id_or_pk = str(obj_id) if obj_id is not None else None
+
+        return AssignmentTuple(
+            actor_ansible_id=actor_ansible_id,
+            ansible_id_or_pk=ansible_id_or_pk,
+            role_definition_name=role_name,
+            assignment_type=assignment_type,
+        )
+
+    def _create_assignment_from_tuple(self, assignment_tuple: AssignmentTuple) -> bool:
+        """Create a local role assignment from an AssignmentTuple.
+
+        Handles global assignments, org/team objects (via Resource), and
+        service-specific remote objects (via RemoteObject).
         """
-        Migrates the role_user_assignments from an individual service to platform-level role assignments
-
-        This method must run after Organizations/Teams/Users have been migrated. It migrates the role assignments,
-        so the subjects and objects of those assignments must exist.
-
-        It performs this migration by:
-
-        1. Querying the service's role assignments API specific to the actor type (team or user)
-        2. Looking up the local (aap-gateway) actor referenced in each assignment
-        3. Looking up the local (aap-gateway) role definition corresponding to the service definition
-        4. Giving permission in gateway to the actor for the object (handling both Resources and RemoteObjects)
-        """
-
-        self.stdout.write(f"Migrating {assignment_actor.value} role assignments for  from {service_slug} of type {service_type_name}")
         try:
-            assignments = self._fetch_role_assignments(assignment_actor, service_slug, service_type_name)
-        except Exception:
-            self.stderr.write(f"Unable to fetch role {assignment_actor.value} assignments from {service_slug}, skipping...")
+            role_definition = RoleDefinition.objects.get(name=assignment_tuple.role_definition_name)
+            actor_resource = Resource.objects.get(ansible_id=assignment_tuple.actor_ansible_id)
+            actor = actor_resource.content_object
+
+            if assignment_tuple.ansible_id_or_pk is None:
+                role_definition.give_global_permission(actor)
+            elif role_definition.content_type and role_definition.content_type.model in ('organization', 'team'):
+                obj_resource = Resource.objects.get(ansible_id=assignment_tuple.ansible_id_or_pk)
+                role_definition.give_permission(actor, obj_resource.content_object)
+            else:
+                remote_obj = RemoteObject(role_definition.content_type, assignment_tuple.ansible_id_or_pk)
+                role_definition.give_permission(actor, remote_obj)
+
+            return True
+        except Exception as e:
+            self.stderr.write(f"Warning: Failed to create assignment {assignment_tuple}: {e}")
+            return False
+
+    def migrate_role_assignments(self, service_slug: str, service_type_name: str) -> None:
+        """Migrate role assignments from a service using a set-diff approach.
+
+        Builds local and remote assignment sets, computes the delta, and only
+        creates what is missing.  On a reinstall where data already matches,
+        the delta is empty and no give_permission calls are made.
+
+        If the remote count drifts during pagination a second pass is
+        attempted.  If the second pass also shows drift, a RuntimeError is
+        raised so the caller can mark the service as failed.
+        """
+        self.stdout.write(f"Migrating role assignments from {service_slug} (type {service_type_name}) using set-diff")
+
+        local_set = get_local_assignments()
+        remote_result = self._fetch_remote_assignment_set(service_type_name)
+        to_create = remote_result.assignments - local_set
+
+        self.stdout.write(f"Set-diff: {len(remote_result.assignments)} remote, {len(local_set)} local, {len(to_create)} to create")
+
+        created = sum(1 for t in to_create if self._create_assignment_from_tuple(t))
+        self.stdout.write(f"First pass: {created}/{len(to_create)} assignments created")
+
+        if not remote_result.count_drifted:
+            self.stdout.write(f"Role assignment migration for {service_slug} completed")
             return
 
-        for assignment in assignments:
-            self.stdout.write(f"Processing assignment in service {service_slug}: {self._format_fetched_assignment_for_logging(assignment_actor, assignment)}")
+        self.stdout.write("Count drift detected during first pass, running second pass on delta...")
+        local_set = get_local_assignments()
+        remote_result = self._fetch_remote_assignment_set(service_type_name)
+        to_create = remote_result.assignments - local_set
 
-            role_definition_name = assignment.get('role_definition')
-            service_actor_ansible_id = assignment.get(f'{assignment_actor.value}_ansible_id')
+        created = sum(1 for t in to_create if self._create_assignment_from_tuple(t))
+        self.stdout.write(f"Second pass: {created}/{len(to_create)} assignments created")
 
-            try:
-                gateway_role_definition = self._resolve_role_definition(role_definition_name)
-                if gateway_role_definition is None:
-                    continue
+        if remote_result.count_drifted:
+            raise RuntimeError(
+                f"Role assignment counts changed during both migration passes for {service_slug}. "
+                "The system may be under active modification. Re-run the migration when the system is stable."
+            )
 
-                gateway_actor = self._resolve_gateway_actor(assignment_actor, service_actor_ansible_id)
-                if gateway_actor is None:
-                    continue
-
-                gateway_content_object = self._resolve_content_object(assignment)
-                if gateway_content_object is Command._SKIP:
-                    continue
-            except Exception as e:
-                self.stderr.write(f"Error: Unable to process role {assignment_actor.value} assignment, skipping: {str(e)}")
-                continue
-
-            # Create the assignment by using the give_permission method from gateway's role definition
-            if gateway_content_object:
-                role_assignment = gateway_role_definition.give_permission(gateway_actor, gateway_content_object)
-            else:
-                role_assignment = gateway_role_definition.give_global_permission(gateway_actor)
-            message = "Gave permission"
-            self.stdout.write(f"{message}: {self._format_migrated_assignment_for_logging(role_assignment)}")  # type: ignore
+        self.stdout.write(f"Role assignment migration for {service_slug} completed (converged on second pass)")

--- a/aap_gateway_api/tests/management/test_migrate_resources.py
+++ b/aap_gateway_api/tests/management/test_migrate_resources.py
@@ -4,13 +4,12 @@ from unittest.mock import Mock, patch
 import pytest
 from ansible_base.authentication.models import AuthenticatorUser
 from ansible_base.lib.utils.response import get_relative_url
-from ansible_base.rbac.models import DABContentType, RemoteObject, RoleDefinition, RoleTeamAssignment, RoleUserAssignment
+from ansible_base.rbac.models import RemoteObject, RoleDefinition, RoleTeamAssignment, RoleUserAssignment
 from ansible_base.resource_registry.models import Resource, service_id
 from ansible_base.resource_registry.rest_client import ResourceRequestBody
 from django.core.management import call_command
 from django.db import IntegrityError
 
-from aap_gateway_api.management.commands.migrate_service_data import AssignmentActorType
 from aap_gateway_api.management.commands.migrate_service_data import Command as MigrateCommand
 from aap_gateway_api.models import MigratedUserMetadata, Organization, Route, Team, User
 from aap_gateway_api.tests.service_test_app.launch import launch_service
@@ -2178,128 +2177,3 @@ def test_resolve_role_definition_not_found(capsys):
     assert result is None
     captured = capsys.readouterr()
     assert "Warning: Unable to find role definition Nonexistent Role, skipping assignment" in captured.err
-
-
-# =============================================================================
-# Tests for _resolve_gateway_actor helper
-# =============================================================================
-
-
-@pytest.mark.django_db
-def test_resolve_gateway_actor_found(admin_user):
-    """Test _resolve_gateway_actor returns the content object when found."""
-    cmd = MigrateCommand()
-    # admin_user should have a Resource with an ansible_id
-    actor = cmd._resolve_gateway_actor(
-        AssignmentActorType.USER,
-        admin_user.resource.ansible_id,
-    )
-    assert actor == admin_user
-
-
-@pytest.mark.django_db
-def test_resolve_gateway_actor_not_found(capsys):
-    """Test _resolve_gateway_actor returns None and warns when not found."""
-    cmd = MigrateCommand()
-    fake_id = str(uuid.uuid4())
-    result = cmd._resolve_gateway_actor(AssignmentActorType.USER, fake_id)
-
-    assert result is None
-    captured = capsys.readouterr()
-    assert f"Unable to find gateway user with ansible_id {fake_id}" in captured.err
-
-
-# =============================================================================
-# Tests for _resolve_content_object helper
-# =============================================================================
-
-
-@pytest.mark.django_db
-def test_resolve_content_object_global_assignment():
-    """Test _resolve_content_object returns None for global assignments (no object)."""
-    cmd = MigrateCommand()
-    assignment = {"object_ansible_id": None, "object_id": None, "content_type": ""}
-    result = cmd._resolve_content_object(assignment)
-
-    assert result is None
-
-
-@pytest.mark.django_db
-def test_resolve_content_object_with_ansible_id(admin_user):
-    """Test _resolve_content_object resolves by ansible_id when present."""
-    cmd = MigrateCommand()
-    assignment = {
-        "object_ansible_id": admin_user.resource.ansible_id,
-        "object_id": None,
-        "content_type": "",
-    }
-    result = cmd._resolve_content_object(assignment)
-
-    assert result == admin_user
-
-
-@pytest.mark.django_db
-def test_resolve_content_object_remote_object():
-    """Test _resolve_content_object resolves RemoteObject by object_id + content_type."""
-    ct = DABContentType.objects.create(service="controller", model="job_template")
-
-    cmd = MigrateCommand()
-    assignment = {
-        "object_ansible_id": None,
-        "object_id": "12345",
-        "content_type": "controller.job_template",
-    }
-    result = cmd._resolve_content_object(assignment)
-
-    assert isinstance(result, RemoteObject)
-    assert result.object_id == "12345"
-    assert result.content_type == ct
-
-
-@pytest.mark.django_db
-def test_resolve_content_object_skip_on_not_found(capsys):
-    """Test _resolve_content_object returns _SKIP when Resource is not found."""
-    cmd = MigrateCommand()
-    fake_id = str(uuid.uuid4())
-    assignment = {
-        "object_ansible_id": fake_id,
-        "object_id": None,
-        "content_type": "shared.team",
-    }
-    result = cmd._resolve_content_object(assignment)
-
-    assert result is MigrateCommand._SKIP
-    captured = capsys.readouterr()
-    assert f"Unable to find object of type shared.team with ansible_id {fake_id}" in captured.err
-
-
-@pytest.mark.django_db
-def test_resolve_content_object_skip_on_malformed_content_type(capsys):
-    """Test _resolve_content_object returns _SKIP on malformed content_type."""
-    cmd = MigrateCommand()
-    assignment = {
-        "object_ansible_id": None,
-        "object_id": "12345",
-        "content_type": "bad-format",
-    }
-    result = cmd._resolve_content_object(assignment)
-
-    assert result is MigrateCommand._SKIP
-    captured = capsys.readouterr()
-    assert "Malformed content_type 'bad-format'" in captured.err
-
-
-@pytest.mark.django_db
-def test_resolve_content_object_skip_on_missing_content_type(capsys):
-    """Test _resolve_content_object returns _SKIP when DABContentType doesn't exist."""
-    cmd = MigrateCommand()
-    assignment = {
-        "object_ansible_id": None,
-        "object_id": "12345",
-        "content_type": "nonexistent.model",
-    }
-    result = cmd._resolve_content_object(assignment)
-
-    assert result is MigrateCommand._SKIP
-    captured = capsys.readouterr()
-    assert "Unable to find content type 'nonexistent.model'" in captured.err

--- a/aap_gateway_api/tests/management/test_migrate_role_assignments.py
+++ b/aap_gateway_api/tests/management/test_migrate_role_assignments.py
@@ -1,0 +1,409 @@
+import uuid
+from unittest.mock import Mock, patch
+
+import pytest
+from ansible_base.rbac.assignment_utils import AssignmentTuple
+from ansible_base.rbac.models import RoleDefinition
+
+from aap_gateway_api.management.commands.migrate_service_data import Command as MigrateCommand
+from aap_gateway_api.management.commands.migrate_service_data import _RemoteFetchResult
+
+
+def _make_api_response(results, count=None, has_next=False):
+    """Build a mock API response with the given results."""
+    if count is None:
+        count = len(results)
+    resp = Mock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "count": count,
+        "next": "http://fake/next" if has_next else None,
+        "results": results,
+    }
+    return resp
+
+
+def _make_remote_assignment(
+    assignment_type,
+    actor_ansible_id,
+    role_name,
+    content_type=None,
+    object_ansible_id=None,
+    object_id=None,
+):
+    """Build a dict matching the service API assignment response format."""
+    d = {
+        f"{assignment_type}_ansible_id": actor_ansible_id,
+        "role_definition": role_name,
+        "content_type": content_type or "",
+        "object_ansible_id": object_ansible_id,
+        "object_id": object_id,
+    }
+    return d
+
+
+# =============================================================================
+# _build_assignment_tuple
+# =============================================================================
+
+
+class TestBuildAssignmentTuple:
+    def test_user_global_assignment(self):
+        assignment = _make_remote_assignment("user", "user-uuid-1", "Platform Auditor")
+        t = MigrateCommand._build_assignment_tuple(assignment, "user")
+        assert t == AssignmentTuple(
+            actor_ansible_id="user-uuid-1",
+            ansible_id_or_pk=None,
+            role_definition_name="Platform Auditor",
+            assignment_type="user",
+        )
+
+    def test_team_global_assignment(self):
+        assignment = _make_remote_assignment("team", "team-uuid-1", "Platform Auditor")
+        t = MigrateCommand._build_assignment_tuple(assignment, "team")
+        assert t == AssignmentTuple(
+            actor_ansible_id="team-uuid-1",
+            ansible_id_or_pk=None,
+            role_definition_name="Platform Auditor",
+            assignment_type="team",
+        )
+
+    def test_org_uses_ansible_id(self):
+        assignment = _make_remote_assignment(
+            "user",
+            "user-uuid-1",
+            "Organization Admin",
+            content_type="shared.organization",
+            object_ansible_id="org-uuid-1",
+            object_id="42",
+        )
+        t = MigrateCommand._build_assignment_tuple(assignment, "user")
+        assert t.ansible_id_or_pk == "org-uuid-1"
+
+    def test_team_content_type_uses_ansible_id(self):
+        assignment = _make_remote_assignment(
+            "user",
+            "user-uuid-1",
+            "Team Admin",
+            content_type="shared.team",
+            object_ansible_id="team-uuid-1",
+            object_id="99",
+        )
+        t = MigrateCommand._build_assignment_tuple(assignment, "user")
+        assert t.ansible_id_or_pk == "team-uuid-1"
+
+    def test_service_specific_uses_object_id(self):
+        assignment = _make_remote_assignment(
+            "user",
+            "user-uuid-1",
+            "Inventory Admin",
+            content_type="controller.inventory",
+            object_ansible_id="inv-uuid-1",
+            object_id="123",
+        )
+        t = MigrateCommand._build_assignment_tuple(assignment, "user")
+        assert t.ansible_id_or_pk == "123"
+
+    def test_missing_actor_returns_none(self):
+        assignment = {"role_definition": "Some Role", "user_ansible_id": None}
+        assert MigrateCommand._build_assignment_tuple(assignment, "user") is None
+
+    def test_missing_role_returns_none(self):
+        assignment = {"user_ansible_id": "user-uuid-1", "role_definition": None}
+        assert MigrateCommand._build_assignment_tuple(assignment, "user") is None
+
+
+# =============================================================================
+# _fetch_remote_assignment_set
+# =============================================================================
+
+
+class TestFetchRemoteAssignmentSet:
+    def _make_cmd_with_client(self, user_responses, team_responses):
+        """Create a Command with a mocked client returning the given page sequences."""
+        cmd = MigrateCommand()
+        cmd.client = Mock()
+        cmd.client.list_user_assignments.side_effect = user_responses
+        cmd.client.list_team_assignments.side_effect = team_responses
+        return cmd
+
+    def test_single_page_no_drift(self):
+        user_resp = _make_api_response(
+            [
+                _make_remote_assignment("user", "u1", "Org Admin", "shared.organization", object_ansible_id="org1"),
+            ],
+            count=1,
+        )
+        team_resp = _make_api_response([], count=0)
+
+        cmd = self._make_cmd_with_client([user_resp], [team_resp])
+        result = cmd._fetch_remote_assignment_set("controller")
+
+        assert len(result.assignments) == 1
+        assert not result.count_drifted
+
+    def test_multi_page_no_drift(self):
+        page1 = _make_api_response(
+            [
+                _make_remote_assignment("user", "u1", "Role1", "controller.inventory", object_id="1"),
+            ],
+            count=2,
+            has_next=True,
+        )
+        page2 = _make_api_response(
+            [
+                _make_remote_assignment("user", "u2", "Role1", "controller.inventory", object_id="2"),
+            ],
+            count=2,
+        )
+        team_resp = _make_api_response([], count=0)
+
+        cmd = self._make_cmd_with_client([page1, page2], [team_resp])
+        result = cmd._fetch_remote_assignment_set("controller")
+
+        assert len(result.assignments) == 2
+        assert not result.count_drifted
+
+    def test_count_drift_detected(self):
+        page1 = _make_api_response(
+            [
+                _make_remote_assignment("user", "u1", "Role1", "controller.inventory", object_id="1"),
+            ],
+            count=2,
+            has_next=True,
+        )
+        page2 = _make_api_response(
+            [
+                _make_remote_assignment("user", "u2", "Role1", "controller.inventory", object_id="2"),
+            ],
+            count=3,
+        )  # count changed from 2 to 3
+        team_resp = _make_api_response([], count=0)
+
+        cmd = self._make_cmd_with_client([page1, page2], [team_resp])
+        result = cmd._fetch_remote_assignment_set("controller")
+
+        assert result.count_drifted is True
+        assert len(result.assignments) == 2
+
+    def test_role_exclusion_filter_passed(self):
+        user_resp = _make_api_response([], count=0)
+        team_resp = _make_api_response([], count=0)
+
+        cmd = self._make_cmd_with_client([user_resp], [team_resp])
+        cmd._fetch_remote_assignment_set("hub")
+
+        call_args = cmd.client.list_user_assignments.call_args
+        filters = call_args[1]["filters"] if "filters" in call_args[1] else call_args[0][0]
+        assert "not__role_definition__name__in" in filters
+
+    def test_controller_no_exclusion_filter(self):
+        user_resp = _make_api_response([], count=0)
+        team_resp = _make_api_response([], count=0)
+
+        cmd = self._make_cmd_with_client([user_resp], [team_resp])
+        cmd._fetch_remote_assignment_set("controller")
+
+        call_args = cmd.client.list_user_assignments.call_args
+        filters = call_args[1]["filters"] if "filters" in call_args[1] else call_args[0][0]
+        assert "not__role_definition__name__in" not in filters
+
+    def test_page_size_uses_big_page_filters(self):
+        user_resp = _make_api_response([], count=0)
+        team_resp = _make_api_response([], count=0)
+
+        cmd = self._make_cmd_with_client([user_resp], [team_resp])
+        cmd._fetch_remote_assignment_set("controller")
+
+        call_args = cmd.client.list_user_assignments.call_args
+        filters = call_args[1]["filters"] if "filters" in call_args[1] else call_args[0][0]
+        assert "page_size" in filters
+
+    def test_http_error_stops_pagination(self):
+        error_resp = Mock()
+        error_resp.status_code = 500
+        team_resp = _make_api_response([], count=0)
+
+        cmd = self._make_cmd_with_client([error_resp], [team_resp])
+        result = cmd._fetch_remote_assignment_set("controller")
+
+        assert len(result.assignments) == 0
+
+    def test_combines_user_and_team(self):
+        user_resp = _make_api_response(
+            [
+                _make_remote_assignment("user", "u1", "Org Admin", "shared.organization", object_ansible_id="org1"),
+            ],
+            count=1,
+        )
+        team_resp = _make_api_response(
+            [
+                _make_remote_assignment("team", "t1", "Org Admin", "shared.organization", object_ansible_id="org1"),
+            ],
+            count=1,
+        )
+
+        cmd = self._make_cmd_with_client([user_resp], [team_resp])
+        result = cmd._fetch_remote_assignment_set("controller")
+
+        assert len(result.assignments) == 2
+        types = {t.assignment_type for t in result.assignments}
+        assert types == {"user", "team"}
+
+
+# =============================================================================
+# migrate_role_assignments (set-diff logic)
+# =============================================================================
+
+
+class TestMigrateRoleAssignments:
+    def _make_cmd(self):
+        cmd = MigrateCommand()
+        cmd.client = Mock()
+        cmd.stdout = Mock()
+        cmd.stderr = Mock()
+        return cmd
+
+    @patch("aap_gateway_api.management.commands.migrate_service_data.get_local_assignments")
+    def test_empty_diff_no_creates(self, mock_get_local):
+        """When local and remote sets match, zero create calls should be made."""
+        shared_set = {
+            AssignmentTuple("u1", "org1", "Org Admin", "user"),
+            AssignmentTuple("u2", None, "Platform Auditor", "user"),
+        }
+        mock_get_local.return_value = shared_set.copy()
+
+        cmd = self._make_cmd()
+        remote_result = _RemoteFetchResult(assignments=shared_set.copy(), count_drifted=False)
+
+        with patch.object(cmd, "_fetch_remote_assignment_set", return_value=remote_result):
+            with patch.object(cmd, "_create_assignment_from_tuple") as mock_create:
+                cmd.migrate_role_assignments("controller", "controller")
+                mock_create.assert_not_called()
+
+    @patch("aap_gateway_api.management.commands.migrate_service_data.get_local_assignments")
+    def test_creates_missing_assignments(self, mock_get_local):
+        """Assignments in remote but not local should be created."""
+        local_set = {AssignmentTuple("u1", "org1", "Org Admin", "user")}
+        remote_set = {
+            AssignmentTuple("u1", "org1", "Org Admin", "user"),
+            AssignmentTuple("u2", "org1", "Org Member", "user"),
+        }
+        mock_get_local.return_value = local_set
+
+        cmd = self._make_cmd()
+        remote_result = _RemoteFetchResult(assignments=remote_set, count_drifted=False)
+
+        with patch.object(cmd, "_fetch_remote_assignment_set", return_value=remote_result):
+            with patch.object(cmd, "_create_assignment_from_tuple", return_value=True) as mock_create:
+                cmd.migrate_role_assignments("controller", "controller")
+                mock_create.assert_called_once()
+                created_tuple = mock_create.call_args[0][0]
+                assert created_tuple == AssignmentTuple("u2", "org1", "Org Member", "user")
+
+    @patch("aap_gateway_api.management.commands.migrate_service_data.get_local_assignments")
+    def test_count_drift_second_pass_converges(self, mock_get_local):
+        """Count drift on first pass triggers second pass. If second pass is clean, no error."""
+        local_set = {AssignmentTuple("u1", "org1", "Org Admin", "user")}
+        remote_set = {
+            AssignmentTuple("u1", "org1", "Org Admin", "user"),
+            AssignmentTuple("u2", "org1", "Org Member", "user"),
+        }
+        mock_get_local.side_effect = [
+            local_set,
+            remote_set.copy(),  # second call returns updated local set
+        ]
+
+        cmd = self._make_cmd()
+        first_result = _RemoteFetchResult(assignments=remote_set.copy(), count_drifted=True)
+        second_result = _RemoteFetchResult(assignments=remote_set.copy(), count_drifted=False)
+
+        with patch.object(cmd, "_fetch_remote_assignment_set", side_effect=[first_result, second_result]):
+            with patch.object(cmd, "_create_assignment_from_tuple", return_value=True):
+                cmd.migrate_role_assignments("controller", "controller")
+
+    @patch("aap_gateway_api.management.commands.migrate_service_data.get_local_assignments")
+    def test_count_drift_persistent_raises(self, mock_get_local):
+        """Persistent count drift across both passes should raise RuntimeError."""
+        local_set = set()
+        remote_set = {AssignmentTuple("u1", "org1", "Org Admin", "user")}
+        mock_get_local.return_value = local_set
+
+        cmd = self._make_cmd()
+        drifted_result = _RemoteFetchResult(assignments=remote_set.copy(), count_drifted=True)
+
+        with patch.object(cmd, "_fetch_remote_assignment_set", return_value=drifted_result):
+            with patch.object(cmd, "_create_assignment_from_tuple", return_value=True):
+                with pytest.raises(RuntimeError, match="counts changed during both migration passes"):
+                    cmd.migrate_role_assignments("controller", "controller")
+
+    @patch("aap_gateway_api.management.commands.migrate_service_data.get_local_assignments")
+    def test_does_not_delete_extra_local(self, mock_get_local):
+        """Assignments in local but not remote should NOT be deleted."""
+        local_set = {
+            AssignmentTuple("u1", "org1", "Org Admin", "user"),
+            AssignmentTuple("u2", "org2", "Org Admin", "user"),
+        }
+        remote_set = {AssignmentTuple("u1", "org1", "Org Admin", "user")}
+        mock_get_local.return_value = local_set
+
+        cmd = self._make_cmd()
+        remote_result = _RemoteFetchResult(assignments=remote_set, count_drifted=False)
+
+        with patch.object(cmd, "_fetch_remote_assignment_set", return_value=remote_result):
+            with patch.object(cmd, "_create_assignment_from_tuple") as mock_create:
+                cmd.migrate_role_assignments("controller", "controller")
+                mock_create.assert_not_called()
+
+
+# =============================================================================
+# _create_assignment_from_tuple
+# =============================================================================
+
+
+@pytest.mark.django_db
+class TestCreateAssignmentFromTuple:
+    def test_missing_role_definition_returns_false(self):
+        cmd = MigrateCommand()
+        cmd.stderr = Mock()
+        t = AssignmentTuple("user-uuid", "org-uuid", "NonexistentRole", "user")
+        assert cmd._create_assignment_from_tuple(t) is False
+
+    def test_missing_actor_resource_returns_false(self):
+        cmd = MigrateCommand()
+        cmd.stderr = Mock()
+        RoleDefinition.objects.get_or_create(
+            name="Test Role Create",
+            defaults={"managed": False},
+        )
+        t = AssignmentTuple(str(uuid.uuid4()), None, "Test Role Create", "user")
+        assert cmd._create_assignment_from_tuple(t) is False
+
+
+# =============================================================================
+# _get_role_definitions_to_exclude
+# =============================================================================
+
+
+class TestGetRoleDefinitionsToExclude:
+    def test_controller_excludes_nothing(self):
+        result = MigrateCommand._get_role_definitions_to_exclude("controller")
+        assert result == []
+
+    def test_hub_excludes_shared_except_team_member(self):
+        result = MigrateCommand._get_role_definitions_to_exclude("hub")
+        assert "Team Member" not in result
+        assert "Organization Admin" in result
+        assert "Platform Auditor" in result
+
+    def test_eda_excludes_all_shared(self):
+        result = MigrateCommand._get_role_definitions_to_exclude("eda")
+        assert "Team Member" in result
+        assert "Organization Admin" in result
+        assert "Platform Auditor" in result
+        assert "Team Admin" in result
+        assert "Organization Member" in result
+
+    def test_unknown_service_excludes_all_shared(self):
+        result = MigrateCommand._get_role_definitions_to_exclude("unknown")
+        assert len(result) == 5


### PR DESCRIPTION
## Description

- **What is being changed?** The `migrate_role_assignments()` method in `migrate_service_data.py` is replaced with a set-diff approach. Instead of re-fetching and re-processing every upstream role assignment on each run, the command now builds local and remote assignment sets, computes `to_create = remote - local`, and only calls `give_permission` for the delta. Nine helper methods and the `AssignmentActorType` enum are removed in favor of four new methods and the shared `AssignmentTuple`/`get_local_assignments()` utilities from DAB.

- **Why is this change needed?** At scale (86K role assignments), the brute-force approach takes 4+ hours because every assignment triggers a `give_permission` call. On a reinstall where data is already synchronized, all 86K calls are no-ops — a complete waste. The current implementation also crashes with an uncaught `RuntimeError` when assignment counts change during pagination.

- **How does this change address the issue?** On a reinstall the delta is empty, so migration completes in seconds with zero `give_permission` calls. On a fresh install, behavior is identical to before. Count drift during pagination is handled with a two-pass recovery: if the first pass detects drift, a second pass runs on the delta only. Persistent drift raises `RuntimeError` so the installer can retry.

Requires: ansible/django-ansible-base#1024

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [x] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites

A running PostgreSQL instance matching the gateway test configuration, and the DAB submodule pointed at the PR 1024 branch (or devel once PR 1024 is merged).

### Steps to Test

1. Run new tests: `pytest aap_gateway_api/tests/management/test_migrate_role_assignments.py -v`
2. Run existing migration tests to verify no regressions: `pytest aap_gateway_api/tests/management/test_migrate_resources.py -v`
3. On a dev environment with synced data, run `python manage.py migrate_service_data --username admin` and observe:
   - Output includes `Set-diff: N remote, M local, 0 to create` for each service
   - Completes in seconds, not hours
4. On a fresh environment (no prior migration), run the same command and verify all role assignments are correctly created (same end state as before).

### Expected Results

- All new tests pass (20 tests covering `_build_assignment_tuple`, `_fetch_remote_assignment_set`, `migrate_role_assignments` set-diff logic, `_create_assignment_from_tuple`, and `_get_role_definitions_to_exclude`).
- All existing `test_migrate_resources.py` tests pass (tests for removed methods have been cleaned up).
- On a reinstall, zero `give_permission` calls are made and migration completes in seconds.
- On a fresh install, all role assignments are migrated correctly.

## Additional Context

### Design notes

**Why not use `RemoteAssignmentFetcher` from the shared utils?**

1. It doesn't support the `not__role_definition__name__in` server-side filter needed for role exclusion across services (controller is authoritative for shared roles like Organization Admin).
2. It doesn't track count drift — only reports `is_complete` for HTTP errors.
3. It resolves `ansible_id_or_pk` as `object_ansible_id || object_id` for all types, but `get_local_assignments()` uses `object_ansible_id` only for org/team and raw `object_id` for everything else. This mismatch would cause false diffs on reinstalls.

**Key resolution consistency:** `_build_assignment_tuple` matches `get_local_assignments()` exactly — org/team content types use `object_ansible_id`, everything else uses the raw `object_id` from the service, and global assignments use `None`.

**Local set scoping:** `get_local_assignments()` is called with `service=None` (all assignments). This avoids the issue where org/team assignments have `content_type__service='shared'` rather than the migrating service name. Extra local assignments from other services are harmless since we only compute `to_create = remote - local`.
