### PR TITLE
[AAP-79308] Make SonarCloud analysis work for feature branches as well

### DIFF
--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -1,12 +1,17 @@
 # SonarCloud Analysis Workflow
 #
 # This workflow performs SonarCloud analysis after the Unit Tests workflow finishes.
-# It is not executed by Unit Tests — GitHub's workflow_run event independently triggers
-# this workflow once Unit Tests completes, regardless of its outcome. The gate job
-# then filters on success, branch eligibility, and token availability.
+# Unit Tests explicitly triggers this workflow via workflow_dispatch, passing the
+# metadata needed for analysis (run ID, event type, branch, SHA, and conclusion).
 #
-# FLOW: Unit Tests finishes → GitHub fires workflow_run event → this workflow starts →
-#       gate job checks prerequisites → appropriate analysis job runs
+# WHY workflow_dispatch instead of workflow_run:
+#   GitHub's workflow_run event only fires for PRs targeting the default branch.
+#   PRs targeting feature branches (e.g. feature-sprint-*) never produce a
+#   workflow_run event, regardless of the branches filter. Using workflow_dispatch
+#   lets Unit Tests trigger this workflow for any PR, on any target branch.
+#
+# FLOW: Unit Tests finishes → final step calls `gh workflow run sonar-pr.yml` →
+#       this workflow starts → gate job checks prerequisites → appropriate analysis job runs
 #
 # CONFIGURATION (via repository variables):
 #   SONAR_BRANCHES:          Comma-separated list of branch patterns to enable scanning for.
@@ -50,16 +55,28 @@
 # https://community.sonarsource.com/t/how-to-use-sonarcloud-with-a-forked-repository-on-github/7363/32
 name: SonarCloud
 on:
-  workflow_run:   # Fires when the Unit Tests workflow finishes (success or failure).
-    workflows:
-      - Unit Tests
-    types:
-      - completed
-    # By default, workflow_run only triggers for runs on the default branch.
-    # Use '**' to allow triggering on all branches; the gate job filters
-    # branch eligibility using the SONAR_BRANCHES repository variable.
-    branches:
-      - '**'
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'The run ID of the Unit Tests workflow that triggered this analysis'
+        required: true
+        type: string
+      event:
+        description: 'The event type that triggered Unit Tests (pull_request or push)'
+        required: true
+        type: string
+      head_branch:
+        description: 'The head branch of the PR or the branch that was pushed to'
+        required: true
+        type: string
+      head_sha:
+        description: 'The commit SHA that Unit Tests ran against'
+        required: true
+        type: string
+      conclusion:
+        description: 'The conclusion of the Unit Tests workflow (success, failure, etc.)'
+        required: true
+        type: string
 
 jobs:
   gate:
@@ -69,7 +86,7 @@ jobs:
     # fork protection: forks won't have these variables configured, so the
     # workflow skips cleanly instead of running and failing on missing credentials.
     if: >-
-      github.event.workflow_run.conclusion == 'success' &&
+      github.event.inputs.conclusion == 'success' &&
       vars.SONAR_BRANCHES != '' &&
       vars.SONAR_TOKEN_SECRET_NAME != ''
     outputs:
@@ -80,8 +97,8 @@ jobs:
         id: check
         env:
           SONAR_BRANCHES: ${{ vars.SONAR_BRANCHES }}
-          EVENT_TYPE: ${{ github.event.workflow_run.event }}
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          EVENT_TYPE: ${{ github.event.inputs.event }}
+          HEAD_BRANCH: ${{ github.event.inputs.head_branch }}
         run: |
           if [ "$EVENT_TYPE" = "pull_request" ]; then
             # workflow_run doesn't expose the PR base branch, so we can't check it here.
@@ -122,14 +139,13 @@ jobs:
       pull-requests: read
     if: |
       needs.gate.outputs.allowed == 'true' &&
-      github.event.workflow_run.event == 'pull_request'
+      github.event.inputs.event == 'pull_request'
     steps:
-      # Pin to the exact commit that the Unit Tests workflow ran against,
-      # since workflow_run context defaults to the repo's default branch.
+      # Pin to the exact commit that Unit Tests ran against.
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.inputs.head_sha }}
 
       # Download all individual coverage artifacts from Unit Tests workflow
       - name: Download coverage artifacts
@@ -137,17 +153,17 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: Unit Tests
-          run_id: ${{ github.event.workflow_run.id }}
+          run_id: ${{ github.event.inputs.run_id }}
           pattern: coverage-*
 
-      # Extract PR metadata from workflow_run event and verify the PR targets
-      # a branch listed in SONAR_BRANCHES. If the base branch doesn't match,
-      # the step exits cleanly and the scan is skipped.
+      # Extract PR metadata and verify the PR targets a branch listed in
+      # SONAR_BRANCHES. If the base branch doesn't match, the step exits
+      # cleanly and the scan is skipped.
       - name: Set PR metadata and prepare files for analysis
         env:
-          COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
+          COMMIT_SHA: ${{ github.event.inputs.head_sha }}
           REPO_NAME: ${{ github.event.repository.full_name }}
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_BRANCH: ${{ github.event.inputs.head_branch }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_BRANCHES: ${{ vars.SONAR_BRANCHES }}
         run: |
@@ -292,14 +308,13 @@ jobs:
       actions: read
     if: |
       needs.gate.outputs.allowed == 'true' &&
-      github.event.workflow_run.event == 'push'
+      github.event.inputs.event == 'push'
     steps:
-      # Pin to the exact commit that the Unit Tests workflow ran against,
-      # since workflow_run context defaults to the repo's default branch.
+      # Pin to the exact commit that Unit Tests ran against.
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.inputs.head_sha }}
 
       # Download all individual coverage artifacts from Unit Tests workflow (optional for branch pushes)
       - name: Download coverage artifacts
@@ -308,12 +323,12 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: Unit Tests
-          run_id: ${{ github.event.workflow_run.id }}
+          run_id: ${{ github.event.inputs.run_id }}
           pattern: coverage-*
 
       - name: Print SonarCloud Analysis Summary
         env:
-          BRANCH_NAME: ${{ github.event.workflow_run.head_branch }}
+          BRANCH_NAME: ${{ github.event.inputs.head_branch }}
         run: |
           # Find all downloaded coverage XML files
           coverage_files=$(find . -name "coverage-*.xml" -type f | tr '\n' ',' | sed 's/,$//')
@@ -322,7 +337,7 @@ jobs:
 
           echo "🔍 SonarCloud Analysis Summary"
           echo "=============================="
-          echo "├── CI Event: ✅ Push (via workflow_run)"
+          echo "├── CI Event: ✅ Push (via workflow_dispatch)"
           echo "├── Branch: $BRANCH_NAME"
           echo "├── Coverage Files: ${coverage_files:-none}"
           echo "├── Python Changes: ➖ N/A (Full codebase scan)"
@@ -333,9 +348,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets[format('{0}', vars.SONAR_TOKEN_SECRET_NAME)] }}
-          # Pass user-controlled workflow_run data through environment variables
-          SCM_REVISION: ${{ github.event.workflow_run.head_sha }}
-          BRANCH_NAME: ${{ github.event.workflow_run.head_branch }}
+          SCM_REVISION: ${{ github.event.inputs.head_sha }}
+          BRANCH_NAME: ${{ github.event.inputs.head_branch }}
         with:
           args: >
             -Dsonar.scm.revision=${{ env.SCM_REVISION }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -160,6 +160,26 @@ jobs:
           name: junit-${{ steps.artifact.outputs.suffix }}
           path: junit-${{ steps.artifact.outputs.suffix }}.xml
 
+  trigger-sonarcloud:
+    name: Trigger SonarCloud analysis
+    runs-on: ubuntu-latest
+    needs: unit-test
+    if: |
+      always() &&
+      (github.repository == 'ansible/jewel' || github.repository == 'ansible/jewel-debug')
+    steps:
+      - name: Trigger SonarCloud workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run sonar-pr.yml \
+            --repo "${{ github.repository }}" \
+            -f run_id="${{ github.run_id }}" \
+            -f event="${{ github.event_name }}" \
+            -f head_branch="${{ github.head_ref || github.ref_name }}" \
+            -f head_sha="${{ github.sha }}" \
+            -f conclusion="${{ needs.unit-test.result }}"
+
   merge-and-upload:
     name: Merge junit and upload results
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -164,6 +164,8 @@ jobs:
     name: Trigger SonarCloud analysis
     runs-on: ubuntu-latest
     needs: unit-test
+    permissions:
+      actions: write
     if: |
       always() &&
       (github.repository == 'ansible/jewel' || github.repository == 'ansible/jewel-debug')
@@ -171,14 +173,19 @@ jobs:
       - name: Trigger SonarCloud workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_BRANCH: ${{ github.head_ref || github.ref_name }}
+          HEAD_SHA: ${{ github.sha }}
+          CONCLUSION: ${{ needs.unit-test.result }}
         run: |
           gh workflow run sonar-pr.yml \
             --repo "${{ github.repository }}" \
-            -f run_id="${{ github.run_id }}" \
-            -f event="${{ github.event_name }}" \
-            -f head_branch="${{ github.head_ref || github.ref_name }}" \
-            -f head_sha="${{ github.sha }}" \
-            -f conclusion="${{ needs.unit-test.result }}"
+            -f run_id="$RUN_ID" \
+            -f event="$EVENT_NAME" \
+            -f head_branch="$HEAD_BRANCH" \
+            -f head_sha="$HEAD_SHA" \
+            -f conclusion="$CONCLUSION"
 
   merge-and-upload:
     name: Merge junit and upload results


### PR DESCRIPTION
## Description

- **What is being changed?**
  The SonarCloud workflow trigger is being changed from `workflow_run` to `workflow_dispatch`. The Unit Tests workflow now explicitly triggers SonarCloud analysis via `gh workflow run` as a final job, passing all required metadata (run ID, event type, branch, SHA, conclusion) as inputs.

- **Why is this change needed?**
  GitHub's `workflow_run` event only fires for PRs targeting the default branch (`devel`). PRs targeting feature branches (e.g. `feature-sprint-2026-24-migrate_service_data`) never produce a `workflow_run` event, regardless of the `branches` filter. This means SonarCloud analysis was silently skipped for all PRs targeting non-default branches.

- **How does this change address the issue?**
  By having Unit Tests explicitly trigger SonarCloud via `workflow_dispatch`, the trigger works for PRs targeting any branch. The existing gate job and `SONAR_BRANCHES` variable continue to control which branches are eligible for analysis.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites

- Repository must have `SONAR_BRANCHES` variable set to include a non-default branch (e.g. `devel,feature-sprint-2026-24-migrate_service_data`)
- Repository must have `SONAR_TOKEN_SECRET_NAME` variable and the corresponding secret configured

### Steps to Test

1. Merge this PR into `devel`
2. Open (or re-run) a PR targeting `devel` — verify SonarCloud analysis still triggers and completes successfully
3. Open (or re-run) a PR targeting a feature branch listed in `SONAR_BRANCHES` (e.g. `feature-sprint-2026-24-migrate_service_data`) — verify SonarCloud analysis now triggers
4. Push directly to `devel` — verify SonarCloud branch analysis still triggers

### Expected Results

- PRs targeting `devel`: SonarCloud PR Analysis runs (no change from current behavior)
- PRs targeting feature branches in `SONAR_BRANCHES`: SonarCloud PR Analysis now runs (previously skipped silently)
- Pushes to `devel`: SonarCloud Branch Analysis runs (no change from current behavior)
- Forks: SonarCloud workflow is triggered but skips cleanly at the gate job (no change from current behavior)

## Additional Context

### Root Cause Analysis

GitHub's `workflow_run` event has an undocumented limitation: for `pull_request`-triggered workflows, the event is only generated when the PR targets the default branch. The `branches` filter on `workflow_run` (including `'**'`) does not help because the event itself is never created by GitHub for non-default target branches.
ing feature branches.

### Changes Summary

| File | Change |
|------|--------|
| `.github/workflows/unit-tests.yml` | Added `trigger-sonarcloud` job that runs after `unit-test` and dispatches the SonarCloud workflow |
| `.github/workflows/sonar-pr.yml` | Replaced `workflow_run` trigger with `workflow_dispatch` inputs; updated all `github.event.workflow_run.*` references to `github.event.inputs.*` |

### What stays the same

- Gate job logic (SONAR_BRANCHES pattern matching, fork protection)
- SonarCloud scan parameters (sonar.pullrequest.base/branch/key)
- Coverage artifact download and processing
- Timing behavior (SonarCloud runs as a separate check after Unit Tests completes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refactored the code quality analysis workflow to use manual workflow dispatch inputs, improving consistency for pull request and branch scans.
  * Updated gating and analysis jobs to derive event metadata, commit details, and coverage artifacts from dispatch inputs.
* **Tests**
  * Enhanced the unit test workflow to automatically trigger the code quality analysis workflow afterward, running only for the intended repositories and forwarding the test result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->