### PR TITLE
Add X-Trusted-Proxy header for routes with enable_gateway_auth=false

### DIFF
--- a/aap_gateway_api/models/route.py
+++ b/aap_gateway_api/models/route.py
@@ -271,9 +271,18 @@ class Route(UniqueNamedCommonModel, AuditableModel):
             }
 
         if not self.enable_gateway_auth:
+            # Instead of disabling the filter, pass NONE as auth_type
+            # This allows the control plane to add X-Trusted-Proxy header
+            # while skipping authentication (service handles its own auth)
             cfg["typed_per_filter_config"][EXT_AUTH_FILTER] = {
                 TYPE_KEY: EXT_AUTH_PER_ROUTE,
-                "disabled": not self.enable_gateway_auth,
+                "check_settings": {
+                    "context_extensions": {
+                        "is_internal_route": "f",
+                        "service_type": self.service_cluster.service_type.name,
+                        "auth_type": "NONE",
+                    },
+                },
             }
         else:
             cfg["typed_per_filter_config"][EXT_AUTH_FILTER] = {

--- a/aap_gateway_api/proxy/control_plane.py
+++ b/aap_gateway_api/proxy/control_plane.py
@@ -260,6 +260,7 @@ class _ExternalAuth:
 
         self.headers = []
         self.service_type = request.attributes.context_extensions["service_type"]
+        self.auth_type = request.attributes.context_extensions.get("auth_type", "JWT")
 
         # Clear the thread local request. If we log before we get the new one, we'll log the wrong request.
         logging_thread_local.request = None
@@ -286,6 +287,13 @@ class _ExternalAuth:
 
         self.request_path = request.attributes.request.http.path
         self.is_internal_route = self.is_route_internal(request)
+
+        # Routes with auth_type=NONE (enable_gateway_auth=false) skip authentication
+        # but still get the X-Trusted-Proxy header to verify they came through the gateway.
+        # This is useful for services like EDA that handle their own authentication.
+        if self.auth_type == "NONE":
+            logger.debug(f"Auth type is NONE for {self.request_id} {self.request_path} - adding trusted proxy header without authentication")
+            return self._return_no_authentication_required()
 
         # OIDC/OAuth2 flow endpoints handle their own authentication via DOT.
         # This check runs before internal/external branching so it works regardless

--- a/aap_gateway_api/tests/proxy/test_proxy.py
+++ b/aap_gateway_api/tests/proxy/test_proxy.py
@@ -505,6 +505,74 @@ class TestOAuth2ScopeValidation:
         # status.code 7 is PERMISSION_DENIED in gRPC
         assert response.status.code == 7
 
+
+@pytest.mark.django_db
+class TestAuthTypeNone:
+    """Tests for auth_type=NONE (enable_gateway_auth=false) which adds X-Trusted-Proxy without authentication."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def mock_close_old_connections(self):
+        with mock.patch("aap_gateway_api.proxy.control_plane.close_old_connections"):
+            yield
+
+    def test_auth_type_none_adds_trusted_proxy_without_auth(self, ext_auth):
+        """Verify that auth_type=NONE adds X-Trusted-Proxy header without attempting authentication."""
+        # Event stream webhook with UUID - handles its own auth
+        request = Request(method="POST", path="/api/eda/v1/external-event-stream/a1b2c3d4-5678-9012-3456-789012345678/", auth_type="NONE")
+        response = ext_auth.Check(request, None)
+
+        # Should return OK (no authentication attempted)
+        assert response.status.code == 0
+        # Should have X-Trusted-Proxy header
+        header_keys = [h.header.key for h in response.ok_response.headers]
+        assert "x-trusted-proxy" in header_keys
+        # Should NOT have JWT token header
+        assert "X-DAB-JW-TOKEN" not in header_keys
+
+    def test_auth_type_none_works_for_get_requests(self, ext_auth):
+        """Verify that auth_type=NONE works for GET requests on event streams."""
+        request = Request(method="GET", path="/api/eda/v1/external-event-stream/12345678-1234-5678-1234-567812345678/", auth_type="NONE")
+        response = ext_auth.Check(request, None)
+
+        # Should return OK
+        assert response.status.code == 0
+        # Should have X-Trusted-Proxy header
+        header_keys = [h.header.key for h in response.ok_response.headers]
+        assert "x-trusted-proxy" in header_keys
+
+    def test_auth_type_none_with_webhook_payload(self, ext_auth):
+        """Verify that auth_type=NONE works for POST requests with webhook payloads."""
+        webhook_payload = '{"source": "github", "event": "push", "data": {"ref": "refs/heads/main"}}'
+        request = Request(
+            method="POST",
+            path="/api/eda/v1/external-event-stream/abcdef12-3456-7890-abcd-ef1234567890/",
+            auth_type="NONE",
+            body=webhook_payload,
+            header_diff={"CONTENT_TYPE": "application/json"}
+        )
+        response = ext_auth.Check(request, None)
+
+        # Should return OK
+        assert response.status.code == 0
+        # Should have X-Trusted-Proxy header
+        header_keys = [h.header.key for h in response.ok_response.headers]
+        assert "x-trusted-proxy" in header_keys
+
+    def test_auth_type_jwt_still_requires_auth(self, ext_auth, admin_user):
+        """Verify that auth_type=JWT (default) still requires authentication."""
+        request = Request(method="GET", path="/api/eda/v1/activations/", auth_type="JWT")
+
+        # Without authentication, should pass through (returning OK but no JWT token added)
+        response = ext_auth.Check(request, None)
+
+        # Should return OK (unauthenticated users can try, service decides)
+        assert response.status.code == 0
+        # Should have X-Trusted-Proxy header
+        header_keys = [h.header.key for h in response.ok_response.headers]
+        assert "x-trusted-proxy" in header_keys
+        # Should NOT have JWT token since no valid auth provided
+        assert "X-DAB-JW-TOKEN" not in header_keys
+
     def test_oauth2_scope_check_token_is_none(self, ext_auth, admin_user):
         """Test that scope check handles None token gracefully (defensive check)."""
         request = Request(method="POST", path="/api/controller/v2/organizations/")


### PR DESCRIPTION
## Summary
This PR enables routes with enable_gateway_auth=false to receive the X-Trusted-Proxy header while skipping authentication. This allows backend services like Event Streams (EDA) to verify that requests originated from the Gateway while handling their own authentication.

## Problem
Previously, routes with enable_gateway_auth=false would completely disable the external auth filter at the Envoy level. This meant:
- No X-Trusted-Proxy header was added
- Backend services could not verify requests came through the Gateway
- Event Streams webhooks had no way to distinguish Gateway-proxied requests from direct requests

## Solution
Instead of disabling the external auth filter when enable_gateway_auth=false, we now:
1. Keep the filter enabled but pass auth_type=NONE in the context
2. Control plane detects auth_type=NONE and adds X-Trusted-Proxy header without attempting authentication
3. Backend service receives the signed X-Trusted-Proxy header and can verify Gateway origin

## Changes
- **route.py**: Modified get_xds_route_config() to pass auth_type=NONE instead of disabling the filter when enable_gateway_auth=false
- **control_plane.py**: Added early check for auth_type=NONE to add trusted proxy header without authentication
- **test_proxy.py**: Added TestAuthTypeNone class with 4 tests covering event stream webhook scenarios

## Benefits
- No database migrations required (uses string value NONE, not a new enum choice)
- No config changes needed for existing deployments
- Backward compatible - services continue to handle their own auth
- Security improved - services can now verify requests came through Gateway
- Minimal code changes - only 2 files modified, 1 test file

## Test Plan
- Added 4 new tests in TestAuthTypeNone class
- Tests cover POST/GET requests to event stream webhooks with UUIDs
- Tests verify X-Trusted-Proxy header is added without JWT token
- Logic verified with standalone test script

## Example Use Case
Event Streams (EDA) webhooks with enable_gateway_auth: false will now receive the X-Trusted-Proxy header to verify requests came from Gateway while still handling their own authentication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected authentication bypass logic for routes with gateway auth disabled to properly skip authentication checks and inject required security headers.

* **Tests**
  * Added test coverage for authentication bypass behavior when gateway auth is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->