### PR TITLE
ci: disable spot instance usage for atf tests pipeline

### DIFF
--- a/.tekton/run-atf-tests-pull-request.yaml
+++ b/.tekton/run-atf-tests-pull-request.yaml
@@ -29,7 +29,7 @@ spec:
       - name: name
         value: aap-api-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-api-tests:0.1@sha256:f7bd040ffa82752122de7a7f2c519d8b75cc13bffcfce8d78c9188fc18f9b17e
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-api-tests:0.1@sha256:0c1621395487e9305fb7652feb6d65071018953a199b991dcf520bd50c0b05ef
       - name: kind
         value: pipeline
       - name: secret


### PR DESCRIPTION
## Description

<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
This PR modifies the run ATF tests pipeline to not use aws spot instances by default. This is primarily used to test the pipeline not using spot instances to see if the errors found during provisioning, go away.


## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Test update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline infrastructure configuration for the automated test pipeline by refreshing the referenced pipeline bundle image digest.

---

**Note:** This is routine infrastructure maintenance intended to keep the test pipeline aligned; it has no direct end-user functionality impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->