### PR TITLE
[AAP-76816] Add progress reporting during merge task execution

### DIFF
--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -64,6 +64,9 @@ class Command(BaseCommand):
     RESOURCE_DATA_FILTERS = {"extra_fields": "resource_data"}
     BIG_PAGE_FILTERS = {"page_size": str(get_setting('RESOURCE_LIST_MAX_PAGE_SIZE', DEFAULT_MAX_PAGE_SIZE))}
 
+    # Progress reporting step size (percentage)
+    PROGRESS_STEP = 5
+
     # Service processing order - Controller first to establish priority for user merging
     SERVICE_TYPE_ORDER = [
         DefaultServiceType.CONTROLLER.value,
@@ -75,6 +78,37 @@ class Command(BaseCommand):
 
     There is no option to control merging of users, because users are never migrated.
     The exception is that the provided --username, which will be merged."""
+
+    def _log_progress(self, label: str, processed: int, total: int) -> None:
+        """
+        Log migration progress when a percentage threshold is crossed.
+
+        Emits a log line at every PROGRESS_STEP% interval. Always logs a starting
+        message on the first item and a 100% message on the last item. If a single
+        item crosses multiple thresholds, only the highest is reported.
+        """
+        if total == 0:
+            logger.info("Migration progress [%s]: 0 items to process", label)
+            return
+
+        percent = (processed / total) * 100
+        threshold = (int(percent) // self.PROGRESS_STEP) * self.PROGRESS_STEP
+        last = self._progress_thresholds.get(label, -1)
+
+        if processed == total:
+            if last < 100:
+                self._progress_thresholds[label] = 100
+                logger.info("Migration progress [%s]: %d/%d (100%%)", label, processed, total)
+            return
+
+        if processed == 1 and last < 0:
+            self._progress_thresholds[label] = threshold
+            logger.info("Migration progress [%s]: %d/%d (%d%%)", label, processed, total, threshold)
+            return
+
+        if threshold > last:
+            self._progress_thresholds[label] = threshold
+            logger.info("Migration progress [%s]: %d/%d (%d%%)", label, processed, total, threshold)
 
     def add_arguments(self, parser) -> None:
         """
@@ -214,6 +248,7 @@ class Command(BaseCommand):
             )
 
         self._services_with_count_drift = set()
+        self._progress_thresholds = {}
 
         # Merge all partially migrated users before proceeding with migration
         self.stdout.write("\n=== Merging partially migrated users ===")
@@ -234,9 +269,10 @@ class Command(BaseCommand):
         successful_services: List[str] = []
         failed_services: Dict[str, str] = {}
 
-        for service_api in service_apis:
+        total_services = len(service_apis)
+        for service_idx, service_api in enumerate(service_apis, 1):
             service_slug = service_api.api_slug
-            self.stdout.write(f"\n=== Processing service: {service_slug} ===")
+            self.stdout.write(f"\n=== Processing service: {service_slug} ({service_idx}/{total_services}) ===")
 
             try:
                 success, error_msg = self._migrate_single_service(service_api, service_slug, user)
@@ -871,6 +907,12 @@ class Command(BaseCommand):
             "content_type__resource_type__name": resource_type_name,
         }
 
+        # Get initial total count for progress reporting
+        initial_count_response = self.client.list_resources(filters=api_call_filters).json()
+        resource_total = initial_count_response.get('count', 0)
+        resource_processed = 0
+        progress_label = f"{resource_type_name} resources"
+
         # Following 'while True' loop is used because we are modifying the list as we go through it.
         # By changing the service ID or setting partially migrated, we are removing items from the filter,
         # so this doesn't actually use pagination. It just keeps loading the same filter over and over
@@ -883,6 +925,8 @@ class Command(BaseCommand):
                 break
 
             for upstream_resource_item in results:
+                resource_processed += 1
+                self._log_progress(progress_label, resource_processed, resource_total)
                 self._process_and_migrate_resource_item(upstream_resource_item, resource_context)
 
     def _get_gateway_user(self, username: str) -> Optional[AbstractUser]:
@@ -1385,6 +1429,7 @@ class Command(BaseCommand):
             json_response = method(filters=filters).json()
             if total_count is None:
                 total_count = json_response.get('count', 0)
+                self._current_assignment_total = total_count
             elif total_count != json_response.get('count', 0):
                 new_count = json_response.get('count', 0)
                 logger.warning(
@@ -1414,10 +1459,15 @@ class Command(BaseCommand):
         4. Giving permission in gateway to the actor for the object (handling both Resources and RemoteObjects)
         """
 
+        progress_label = f"{service_slug} {assignment_actor.value} role assignments"
+        self._current_assignment_total = 0
         self.stdout.write(f"Migrating {assignment_actor.value} role assignments from {service_slug} of type {service_type_name}")
         try:
             assignments = self._fetch_role_assignments(assignment_actor, service_slug, service_type_name)
+            processed = 0
             for assignment in assignments:
+                processed += 1
+                self._log_progress(progress_label, processed, self._current_assignment_total)
                 log_detail = self._format_fetched_assignment_for_logging(assignment_actor, assignment)
                 self.stdout.write(f"Processing assignment in service {service_slug}: {log_detail}")
 

--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -731,7 +731,7 @@ class Command(BaseCommand):
 
         return create_gateway_resource
 
-    def _get_filtered_resources(self, filters: Dict[str, Any], resource_type_name: str) -> List[Dict[str, Any]]:
+    def _get_filtered_resources(self, filters: Dict[str, Any], resource_type_name: str) -> Tuple[List[Dict[str, Any]], int]:
         """
         Retrieve and filter resources from the upstream service.
 
@@ -765,7 +765,7 @@ class Command(BaseCommand):
             # Currently, the system username is None in controller, and in hub and eda it's the same as gateway's,
             # If Hub and EDA system username is updated to != gateway's, we are migrating it too and we should avoid it
             results = [res for res in results if res['name'] != settings.SYSTEM_USERNAME]
-        return results
+        return results, data['count']
 
     def _process_and_migrate_resource_item(self, upstream_resource_item: Dict[str, Any], resource_context: Dict[str, Any]) -> None:
         """
@@ -908,9 +908,7 @@ class Command(BaseCommand):
             "content_type__resource_type__name": resource_type_name,
         }
 
-        # Get initial total count for progress reporting
-        initial_count_response = self.client.list_resources(filters=api_call_filters).json()
-        resource_total = initial_count_response.get('count', 0)
+        resource_total = None
         resource_processed = 0
         progress_label = f"{self.client.service.api_slug} {resource_type_name} resources"
 
@@ -919,7 +917,9 @@ class Command(BaseCommand):
         # so this doesn't actually use pagination. It just keeps loading the same filter over and over
         # until nothing is left to migrate.
         while True:
-            results = self._get_filtered_resources(api_call_filters, resource_type_name)
+            results, count = self._get_filtered_resources(api_call_filters, resource_type_name)
+            if resource_total is None:
+                resource_total = count + resource_processed
 
             if len(results) == 0:
                 self.stdout.write("No more items remaining to migrate.")
@@ -1461,6 +1461,7 @@ class Command(BaseCommand):
         """
 
         progress_label = f"{service_slug} {assignment_actor.value} role assignments"
+        # Initialized here, updated by _fetch_role_assignments on the first page response
         self._current_assignment_total = 0
         self.stdout.write(f"Migrating {assignment_actor.value} role assignments from {service_slug} of type {service_type_name}")
         try:

--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -95,7 +95,7 @@ class Command(BaseCommand):
         threshold = (int(percent) // self.PROGRESS_STEP) * self.PROGRESS_STEP
         last = self._progress_thresholds.get(label, -1)
 
-        if processed == total:
+        if processed >= total:
             if last < 100:
                 self._progress_thresholds[label] = 100
                 logger.info("Migration progress [%s]: %d/%d (100%%)", label, processed, total)
@@ -106,6 +106,7 @@ class Command(BaseCommand):
             logger.info("Migration progress [%s]: %d/%d (%d%%)", label, processed, total, threshold)
             return
 
+        threshold = min(threshold, 100)
         if threshold > last:
             self._progress_thresholds[label] = threshold
             logger.info("Migration progress [%s]: %d/%d (%d%%)", label, processed, total, threshold)
@@ -911,7 +912,7 @@ class Command(BaseCommand):
         initial_count_response = self.client.list_resources(filters=api_call_filters).json()
         resource_total = initial_count_response.get('count', 0)
         resource_processed = 0
-        progress_label = f"{resource_type_name} resources"
+        progress_label = f"{self.client.service.api_slug} {resource_type_name} resources"
 
         # Following 'while True' loop is used because we are modifying the list as we go through it.
         # By changing the service ID or setting partially migrated, we are removing items from the filter,

--- a/aap_gateway_api/tests/management/test_migrate_resources.py
+++ b/aap_gateway_api/tests/management/test_migrate_resources.py
@@ -2594,7 +2594,6 @@ def test_give_permission_failure_does_not_block_migration(admin_user, capsys, se
 # =============================================================================
 
 
-@pytest.mark.django_db
 def test_log_progress_emits_at_thresholds(caplog):
     """Test that progress is logged at 5% threshold crossings."""
     cmd = MigrateCommand()
@@ -2610,7 +2609,6 @@ def test_log_progress_emits_at_thresholds(caplog):
     assert "(100%)" in progress_msgs[-1]
 
 
-@pytest.mark.django_db
 def test_log_progress_zero_items(caplog):
     """Test that zero items logs a single message."""
     cmd = MigrateCommand()
@@ -2624,7 +2622,6 @@ def test_log_progress_zero_items(caplog):
     assert "0 items to process" in progress_msgs[0]
 
 
-@pytest.mark.django_db
 def test_log_progress_small_count_skips_intermediate(caplog):
     """Test that small counts skip intermediate thresholds."""
     cmd = MigrateCommand()
@@ -2639,7 +2636,6 @@ def test_log_progress_small_count_skips_intermediate(caplog):
     assert any("(10%)" in msg for msg in progress_msgs)
 
 
-@pytest.mark.django_db
 def test_log_progress_bookends_always_logged(caplog):
     """Test that first and last items always generate log output."""
     cmd = MigrateCommand()
@@ -2656,7 +2652,6 @@ def test_log_progress_bookends_always_logged(caplog):
     assert "(100%)" in progress_msgs[-1]
 
 
-@pytest.mark.django_db
 def test_log_progress_no_duplicate_100(caplog):
     """Test that 100% is not logged twice when last item lands exactly on a threshold."""
     cmd = MigrateCommand()

--- a/aap_gateway_api/tests/management/test_migrate_resources.py
+++ b/aap_gateway_api/tests/management/test_migrate_resources.py
@@ -2315,6 +2315,7 @@ def test_fetch_role_assignments_tolerates_count_change(caplog):
     """Test that _fetch_role_assignments logs a warning instead of raising when count changes between pages."""
     cmd = MigrateCommand()
     cmd._services_with_count_drift = set()
+    cmd._progress_thresholds = {}
     mock_client = Mock()
     cmd.client = mock_client
 
@@ -2345,6 +2346,7 @@ def test_fetch_role_assignments_updates_total_count_on_change(caplog):
     """Test that total_count is updated after a count change so subsequent pages compare against the new value."""
     cmd = MigrateCommand()
     cmd._services_with_count_drift = set()
+    cmd._progress_thresholds = {}
     mock_client = Mock()
     cmd.client = mock_client
 
@@ -2372,6 +2374,7 @@ def test_fetch_role_assignments_tracks_drift_services():
     """Test that services with count drift are tracked in _services_with_count_drift."""
     cmd = MigrateCommand()
     cmd._services_with_count_drift = set()
+    cmd._progress_thresholds = {}
     mock_client = Mock()
     cmd.client = mock_client
 
@@ -2392,6 +2395,7 @@ def test_fetch_role_assignments_no_drift_not_tracked():
     """Test that services without count drift are not added to _services_with_count_drift."""
     cmd = MigrateCommand()
     cmd._services_with_count_drift = set()
+    cmd._progress_thresholds = {}
     mock_client = Mock()
     cmd.client = mock_client
 
@@ -2417,6 +2421,7 @@ def test_migrate_role_assignments_catches_fetch_error(capsys):
     """Test that errors during generator iteration are caught by the outer try/except."""
     cmd = MigrateCommand()
     cmd._services_with_count_drift = set()
+    cmd._progress_thresholds = {}
     cmd.stdout = Mock()
     cmd.stderr = Mock()
     mock_client = Mock()
@@ -2438,6 +2443,7 @@ def test_migrate_role_assignments_catches_give_permission_error(admin_user, caps
     """Test that errors in give_permission are caught separately from fetch errors."""
     cmd = MigrateCommand()
     cmd._services_with_count_drift = set()
+    cmd._progress_thresholds = {}
     mock_client = Mock()
     cmd.client = mock_client
 
@@ -2581,3 +2587,84 @@ def test_give_permission_failure_does_not_block_migration(admin_user, capsys, se
         assert "Completed migration for service" in captured.out
         assert "Successful migrations: 1" in captured.out
         assert "Migration flag updated" in captured.out
+
+
+# =============================================================================
+# Tests for _log_progress (AAP-76816)
+# =============================================================================
+
+
+@pytest.mark.django_db
+def test_log_progress_emits_at_thresholds(caplog):
+    """Test that progress is logged at 5% threshold crossings."""
+    cmd = MigrateCommand()
+    cmd._progress_thresholds = {}
+
+    with caplog.at_level("INFO", logger="aap.gateway.management.commands.migrate_service_data"):
+        for i in range(1, 101):
+            cmd._log_progress("test", i, 100)
+
+    progress_msgs = [msg for msg in caplog.messages if "Migration progress [test]" in msg]
+    assert len(progress_msgs) == 21  # 0% + 5% through 100%
+    assert "(0%)" in progress_msgs[0]
+    assert "(100%)" in progress_msgs[-1]
+
+
+@pytest.mark.django_db
+def test_log_progress_zero_items(caplog):
+    """Test that zero items logs a single message."""
+    cmd = MigrateCommand()
+    cmd._progress_thresholds = {}
+
+    with caplog.at_level("INFO", logger="aap.gateway.management.commands.migrate_service_data"):
+        cmd._log_progress("empty", 0, 0)
+
+    progress_msgs = [msg for msg in caplog.messages if "Migration progress [empty]" in msg]
+    assert len(progress_msgs) == 1
+    assert "0 items to process" in progress_msgs[0]
+
+
+@pytest.mark.django_db
+def test_log_progress_small_count_skips_intermediate(caplog):
+    """Test that small counts skip intermediate thresholds."""
+    cmd = MigrateCommand()
+    cmd._progress_thresholds = {}
+
+    with caplog.at_level("INFO", logger="aap.gateway.management.commands.migrate_service_data"):
+        for i in range(1, 11):
+            cmd._log_progress("small", i, 10)
+
+    progress_msgs = [msg for msg in caplog.messages if "Migration progress [small]" in msg]
+    assert not any("(5%)" in msg for msg in progress_msgs)
+    assert any("(10%)" in msg for msg in progress_msgs)
+
+
+@pytest.mark.django_db
+def test_log_progress_bookends_always_logged(caplog):
+    """Test that first and last items always generate log output."""
+    cmd = MigrateCommand()
+    cmd._progress_thresholds = {}
+
+    with caplog.at_level("INFO", logger="aap.gateway.management.commands.migrate_service_data"):
+        cmd._log_progress("bookend", 1, 7)
+        cmd._log_progress("bookend", 7, 7)
+
+    progress_msgs = [msg for msg in caplog.messages if "Migration progress [bookend]" in msg]
+    assert len(progress_msgs) >= 2
+    assert "1/7" in progress_msgs[0]
+    assert "7/7" in progress_msgs[-1]
+    assert "(100%)" in progress_msgs[-1]
+
+
+@pytest.mark.django_db
+def test_log_progress_no_duplicate_100(caplog):
+    """Test that 100% is not logged twice when last item lands exactly on a threshold."""
+    cmd = MigrateCommand()
+    cmd._progress_thresholds = {}
+
+    with caplog.at_level("INFO", logger="aap.gateway.management.commands.migrate_service_data"):
+        for i in range(1, 21):
+            cmd._log_progress("exact", i, 20)
+
+    progress_msgs = [msg for msg in caplog.messages if "(100%)" in msg and "exact" in msg]
+    assert len(progress_msgs) == 1


### PR DESCRIPTION
## Summary
- Add percentage-based progress logging to `migrate_service_data` at 5% threshold intervals
- Progress reported for both resource migration and role assignment migration phases
- Includes bookend messages at start and 100% completion
- Uses `logger.info` so output appears in `podman logs` / container log output
- Service processing loop now shows index: `Processing service: controller (1/3)`

## Format
```
Migration progress [controller user role assignments]: 4300/86000 (5%)
Migration progress [controller user role assignments]: 8600/86000 (10%)
...
Migration progress [controller user role assignments]: 86000/86000 (100%)
```

## Test plan
- [ ] Unit tests for `_log_progress` threshold logic, edge cases (0 items, small counts, no duplicate 100%)
- [ ] DVT: run against cluster with 210+ seeded users, verify ~20 progress lines appear
- [ ] Verify progress appears in `podman logs` output

Replaces: #118 (closed due to target branch deletion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced migration visibility with percentage-based progress logging for services, resources, and role assignments.
  * Service processing output now includes the current service index/total.
* **Bug Fixes**
  * Progress reporting correctly handles zero-item scenarios and avoids duplicate “100%” logs when thresholds are hit exactly.
* **Tests**
  * Added targeted coverage for progress logging threshold behavior, including zero items, small-count skipping, and consistent bookend messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->