### PR TITLE
Revert "[AAP-79308] Update SonarCloud Code Analysis workflow to run on PRs targeting feature branches"

### DIFF
--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -55,11 +55,6 @@ on:
       - Unit Tests
     types:
       - completed
-    # By default, workflow_run only triggers for runs on the default branch.
-    # Use '**' to allow triggering on all branches; the gate job filters
-    # branch eligibility using the SONAR_BRANCHES repository variable.
-    branches:
-      - '**'
 
 jobs:
   gate:


### PR DESCRIPTION
Reverts ansible/jewel#122

Reerting because `branches` filter behaves differently when `workflow_run` is triggered from pull request and the pull request is from a fork.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow trigger configuration to align with GitHub's default branch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->