### PR TITLE
[AAP-80580] Pin dynaconf<3.3.0 to fix startup crash

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -20,7 +20,7 @@ PyYAML
 # Not directly imported but pinned per dependabot alerts
 urllib3>=2.7.0   # CVE-2026-44431 / CVE-2026-44432
 argon2-cffi
-dynaconf>=3.2.13,<4.0.0  # CVE-2026-33154
+dynaconf>=3.2.13,<3.3.0  # CVE-2026-33154; pin <3.3.0 per AAP-80580 (breaking internal API change)
 referencing<0.37.0  # consistent with DAB pin from jsonschema-path
 jsonschema<4.26  # 4.26+ requires rpds-py>=0.25, incompatible with hermeto
 rpds-py<0.25  # hermeto does not support rpds-py>=0.25


### PR DESCRIPTION
## Description

- **What is being changed?** Tightening the upper bound on dynaconf from `<4.0.0` to `<3.3.0` in `requirements/requirements.in`.
- **Why is this change needed?** Dynaconf 3.3.0 (released June 24, 2026) includes [PR #1335](https://github.com/dynaconf/dynaconf/pull/1335) which moved internal attributes (`_loaded_files`, `_post_hooks`) to a new `DynaconfCore` namespace with no backwards compatibility. DAB's `load_python_file_with_injected_context()` accesses these attributes directly, causing gateway to crash on startup with `AttributeError: _loaded_files`.
- **How does this change address the issue?** Prevents pip from resolving dynaconf 3.3.0, keeping the working 3.2.x series until DAB is updated to not rely on dynaconf internals.

**JIRA:** AAP-80580

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites
- A local aap-dev environment or Konflux CI

### Steps to Test
1. Without this pin: `pip install dynaconf>=3.2.13,<4.0.0` resolves to 3.3.0 → gateway crashes on startup
2. With this pin: `pip install dynaconf>=3.2.13,<3.3.0` resolves to 3.2.13 → gateway starts normally

### Expected Results
Gateway starts and migrations run successfully without `AttributeError: _loaded_files`.

## Additional Context

### Required Actions

- [x] Requires downstream repository changes
  - django-ansible-base needs the same pin (separate PR)
  - Long-term: DAB should stop relying on dynaconf internal attributes

### Error Stack Trace

```
File "/app/django-ansible-base/ansible_base/lib/dynamic_config/dynaconf_helpers.py", line 290
    settings._loaded_files.append(file_path)
AttributeError: _loaded_files
```

---
**Note:** This PR was developed with assistance from Claude AI assistant.

[AAP-80580]: https://redhat.atlassian.net/browse/AAP-80580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency constraint to keep the app on a safe, compatible version range.
  * Applied a stricter version cap to avoid a known security issue and prevent compatibility problems with newer releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->