### PR TITLE
[AAP-76816] Route migrate_service_data output through dual stdout/log-file channels

### DIFF
--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -101,7 +101,12 @@ class Command(BaseCommand):
             self._log_file_handle = open(log_file, 'w')
             handler = logging.StreamHandler(self._log_file_handle)
             handler.setLevel(logging.INFO)
-            handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)-8s %(name)s %(message)s'))
+            console_handler = logging.getLogger('aap').handlers[0] if logging.getLogger('aap').handlers else None
+            if console_handler:
+                if console_handler.formatter:
+                    handler.setFormatter(console_handler.formatter)
+                for f in console_handler.filters:
+                    handler.addFilter(f)
             logger.addHandler(handler)
             if logger.level == logging.NOTSET or logger.level > logging.INFO:
                 logger.setLevel(logging.INFO)

--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -79,37 +79,73 @@ class Command(BaseCommand):
     There is no option to control merging of users, because users are never migrated.
     The exception is that the provided --username, which will be merged."""
 
+    def _configure_logging(self, log_file: Optional[str]) -> None:
+        """
+        Configure the command's logger based on --log-file.
+
+        When a log file path is provided, attaches a StreamHandler at INFO level
+        so progress messages are written with structured formatting. When omitted,
+        replaces all handlers with a NullHandler so logger calls are silently
+        discarded and all output goes through self.stdout only.
+        """
+        logger.handlers.clear()
+        logger.propagate = False
+
+        if log_file:
+            self._log_file_handle = open(log_file, 'w')
+            handler = logging.StreamHandler(self._log_file_handle)
+            handler.setLevel(logging.INFO)
+            handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)-8s %(name)s %(message)s'))
+            logger.addHandler(handler)
+            logger.setLevel(logging.INFO)
+        else:
+            logger.addHandler(logging.NullHandler())
+
+    def _log(self, msg: str, level: int = logging.INFO) -> None:
+        """
+        Write a message to both stdout (returned to the caller) and the logger
+        (written to --log-file when provided).
+        """
+        if level >= logging.WARNING:
+            self.stderr.write(self.style.WARNING(msg))
+        else:
+            self.stdout.write(msg)
+        logger.log(level, msg)
+
     def _log_progress(self, label: str, processed: int, total: int) -> None:
         """
-        Log migration progress when a percentage threshold is crossed.
+        Report migration progress when a percentage threshold is crossed.
 
-        Emits a log line at every PROGRESS_STEP% interval. Always logs a starting
+        Emits a message at every PROGRESS_STEP% interval. Always reports a starting
         message on the first item and a 100% message on the last item. If a single
         item crosses multiple thresholds, only the highest is reported.
+
+        Output goes through _log(), which writes to both stdout and --log-file.
         """
+        msg = None
+
         if total == 0:
-            logger.info("Migration progress [%s]: 0 items to process", label)
-            return
+            msg = f"Migration progress [{label}]: 0 items to process"
+        else:
+            percent = (processed / total) * 100
+            threshold = (int(percent) // self.PROGRESS_STEP) * self.PROGRESS_STEP
+            last = self._progress_thresholds.get(label, -1)
 
-        percent = (processed / total) * 100
-        threshold = (int(percent) // self.PROGRESS_STEP) * self.PROGRESS_STEP
-        last = self._progress_thresholds.get(label, -1)
+            if processed >= total:
+                if last < 100:
+                    self._progress_thresholds[label] = 100
+                    msg = f"Migration progress [{label}]: {processed}/{total} (100%)"
+            elif processed == 1 and last < 0:
+                self._progress_thresholds[label] = threshold
+                msg = f"Migration progress [{label}]: {processed}/{total} ({threshold}%)"
+            else:
+                threshold = min(threshold, 100)
+                if threshold > last:
+                    self._progress_thresholds[label] = threshold
+                    msg = f"Migration progress [{label}]: {processed}/{total} ({threshold}%)"
 
-        if processed >= total:
-            if last < 100:
-                self._progress_thresholds[label] = 100
-                logger.info("Migration progress [%s]: %d/%d (100%%)", label, processed, total)
-            return
-
-        if processed == 1 and last < 0:
-            self._progress_thresholds[label] = threshold
-            logger.info("Migration progress [%s]: %d/%d (%d%%)", label, processed, total, threshold)
-            return
-
-        threshold = min(threshold, 100)
-        if threshold > last:
-            self._progress_thresholds[label] = threshold
-            logger.info("Migration progress [%s]: %d/%d (%d%%)", label, processed, total, threshold)
+        if msg:
+            self._log(msg)
 
     def add_arguments(self, parser) -> None:
         """
@@ -142,6 +178,13 @@ class Command(BaseCommand):
             ),
             default=True,
         )
+        parser.add_argument(
+            "--log-file",
+            type=str,
+            help="Path to write structured log output (e.g. /proc/1/fd/1 for container logs). When omitted, progress is only written to stdout.",
+            required=False,
+            default=None,
+        )
 
     def _warn_ignored_flags(self, options: dict) -> None:
         if options.get("api_slug"):
@@ -173,6 +216,7 @@ class Command(BaseCommand):
             CommandError: If service doesn't exist, user doesn't exist, or migration fails
         """
         self._warn_ignored_flags(options)
+        self._configure_logging(options.get("log_file"))
 
         if MigrateServiceDataHasRan.has_migration_completed():
             self.stdout.write("Migration has already completed. Skipping.")
@@ -713,10 +757,10 @@ class Command(BaseCommand):
             updated_service_resource["service_id"] = existing_resource.service_id
 
             if incoming_data == local_data:
-                logger.info(f"Correcting service_id of {resource_type.name} with name {upstream_resource['name']}.")
+                self._log(f"Correcting service_id of {resource_type.name} with name {upstream_resource['name']}.")
             else:
                 updated_service_resource["resource_data"] = local_data
-                logger.warning(f"Updating already-merged {resource_type.name} with name {upstream_resource['name']}.")
+                self._log(f"Updating already-merged {resource_type.name} with name {upstream_resource['name']}.", logging.WARNING)
 
         # case 2: merge: We only set upstream metadata and ansible_id to be the same as gateway's
         # don't set anything on the gateway
@@ -727,7 +771,7 @@ class Command(BaseCommand):
                 "resource_data": local_data,
             }
         )
-        logger.warning(f"Merging {resource_type.name} with conflicting name {upstream_resource['name']}.")
+        self._log(f"Merging {resource_type.name} with conflicting name {upstream_resource['name']}.", logging.WARNING)
 
         return create_gateway_resource
 
@@ -1417,7 +1461,7 @@ class Command(BaseCommand):
         page = 1
         total_count = None  # we will check this on each page to see if anything changed
         while True:
-            logger.info(f"Fetching page {page} of role {assignment_actor.value} assignments from {service_slug}")
+            self._log(f"Fetching page {page} of role {assignment_actor.value} assignments from {service_slug}")
             filters: Dict[str, int | str] = {'page': page, **self.BIG_PAGE_FILTERS}
             if role_definitions_to_exclude:
                 filters['not__role_definition__name__in'] = ','.join(role_definitions_to_exclude)
@@ -1433,9 +1477,10 @@ class Command(BaseCommand):
                 self._current_assignment_total = total_count
             elif total_count != json_response.get('count', 0):
                 new_count = json_response.get('count', 0)
-                logger.warning(
+                self._log(
                     f"Role {assignment_actor.value} assignment count changed from {total_count} to {new_count}"
-                    " during pagination (concurrent modification); continuing but will need re-run"
+                    " during pagination (concurrent modification); continuing but will need re-run",
+                    logging.WARNING,
                 )
                 total_count = new_count
                 self._services_with_count_drift.add(service_slug)

--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -105,7 +105,7 @@ class Command(BaseCommand):
             if console_handler and console_handler.formatter:
                 handler.setFormatter(console_handler.formatter)
             logger.addHandler(handler)
-            if logger.getEffectiveLevel() > logging.INFO:
+            if logger.level == logging.NOTSET or logger.level > logging.INFO:
                 logger.setLevel(logging.INFO)
         else:
             logger.addHandler(logging.NullHandler())

--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -88,8 +88,14 @@ class Command(BaseCommand):
         replaces all handlers with a NullHandler so logger calls are silently
         discarded and all output goes through self.stdout only.
         """
+        for handler in logger.handlers[:]:
+            handler.close()
         logger.handlers.clear()
         logger.propagate = False
+
+        if hasattr(self, '_log_file_handle') and self._log_file_handle:
+            self._log_file_handle.close()
+            self._log_file_handle = None
 
         if log_file:
             self._log_file_handle = open(log_file, 'w')
@@ -99,11 +105,12 @@ class Command(BaseCommand):
             if console_handler and console_handler.formatter:
                 handler.setFormatter(console_handler.formatter)
             logger.addHandler(handler)
-            logger.setLevel(logging.INFO)
+            if logger.level > logging.INFO:
+                logger.setLevel(logging.INFO)
         else:
             logger.addHandler(logging.NullHandler())
 
-    def _log(self, msg: str, level: int = logging.INFO) -> None:
+    def _log(self, msg: str, level: int) -> None:
         """
         Write a message to both stdout (returned to the caller) and the logger
         (written to --log-file when provided).
@@ -147,7 +154,7 @@ class Command(BaseCommand):
                     msg = f"Migration progress [{label}]: {processed}/{total} ({threshold}%)"
 
         if msg:
-            self._log(msg)
+            self._log(msg, logging.INFO)
 
     def add_arguments(self, parser) -> None:
         """
@@ -759,7 +766,7 @@ class Command(BaseCommand):
             updated_service_resource["service_id"] = existing_resource.service_id
 
             if incoming_data == local_data:
-                self._log(f"Correcting service_id of {resource_type.name} with name {upstream_resource['name']}.")
+                self._log(f"Correcting service_id of {resource_type.name} with name {upstream_resource['name']}.", logging.INFO)
             else:
                 updated_service_resource["resource_data"] = local_data
                 self._log(f"Updating already-merged {resource_type.name} with name {upstream_resource['name']}.", logging.WARNING)
@@ -1463,7 +1470,7 @@ class Command(BaseCommand):
         page = 1
         total_count = None  # we will check this on each page to see if anything changed
         while True:
-            self._log(f"Fetching page {page} of role {assignment_actor.value} assignments from {service_slug}")
+            self._log(f"Fetching page {page} of role {assignment_actor.value} assignments from {service_slug}", logging.INFO)
             filters: Dict[str, int | str] = {'page': page, **self.BIG_PAGE_FILTERS}
             if role_definitions_to_exclude:
                 filters['not__role_definition__name__in'] = ','.join(role_definitions_to_exclude)

--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -79,6 +79,18 @@ class Command(BaseCommand):
     There is no option to control merging of users, because users are never migrated.
     The exception is that the provided --username, which will be merged."""
 
+    @staticmethod
+    def _copy_console_handler_config(handler: logging.Handler) -> None:
+        """Copy formatter and filters from the 'aap' logger's console handler."""
+        aap_handlers = logging.getLogger('aap').handlers
+        if not aap_handlers:
+            return
+        console_handler = aap_handlers[0]
+        if console_handler.formatter:
+            handler.setFormatter(console_handler.formatter)
+        for f in console_handler.filters:
+            handler.addFilter(f)
+
     def _configure_logging(self, log_file: Optional[str]) -> None:
         """
         Configure the command's logger based on --log-file.
@@ -101,12 +113,7 @@ class Command(BaseCommand):
             self._log_file_handle = open(log_file, 'w')
             handler = logging.StreamHandler(self._log_file_handle)
             handler.setLevel(logging.INFO)
-            console_handler = logging.getLogger('aap').handlers[0] if logging.getLogger('aap').handlers else None
-            if console_handler:
-                if console_handler.formatter:
-                    handler.setFormatter(console_handler.formatter)
-                for f in console_handler.filters:
-                    handler.addFilter(f)
+            self._copy_console_handler_config(handler)
             logger.addHandler(handler)
             if logger.level == logging.NOTSET or logger.level > logging.INFO:
                 logger.setLevel(logging.INFO)

--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -95,7 +95,9 @@ class Command(BaseCommand):
             self._log_file_handle = open(log_file, 'w')
             handler = logging.StreamHandler(self._log_file_handle)
             handler.setLevel(logging.INFO)
-            handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)-8s %(name)s %(message)s'))
+            console_handler = logging.getLogger('aap').handlers[0] if logging.getLogger('aap').handlers else None
+            if console_handler and console_handler.formatter:
+                handler.setFormatter(console_handler.formatter)
             logger.addHandler(handler)
             logger.setLevel(logging.INFO)
         else:

--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -102,8 +102,11 @@ class Command(BaseCommand):
             handler = logging.StreamHandler(self._log_file_handle)
             handler.setLevel(logging.INFO)
             console_handler = logging.getLogger('aap').handlers[0] if logging.getLogger('aap').handlers else None
-            if console_handler and console_handler.formatter:
-                handler.setFormatter(console_handler.formatter)
+            if console_handler:
+                if console_handler.formatter:
+                    handler.setFormatter(console_handler.formatter)
+                for f in console_handler.filters:
+                    handler.addFilter(f)
             logger.addHandler(handler)
             if logger.level == logging.NOTSET or logger.level > logging.INFO:
                 logger.setLevel(logging.INFO)

--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -101,12 +101,7 @@ class Command(BaseCommand):
             self._log_file_handle = open(log_file, 'w')
             handler = logging.StreamHandler(self._log_file_handle)
             handler.setLevel(logging.INFO)
-            console_handler = logging.getLogger('aap').handlers[0] if logging.getLogger('aap').handlers else None
-            if console_handler:
-                if console_handler.formatter:
-                    handler.setFormatter(console_handler.formatter)
-                for f in console_handler.filters:
-                    handler.addFilter(f)
+            handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)-8s %(name)s %(message)s'))
             logger.addHandler(handler)
             if logger.level == logging.NOTSET or logger.level > logging.INFO:
                 logger.setLevel(logging.INFO)

--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -105,7 +105,7 @@ class Command(BaseCommand):
             if console_handler and console_handler.formatter:
                 handler.setFormatter(console_handler.formatter)
             logger.addHandler(handler)
-            if logger.level > logging.INFO:
+            if logger.getEffectiveLevel() > logging.INFO:
                 logger.setLevel(logging.INFO)
         else:
             logger.addHandler(logging.NullHandler())

--- a/aap_gateway_api/tests/management/test_migrate_resources.py
+++ b/aap_gateway_api/tests/management/test_migrate_resources.py
@@ -2748,24 +2748,17 @@ def test_configure_logging_respects_lower_level(tmp_path):
     cmd._log_file_handle.close()
 
 
-def test_configure_logging_inherits_formatter(tmp_path):
-    """When the aap logger has a console handler with a formatter, it should be reused."""
-    aap_logger = logging.getLogger("aap")
-    original_handlers = aap_logger.handlers[:]
-    test_formatter = logging.Formatter("TEST %(message)s")
-    test_handler = logging.StreamHandler()
-    test_handler.setFormatter(test_formatter)
-    aap_logger.handlers = [test_handler]
+def test_configure_logging_uses_simple_formatter(tmp_path):
+    """_configure_logging sets a standalone formatter that doesn't depend on custom filters."""
+    cmd = MigrateCommand()
+    cmd._configure_logging(str(tmp_path / "test.log"))
 
-    try:
-        cmd = MigrateCommand()
-        cmd._configure_logging(str(tmp_path / "test.log"))
-
-        migrate_logger = logging.getLogger(MIGRATE_LOGGER_NAME)
-        assert migrate_logger.handlers[0].formatter is test_formatter
-        cmd._log_file_handle.close()
-    finally:
-        aap_logger.handlers = original_handlers
+    migrate_logger = logging.getLogger(MIGRATE_LOGGER_NAME)
+    formatter = migrate_logger.handlers[0].formatter
+    assert formatter is not None
+    assert "%(message)s" in formatter._fmt
+    assert "%(levelname)" in formatter._fmt
+    cmd._log_file_handle.close()
 
 
 def test_log_info_writes_to_stdout(caplog):

--- a/aap_gateway_api/tests/management/test_migrate_resources.py
+++ b/aap_gateway_api/tests/management/test_migrate_resources.py
@@ -1,4 +1,6 @@
+import logging
 import uuid
+from io import StringIO
 from unittest.mock import Mock, patch
 
 import pytest
@@ -2663,3 +2665,140 @@ def test_log_progress_no_duplicate_100(caplog):
 
     progress_msgs = [msg for msg in caplog.messages if "(100%)" in msg and "exact" in msg]
     assert len(progress_msgs) == 1
+
+
+# =============================================================================
+# Tests for _configure_logging and _log (AAP-76816)
+# =============================================================================
+
+MIGRATE_LOGGER_NAME = "aap.gateway.management.commands.migrate_service_data"
+
+
+def test_configure_logging_with_log_file(tmp_path):
+    """When --log-file is provided, logger gets a StreamHandler at INFO."""
+    cmd = MigrateCommand()
+    log_file = tmp_path / "test.log"
+
+    cmd._configure_logging(str(log_file))
+
+    migrate_logger = logging.getLogger(MIGRATE_LOGGER_NAME)
+    assert len(migrate_logger.handlers) == 1
+    assert isinstance(migrate_logger.handlers[0], logging.StreamHandler)
+    assert migrate_logger.level <= logging.INFO
+    assert not migrate_logger.propagate
+
+    cmd._log_file_handle.close()
+
+
+def test_configure_logging_without_log_file():
+    """When --log-file is omitted, logger gets a NullHandler."""
+    cmd = MigrateCommand()
+
+    cmd._configure_logging(None)
+
+    migrate_logger = logging.getLogger(MIGRATE_LOGGER_NAME)
+    assert len(migrate_logger.handlers) == 1
+    assert isinstance(migrate_logger.handlers[0], logging.NullHandler)
+    assert not migrate_logger.propagate
+
+
+def test_configure_logging_closes_previous_file_handle(tmp_path):
+    """Calling _configure_logging twice closes the previous file handle."""
+    cmd = MigrateCommand()
+    first_log = tmp_path / "first.log"
+    second_log = tmp_path / "second.log"
+
+    cmd._configure_logging(str(first_log))
+    first_handle = cmd._log_file_handle
+    assert not first_handle.closed
+
+    cmd._configure_logging(str(second_log))
+    assert first_handle.closed
+    assert not cmd._log_file_handle.closed
+
+    cmd._log_file_handle.close()
+
+
+def test_configure_logging_respects_lower_level(tmp_path):
+    """If the logger is already at DEBUG, _configure_logging should not raise it to INFO."""
+    migrate_logger = logging.getLogger(MIGRATE_LOGGER_NAME)
+    migrate_logger.setLevel(logging.DEBUG)
+
+    cmd = MigrateCommand()
+    cmd._configure_logging(str(tmp_path / "test.log"))
+
+    assert migrate_logger.level == logging.DEBUG
+
+    cmd._log_file_handle.close()
+
+
+def test_configure_logging_inherits_formatter(tmp_path):
+    """When the aap logger has a console handler with a formatter, it should be reused."""
+    aap_logger = logging.getLogger("aap")
+    original_handlers = aap_logger.handlers[:]
+    test_formatter = logging.Formatter("TEST %(message)s")
+    test_handler = logging.StreamHandler()
+    test_handler.setFormatter(test_formatter)
+    aap_logger.handlers = [test_handler]
+
+    try:
+        cmd = MigrateCommand()
+        cmd._configure_logging(str(tmp_path / "test.log"))
+
+        migrate_logger = logging.getLogger(MIGRATE_LOGGER_NAME)
+        assert migrate_logger.handlers[0].formatter is test_formatter
+        cmd._log_file_handle.close()
+    finally:
+        aap_logger.handlers = original_handlers
+
+
+def test_log_info_writes_to_stdout(caplog):
+    """_log at INFO writes to stdout and the logger."""
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+
+    with caplog.at_level("INFO", logger=MIGRATE_LOGGER_NAME):
+        cmd._log("test info message", logging.INFO)
+
+    assert "test info message" in cmd.stdout.getvalue()
+    assert "test info message" in caplog.messages
+
+
+def test_log_warning_writes_to_stderr(caplog):
+    """_log at WARNING writes to stderr and the logger."""
+    cmd = MigrateCommand()
+    cmd.stderr = StringIO()
+
+    with caplog.at_level("WARNING", logger=MIGRATE_LOGGER_NAME):
+        cmd._log("test warning message", logging.WARNING)
+
+    assert "test warning message" in cmd.stderr.getvalue()
+    assert "test warning message" in caplog.messages
+
+
+def test_log_writes_to_log_file(tmp_path):
+    """_log writes structured output to --log-file."""
+    cmd = MigrateCommand()
+    log_file = tmp_path / "test.log"
+
+    cmd._configure_logging(str(log_file))
+    cmd._log("file output test", logging.INFO)
+    cmd._log_file_handle.flush()
+
+    content = log_file.read_text()
+    assert "file output test" in content
+    assert "INFO" in content
+
+    cmd._log_file_handle.close()
+
+
+def test_log_file_not_written_without_flag(tmp_path, caplog):
+    """Without --log-file, logger messages go to NullHandler only."""
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd._configure_logging(None)
+
+    cmd._log("null handler test", logging.INFO)
+
+    assert "null handler test" in cmd.stdout.getvalue()
+    assert "null handler test" not in caplog.messages

--- a/aap_gateway_api/tests/management/test_migrate_resources.py
+++ b/aap_gateway_api/tests/management/test_migrate_resources.py
@@ -2748,17 +2748,24 @@ def test_configure_logging_respects_lower_level(tmp_path):
     cmd._log_file_handle.close()
 
 
-def test_configure_logging_uses_simple_formatter(tmp_path):
-    """_configure_logging sets a standalone formatter that doesn't depend on custom filters."""
-    cmd = MigrateCommand()
-    cmd._configure_logging(str(tmp_path / "test.log"))
+def test_configure_logging_inherits_formatter(tmp_path):
+    """When the aap logger has a console handler with a formatter, it should be reused."""
+    aap_logger = logging.getLogger("aap")
+    original_handlers = aap_logger.handlers[:]
+    test_formatter = logging.Formatter("TEST %(message)s")
+    test_handler = logging.StreamHandler()
+    test_handler.setFormatter(test_formatter)
+    aap_logger.handlers = [test_handler]
 
-    migrate_logger = logging.getLogger(MIGRATE_LOGGER_NAME)
-    formatter = migrate_logger.handlers[0].formatter
-    assert formatter is not None
-    assert "%(message)s" in formatter._fmt
-    assert "%(levelname)" in formatter._fmt
-    cmd._log_file_handle.close()
+    try:
+        cmd = MigrateCommand()
+        cmd._configure_logging(str(tmp_path / "test.log"))
+
+        migrate_logger = logging.getLogger(MIGRATE_LOGGER_NAME)
+        assert migrate_logger.handlers[0].formatter is test_formatter
+        cmd._log_file_handle.close()
+    finally:
+        aap_logger.handlers = original_handlers
 
 
 def test_log_info_writes_to_stdout(caplog):

--- a/aap_gateway_api/tests/management/test_migrate_resources.py
+++ b/aap_gateway_api/tests/management/test_migrate_resources.py
@@ -2674,6 +2674,22 @@ def test_log_progress_no_duplicate_100(caplog):
 MIGRATE_LOGGER_NAME = "aap.gateway.management.commands.migrate_service_data"
 
 
+@pytest.fixture(autouse=True)
+def _restore_migrate_logger_state():
+    migrate_logger = logging.getLogger(MIGRATE_LOGGER_NAME)
+    original_handlers = migrate_logger.handlers[:]
+    original_level = migrate_logger.level
+    original_propagate = migrate_logger.propagate
+    try:
+        yield
+    finally:
+        for handler in migrate_logger.handlers[:]:
+            handler.close()
+        migrate_logger.handlers = original_handlers
+        migrate_logger.setLevel(original_level)
+        migrate_logger.propagate = original_propagate
+
+
 def test_configure_logging_with_log_file(tmp_path):
     """When --log-file is provided, logger gets a StreamHandler at INFO."""
     cmd = MigrateCommand()
@@ -2798,7 +2814,8 @@ def test_log_file_not_written_without_flag(tmp_path, caplog):
     cmd.stdout = StringIO()
     cmd._configure_logging(None)
 
-    cmd._log("null handler test", logging.INFO)
+    with caplog.at_level("INFO", logger=MIGRATE_LOGGER_NAME):
+        cmd._log("null handler test", logging.INFO)
 
     assert "null handler test" in cmd.stdout.getvalue()
     assert "null handler test" not in caplog.messages

--- a/aap_gateway_api/tests/management/test_migrate_resources.py
+++ b/aap_gateway_api/tests/management/test_migrate_resources.py
@@ -2819,3 +2819,87 @@ def test_log_file_not_written_without_flag(tmp_path, caplog):
 
     assert "null handler test" in cmd.stdout.getvalue()
     assert "null handler test" not in caplog.messages
+
+
+def test_copy_console_handler_config_no_aap_handlers(tmp_path):
+    """When the aap logger has no handlers, _copy_console_handler_config is a no-op."""
+    aap_logger = logging.getLogger("aap")
+    original_handlers = aap_logger.handlers[:]
+    aap_logger.handlers = []
+
+    try:
+        cmd = MigrateCommand()
+        cmd._configure_logging(str(tmp_path / "test.log"))
+
+        migrate_logger = logging.getLogger(MIGRATE_LOGGER_NAME)
+        assert migrate_logger.handlers[0].formatter is None
+        assert migrate_logger.handlers[0].filters == []
+        cmd._log_file_handle.close()
+    finally:
+        aap_logger.handlers = original_handlers
+
+
+@pytest.mark.django_db
+def test_reconcile_existing_resource_matching_ansible_id_same_data():
+    """Case 1 with matching data: logs 'Correcting service_id'."""
+    from ansible_base.resource_registry.models import ResourceType
+
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+
+    resource_type = ResourceType.objects.get(name="shared.organization")
+    org = Organization.objects.create(name="reconcile-org")
+    resource = Resource.objects.get(content_type=resource_type.content_type, object_id=org.pk)
+    local_data = resource_type.serializer_class(org).data
+
+    resource_context = {
+        "type": resource_type,
+        "unique_fields": ["name"],
+        "LocalResourceModel": Organization,
+    }
+    upstream_resource = {
+        "ansible_id": str(resource.ansible_id),
+        "name": org.name,
+        "resource_data": local_data,
+    }
+    updated_service_resource = {}
+
+    result = cmd._reconcile_existing_resource(upstream_resource, resource_context, local_data, updated_service_resource)
+
+    assert result is False
+    assert "Correcting service_id" in cmd.stdout.getvalue()
+
+
+@pytest.mark.django_db
+def test_reconcile_existing_resource_matching_ansible_id_different_data():
+    """Case 1 with different data: logs 'Updating already-merged' and overwrites resource_data."""
+    from ansible_base.resource_registry.models import ResourceType
+
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+
+    resource_type = ResourceType.objects.get(name="shared.organization")
+    org = Organization.objects.create(name="reconcile-org-diff")
+    resource = Resource.objects.get(content_type=resource_type.content_type, object_id=org.pk)
+    local_data = resource_type.serializer_class(org).data
+
+    resource_context = {
+        "type": resource_type,
+        "unique_fields": ["name"],
+        "LocalResourceModel": Organization,
+    }
+    upstream_resource = {
+        "ansible_id": str(resource.ansible_id),
+        "name": org.name,
+        "resource_data": {**local_data, "description": "stale upstream copy"},
+    }
+    updated_service_resource = {}
+
+    result = cmd._reconcile_existing_resource(upstream_resource, resource_context, local_data, updated_service_resource)
+
+    assert result is False
+    assert updated_service_resource["resource_data"] == local_data
+    combined_output = cmd.stdout.getvalue() + cmd.stderr.getvalue()
+    assert "Updating already-merged" in combined_output

--- a/tools/scripts/run_tests.sh
+++ b/tools/scripts/run_tests.sh
@@ -21,5 +21,5 @@ pytest \
     --cov-report=json \
     --cov-branch \
     --junit-xml=aap-gateway-test-results.xml \
-    ${GATEWAY_TEST_DIRS-aap_gateway_api/tests} \
+    ${GATEWAY_TEST_DIRS:-aap_gateway_api/tests} \
     "$@"

--- a/tools/scripts/run_tests.sh
+++ b/tools/scripts/run_tests.sh
@@ -21,5 +21,5 @@ pytest \
     --cov-report=json \
     --cov-branch \
     --junit-xml=aap-gateway-test-results.xml \
-    ${GATEWAY_TEST_DIRS:-aap_gateway_api/tests} \
+    ${GATEWAY_TEST_DIRS-aap_gateway_api/tests} \
     "$@"


### PR DESCRIPTION
## Summary

- Adds `--log-file` argument to `migrate_service_data` for writing structured log output to a file (e.g. `/proc/1/fd/1` for OCP container logs)
- Introduces `_log(msg, level)` method that writes to both stdout/stderr (returned to Ansible) and the logger (written to `--log-file`)
- Replaces all direct `logger.info()`/`logger.warning()` calls with `_log()` for consistent dual-channel output
- When `--log-file` is omitted, logger uses `NullHandler` — no log level configuration needed in Django settings

## Why

Progress messages from AAP-76816 used `logger.info()` which is silently dropped under the default `WARNING` log level. Rather than changing global log levels (noisy) or patching Django settings templates, the command now manages its own logging: `--log-file` enables structured output to a specific destination, while stdout always works for the direct caller.

## Operator integration

The operator playbook change is minimal — no `tee`, no `pipefail`, no settings template changes:

```yaml
command: aap-gateway-manage migrate_service_data --username={{ admin_user }} --log-file=/proc/1/fd/1
```

End users see progress via `oc logs -f <pod> -c api`.

## Test plan

- [x] Existing `_log_progress` tests pass unchanged (`caplog` still captures via `logger.log()`)
- [x] Count-drift warning tests pass unchanged
- [ ] Manual: `aap-gateway-manage migrate_service_data --username=admin` — progress on stdout only
- [ ] Manual: `aap-gateway-manage migrate_service_data --username=admin --log-file=/tmp/test.log` — progress on stdout AND structured log in file
- [ ] OCP: operator with `--log-file=/proc/1/fd/1` — progress visible in `oc logs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--log-file` option to write migration logs to a user-specified file.

* **Refactor**
  * Improved migration logging with safe reconfiguration, consistent message routing (info to stdout, warnings to stderr), and clearer progress/status output.
  * Standardized related conflict and pagination messaging for more consistent visibility.

* **Tests**
  * Added unit tests validating `--log-file` handling, handler/formatter behavior, stdout/stderr routing, and log file output.

* **Chores**
  * Adjusted test runner fallback behavior for default test directory selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->