### PR TITLE
[AAP-80669] rbac service cursor pagination

### DIFF
--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -1,6 +1,7 @@
 import logging
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Tuple, Type
+from urllib.parse import parse_qs, urlparse
 
 from ansible_base.authentication.models import AuthenticatorUser
 from ansible_base.authentication.models.authenticator import Authenticator
@@ -1525,10 +1526,11 @@ class Command(BaseCommand):
         Crash safety: the cursor is advanced in the database after each
         fully-processed page, so at most one page of work is lost.
         """
-        page = 1
+        page_num = 1
         created = 0
+        next_cursor = None
 
-        # Build base filters once — only 'page' changes between iterations.
+        # Build base filters once.
         # snapshot_pk is immutable (set once in _CursorStore.__init__).
         base_filters: Dict[str, Any] = {'order_by': 'id', **self.BIG_PAGE_FILTERS}
         if roles_to_exclude:
@@ -1537,9 +1539,12 @@ class Command(BaseCommand):
             base_filters['id__gt'] = str(cursor.last_pk)
 
         while True:
-            response = list_fn(filters={**base_filters, 'page': page})
+            filters = {**base_filters}
+            if next_cursor:
+                filters['cursor'] = next_cursor
+            response = list_fn(filters=filters)
             if response.status_code != 200:
-                self._raise_fetch_error(response, assignment_type, page)
+                self._raise_fetch_error(response, assignment_type, page_num)
 
             data = response.json()
             results = data.get('results') or []
@@ -1559,9 +1564,13 @@ class Command(BaseCommand):
                 )
             cursor.advance(last_pk_on_page)
 
-            if not data.get('next'):
+            next_url = data.get('next')
+            if not next_url:
                 break
-            page += 1
+            next_cursor = parse_qs(urlparse(next_url).query).get('cursor', [None])[0]
+            if not next_cursor:
+                break
+            page_num += 1
 
         return created
 
@@ -1769,7 +1778,7 @@ class Command(BaseCommand):
 
         try:
             check_resp = list_fn(filters={'order_by': 'id', 'id__gt': str(db_cursor.last_pk), 'page_size': '1'})
-            if check_resp.status_code == 200 and check_resp.json().get('count', 0) > 0:
+            if check_resp.status_code == 200 and len(check_resp.json().get('results', [])) > 0:
                 self._log(f"Warning: new {assignment_type} assignments appeared during migration of {service_slug} (concurrent modification)", logging.WARNING)
                 return True
         except Exception:

--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -43,10 +43,11 @@ class _CursorStore:
     trivial to backport across versions.
 
     Key invariant: self.last_pk is set once in __init__ and NEVER
-    mutated.  advance() only persists progress to the database.
-    This ensures the HTTP id__gt filter stays immutable across all
-    pages of a single run, preventing items from being skipped when
-    the cursor advances in the database between pages.
+    mutated.  advance() only persists progress to the database
+    and updates last_advanced_pk in memory.  This ensures the HTTP
+    id__gt filter stays immutable across all pages of a single run,
+    while last_advanced_pk tracks the actual high-water mark for
+    drift detection without requiring a DB re-read.
 
     If any database operation fails, the store degrades gracefully
     to last_pk=0, causing the command to reprocess all assignments.
@@ -62,6 +63,7 @@ class _CursorStore:
         self.service_slug = service_slug
         self.assignment_type = assignment_type
         self.last_pk = self._load()
+        self.last_advanced_pk = self.last_pk
 
     def _ensure_table(self):
         """Create the cursor table if it does not already exist."""
@@ -105,10 +107,13 @@ class _CursorStore:
 
         The in-memory last_pk stays at its initial value so the HTTP
         id__gt filter remains consistent across all pages of a run.
+        last_advanced_pk is updated unconditionally so drift detection
+        can use the actual high-water mark without a DB re-read.
         If the upsert fails, a warning is logged but the run continues —
         the next invocation will reprocess from the old position, which
         is safe because give_permission is idempotent.
         """
+        self.last_advanced_pk = pk
         try:
             with connection.cursor() as cur:
                 cur.execute(
@@ -1508,34 +1513,30 @@ class Command(BaseCommand):
         raise RuntimeError(f"Failed to fetch {assignment_type} assignments page {page}: HTTP {response.status_code}\n{body_preview}")
 
     def _paginate_and_create(self, list_fn, assignment_type: str, roles_to_exclude: List[str], cursor: '_CursorStore') -> int:
-        """Paginate one assignment endpoint using cursor pagination, creating assignments per page.
+        """Paginate one assignment endpoint, creating assignments per page.
 
-        Uses cursor-based pagination where results are ordered by ``id``
-        (ascending), so the last result on each page has the highest PK.
-        The cursor is advanced per page so the drift check knows where
-        this run ended and crash recovery can resume from the last
-        completed page.
+        Follows API pagination tokens from the ``next`` URL while tracking
+        progress via a PK watermark (``_CursorStore``) for crash recovery.
+        Results are ordered by ``id`` (ascending) by DAB's
+        ``ServiceCursorPagination``, so the last result on each page has
+        the highest PK.
 
-        On a reinstall where the cursor is already past the last PK,
+        On a reinstall where the watermark is already past the last PK,
         the first page returns zero results and the method returns
         immediately.
 
-        No per-page retry — the PK cursor provides crash recovery.
-        If the command fails on an HTTP error, the installer re-runs
-        it and the cursor resumes from the last completed page.
-
-        Crash safety: the cursor is advanced in the database after each
-        fully-processed page, so at most one page of work is lost.
-        Since give_permission is idempotent, replayed assignments are
-        harmless.
+        Crash safety: the watermark is advanced in the database after
+        each fully-processed page, so at most one page of work is
+        replayed on re-run. Since give_permission is idempotent,
+        replayed assignments are harmless.
         """
         page_num = 1
         created = 0
         pagination_token = None
         last_pk = None
 
-        # Build base filters once.
-        # snapshot_pk is immutable (set once in _CursorStore.__init__).
+        # Build base filters once.  cursor.last_pk is immutable (set once
+        # in _CursorStore.__init__), so id__gt stays consistent across pages.
         base_filters: Dict[str, Any] = self._get_base_filters(roles_to_exclude, cursor)
 
         while True:
@@ -1553,15 +1554,10 @@ class Command(BaseCommand):
 
             created += self._create_page_assignments(results, assignment_type)
 
-            # Advance cursor in DB for crash recovery.  cursor.last_pk
-            # is NOT mutated — base_filters stays consistent.
+            # Advance watermark in DB for crash recovery.
             last_pk = results[-1].get('id')
             if last_pk is None:
-                raise RuntimeError(
-                    f"API returned {assignment_type} assignment without 'id' field — "
-                    f"cannot advance cursor. Check that the upstream service "
-                    f"is running a compatible DAB version."
-                )
+                raise RuntimeError(f"API returned {assignment_type} assignment without 'id' field — cannot advance watermark.")
             cursor.advance(last_pk)
             pagination_token, is_last = self._is_last(data)
             if is_last:
@@ -1573,18 +1569,18 @@ class Command(BaseCommand):
     def _get_base_filters(self, roles_to_exclude: List[str], cursor: '_CursorStore') -> Dict[str, Any]:
         """Build base filters for assignment pagination.
 
-        This method is called once per assignment type to construct the
-        base filters used in the pagination loop.  It sets up the
-        'order_by', 'id__gt', and 'not__role_definition__name__in' filters
-        based on the cursor and roles to exclude.
+        Called once per assignment type.  Sets up 'id__gt' and
+        'not__role_definition__name__in' filters based on the watermark
+        and roles to exclude.
 
         Args:
             roles_to_exclude: List of role names to exclude from the results
             cursor: CursorStore instance tracking the last processed PK
         """
-
-        # Note: ordering is controlled by ServiceCursorPagination (ordering = 'id')
-        # in DAB, not by a query param.
+        # NOTE: order_by here is redundant — ServiceCursorPagination in DAB
+        # controls the actual ordering and ignores this query param. We
+        # include it for readability but it has no effect on cursor-paginated
+        # endpoints.
         base_filters: Dict[str, Any] = {**self.BIG_PAGE_FILTERS, 'order_by': 'id'}
         if roles_to_exclude:
             base_filters['not__role_definition__name__in'] = ','.join(roles_to_exclude)
@@ -1786,7 +1782,7 @@ class Command(BaseCommand):
             # fetched" and "this check."  A tiny window remains between
             # this check and the migration flag being set, but that gap
             # is milliseconds and practically negligible.
-            if self._check_for_drift(list_fn, assignment_type, service_slug):
+            if self._check_for_drift(list_fn, assignment_type, service_slug, cursor):
                 drift_detected = True
 
         self._log(f"Role assignment migration for {service_slug} completed ({total_created} total created)", logging.INFO)
@@ -1798,19 +1794,19 @@ class Command(BaseCommand):
                 f"detected. Re-run to process remaining assignments."
             )
 
-    def _check_for_drift(self, list_fn, assignment_type: str, service_slug: str) -> bool:
-        """Check if new assignments appeared since the cursor was last advanced.
+    def _check_for_drift(self, list_fn, assignment_type: str, service_slug: str, cursor: '_CursorStore') -> bool:
+        """Check if new assignments appeared since the last page was processed.
 
-        Loads a fresh cursor from the DB (reflecting the last advance()
-        call) and asks the API if any items exist beyond it.  Returns
-        True if drift is detected, False otherwise.
+        Uses cursor.last_advanced_pk (the in-memory high-water mark) so
+        this check works even if the DB writes in advance() failed.
+        Returns True if drift is detected, False otherwise.
         """
-        db_cursor = _CursorStore(service_slug, assignment_type)
-        if db_cursor.last_pk <= 0:
+        if cursor.last_advanced_pk <= 0:
             return False
 
         try:
-            check_resp = list_fn(filters={'order_by': 'id', 'id__gt': str(db_cursor.last_pk), 'page_size': '1'})
+            # NOTE: order_by is redundant — CursorPagination controls ordering.
+            check_resp = list_fn(filters={'order_by': 'id', 'id__gt': str(cursor.last_advanced_pk), 'page_size': '1'})
             if check_resp.status_code == 200 and len(check_resp.json().get('results', [])) > 0:
                 self._log(f"Warning: new {assignment_type} assignments appeared during migration of {service_slug} (concurrent modification)", logging.WARNING)
                 return True

--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -1508,40 +1508,40 @@ class Command(BaseCommand):
         raise RuntimeError(f"Failed to fetch {assignment_type} assignments page {page}: HTTP {response.status_code}\n{body_preview}")
 
     def _paginate_and_create(self, list_fn, assignment_type: str, roles_to_exclude: List[str], cursor: '_CursorStore') -> int:
-        """Paginate one assignment endpoint using a PK cursor, creating assignments per page.
+        """Paginate one assignment endpoint using cursor pagination, creating assignments per page.
 
-        Queries with ``order_by=id&id__gt=<snapshot_pk>`` so only
-        assignments newer than the cursor are fetched.  The snapshot_pk
-        is captured once and stays immutable for the entire run, preventing
-        items from being skipped when the DB cursor advances between pages.
+            Uses cursor-based pagination where results are ordered by ``id``
+            (ascending), so the last result on each page has the highest PK.
+            The cursor is advanced per page so the drift check knows where
+            this run ended and crash recovery can resume from the last
+            completed page.
 
-        On a reinstall where the cursor is already past the last PK,
-        the first page returns zero results and the method returns
-        immediately.
+            On a reinstall where the cursor is already past the last PK,
+            the first page returns zero results and the method returns
+            immediately.
 
-        No per-page retry — the PK cursor provides crash recovery.
-        If the command fails on an HTTP error, the installer re-runs
-        it and the cursor resumes from the last completed page.
+            No per-page retry — the PK cursor provides crash recovery.
+            If the command fails on an HTTP error, the installer re-runs
+            it and the cursor resumes from the last completed page.
 
-        Crash safety: the cursor is advanced in the database after each
-        fully-processed page, so at most one page of work is lost.
+            Crash safety: the cursor is advanced in the database after each
+            fully-processed page, so at most one page of work is lost.
+            Since give_permission is idempotent, replayed assignments are
+            harmless.
         """
         page_num = 1
         created = 0
-        next_cursor = None
+        pagination_token = None
+        last_pk = None
 
         # Build base filters once.
         # snapshot_pk is immutable (set once in _CursorStore.__init__).
-        base_filters: Dict[str, Any] = {'order_by': 'id', **self.BIG_PAGE_FILTERS}
-        if roles_to_exclude:
-            base_filters['not__role_definition__name__in'] = ','.join(roles_to_exclude)
-        if cursor.last_pk > 0:
-            base_filters['id__gt'] = str(cursor.last_pk)
+        base_filters: Dict[str, Any] = self._get_base_filters(roles_to_exclude, cursor)
 
         while True:
             filters = {**base_filters}
-            if next_cursor:
-                filters['cursor'] = next_cursor
+            if pagination_token:
+                filters['cursor'] = pagination_token
             response = list_fn(filters=filters)
             if response.status_code != 200:
                 self._raise_fetch_error(response, assignment_type, page_num)
@@ -1555,24 +1555,57 @@ class Command(BaseCommand):
 
             # Advance cursor in DB for crash recovery.  cursor.last_pk
             # is NOT mutated — base_filters stays consistent.
-            last_pk_on_page = results[-1].get('id')
-            if last_pk_on_page is None:
-                raise RuntimeError(
+            last_pk = results[-1].get('id')
+            if last_pk is None:
+                raise RuntimeError( 
                     f"API returned {assignment_type} assignment without 'id' field — "
                     f"cannot advance cursor. Check that the upstream service "
-                    f"is running a compatible DAB version (requires PR 1032+)."
-                )
-            cursor.advance(last_pk_on_page)
-
-            next_url = data.get('next')
-            if not next_url:
-                break
-            next_cursor = parse_qs(urlparse(next_url).query).get('cursor', [None])[0]
-            if not next_cursor:
+                    f"is running a compatible DAB version."
+                    )
+            cursor.advance(last_pk)
+            pagination_token, is_last = self._is_last(data)
+            if is_last:
                 break
             page_num += 1
 
         return created
+
+    def _get_base_filters(self, roles_to_exclude: List[str], cursor: '_CursorStore') -> Dict[str, Any]:
+        """Build base filters for assignment pagination.
+
+        This method is called once per assignment type to construct the
+        base filters used in the pagination loop.  It sets up the
+        'order_by', 'id__gt', and 'not__role_definition__name__in' filters
+        based on the cursor and roles to exclude.
+
+        Args:
+            roles_to_exclude: List of role names to exclude from the results
+            cursor: CursorStore instance tracking the last processed PK
+        """
+
+        # Note: ordering is controlled by ServiceCursorPagination (ordering = 'id')
+        # in DAB, not by a query param.
+        base_filters: Dict[str, Any] = {**self.BIG_PAGE_FILTERS, 'order_by': 'id'}
+        if roles_to_exclude:
+            base_filters['not__role_definition__name__in'] = ','.join(roles_to_exclude)
+        if cursor.last_pk > 0:
+            base_filters['id__gt'] = str(cursor.last_pk)
+        return base_filters
+
+    def _is_last(self, data: Dict[str, Any]) -> Tuple[str, bool]:
+        """Determine if the current page is the last page of results.
+
+        Returns True if the 'next' field is None or empty, indicating
+        that there are no more pages to fetch.
+        """
+        next_url = data.get('next')
+        if not next_url:
+            return ("", True)
+        parsed_qs = parse_qs(urlparse(next_url).query)
+        pagination_token = parsed_qs.get('cursor', [None])[0]
+        if pagination_token is None:
+            return ("", True)
+        return (pagination_token, False)
 
     def _create_page_assignments(self, results: List[Dict[str, Any]], assignment_type: str) -> int:
         """Create assignments from one page of API results.

--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -1510,24 +1510,24 @@ class Command(BaseCommand):
     def _paginate_and_create(self, list_fn, assignment_type: str, roles_to_exclude: List[str], cursor: '_CursorStore') -> int:
         """Paginate one assignment endpoint using cursor pagination, creating assignments per page.
 
-            Uses cursor-based pagination where results are ordered by ``id``
-            (ascending), so the last result on each page has the highest PK.
-            The cursor is advanced per page so the drift check knows where
-            this run ended and crash recovery can resume from the last
-            completed page.
+        Uses cursor-based pagination where results are ordered by ``id``
+        (ascending), so the last result on each page has the highest PK.
+        The cursor is advanced per page so the drift check knows where
+        this run ended and crash recovery can resume from the last
+        completed page.
 
-            On a reinstall where the cursor is already past the last PK,
-            the first page returns zero results and the method returns
-            immediately.
+        On a reinstall where the cursor is already past the last PK,
+        the first page returns zero results and the method returns
+        immediately.
 
-            No per-page retry — the PK cursor provides crash recovery.
-            If the command fails on an HTTP error, the installer re-runs
-            it and the cursor resumes from the last completed page.
+        No per-page retry — the PK cursor provides crash recovery.
+        If the command fails on an HTTP error, the installer re-runs
+        it and the cursor resumes from the last completed page.
 
-            Crash safety: the cursor is advanced in the database after each
-            fully-processed page, so at most one page of work is lost.
-            Since give_permission is idempotent, replayed assignments are
-            harmless.
+        Crash safety: the cursor is advanced in the database after each
+        fully-processed page, so at most one page of work is lost.
+        Since give_permission is idempotent, replayed assignments are
+        harmless.
         """
         page_num = 1
         created = 0
@@ -1557,11 +1557,11 @@ class Command(BaseCommand):
             # is NOT mutated — base_filters stays consistent.
             last_pk = results[-1].get('id')
             if last_pk is None:
-                raise RuntimeError( 
+                raise RuntimeError(
                     f"API returned {assignment_type} assignment without 'id' field — "
                     f"cannot advance cursor. Check that the upstream service "
                     f"is running a compatible DAB version."
-                    )
+                )
             cursor.advance(last_pk)
             pagination_token, is_last = self._is_last(data)
             if is_last:

--- a/aap_gateway_api/tests/management/test_migrate_resources.py
+++ b/aap_gateway_api/tests/management/test_migrate_resources.py
@@ -495,7 +495,6 @@ def test_migrating_user_with_invalid_email(migration_service_invalid_users, admi
 
 @pytest.mark.django_db(transaction=True)
 def test_updating_resource_data_for_invalid_resource(migration_service_invalid_users, patched_load_rbac, admin_user):
-
     with patch.object(MigrateCommand, "update_resource_data") as mocked_update_resource_data_method:
         mocked_update_resource_data_method.return_value = None  # None indicates that its data could not be updated
 

--- a/aap_gateway_api/tests/management/test_migrate_resources.py
+++ b/aap_gateway_api/tests/management/test_migrate_resources.py
@@ -92,12 +92,12 @@ def _setup_empty_assignment_mocks(mock_client):
     """
     empty_user_resp = Mock()
     empty_user_resp.status_code = 200
-    empty_user_resp.json.return_value = {"count": 0, "results": [], "next": None}
+    empty_user_resp.json.return_value = {"results": [], "next": None}
     mock_client.list_user_assignments.return_value = empty_user_resp
 
     empty_team_resp = Mock()
     empty_team_resp.status_code = 200
-    empty_team_resp.json.return_value = {"count": 0, "results": [], "next": None}
+    empty_team_resp.json.return_value = {"results": [], "next": None}
     mock_client.list_team_assignments.return_value = empty_team_resp
 
 
@@ -1666,14 +1666,13 @@ def test_role_assignment_migration_skips_user_not_found(admin_user, capsys, serv
         # empty for the post-run drift check.
         data_resp = Mock(status_code=200)
         data_resp.json.return_value = {
-            "count": 1,
             "next": None,
             "results": [
                 {"id": 1, "object_ansible_id": None, "content_type": "", "role_definition": "Platform Auditor", "user_ansible_id": invalid_user_ansible_id}
             ],
         }
         empty_resp = Mock(status_code=200)
-        empty_resp.json.return_value = {"count": 0, "next": None, "results": []}
+        empty_resp.json.return_value = {"results": [], "next": None}
         mock_client.list_user_assignments.side_effect = [data_resp, empty_resp]
         mock_client.list_team_assignments.return_value = empty_resp
         mock_client_class.return_value = mock_client
@@ -1716,7 +1715,6 @@ def test_role_assignment_migration_skips_role_definition_not_found(admin_user, c
         # empty for the post-run drift check.
         data_resp = Mock(status_code=200)
         data_resp.json.return_value = {
-            "count": 1,
             "next": None,
             "results": [
                 {
@@ -1729,7 +1727,7 @@ def test_role_assignment_migration_skips_role_definition_not_found(admin_user, c
             ],
         }
         empty_resp = Mock(status_code=200)
-        empty_resp.json.return_value = {"count": 0, "next": None, "results": []}
+        empty_resp.json.return_value = {"results": [], "next": None}
         mock_client.list_user_assignments.side_effect = [data_resp, empty_resp]
         mock_client.list_team_assignments.return_value = empty_resp
         mock_client_class.return_value = mock_client
@@ -1773,7 +1771,6 @@ def test_role_assignment_migration_skips_object_not_found(admin_user, capsys, se
         # empty for the post-run drift check.
         data_resp = Mock(status_code=200)
         data_resp.json.return_value = {
-            "count": 1,
             "next": None,
             "results": [
                 {
@@ -1786,7 +1783,7 @@ def test_role_assignment_migration_skips_object_not_found(admin_user, capsys, se
             ],
         }
         empty_resp = Mock(status_code=200)
-        empty_resp.json.return_value = {"count": 0, "next": None, "results": []}
+        empty_resp.json.return_value = {"results": [], "next": None}
         mock_client.list_user_assignments.side_effect = [data_resp, empty_resp]
         mock_client.list_team_assignments.return_value = empty_resp
         mock_client_class.return_value = mock_client

--- a/aap_gateway_api/tests/management/test_migrate_resources.py
+++ b/aap_gateway_api/tests/management/test_migrate_resources.py
@@ -11,6 +11,7 @@ from ansible_base.rbac.models import RemoteObject, RoleTeamAssignment, RoleUserA
 from ansible_base.resource_registry.models import Resource, service_id
 from ansible_base.resource_registry.rest_client import ResourceRequestBody
 from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.db import IntegrityError
 
 from aap_gateway_api.management.commands.migrate_service_data import Command as MigrateCommand
@@ -494,7 +495,6 @@ def test_migrating_user_with_invalid_email(migration_service_invalid_users, admi
 
 @pytest.mark.django_db(transaction=True)
 def test_updating_resource_data_for_invalid_resource(migration_service_invalid_users, patched_load_rbac, admin_user):
-    from django.core.management.base import CommandError
 
     with patch.object(MigrateCommand, "update_resource_data") as mocked_update_resource_data_method:
         mocked_update_resource_data_method.return_value = None  # None indicates that its data could not be updated
@@ -553,7 +553,7 @@ def test_service_processing_order(admin_user, capsys, service_api_route_controll
         mock_client_class.return_value = mock_client
 
         # Should process all three services and fail on each, but in the right order
-        with pytest.raises(Exception):
+        with pytest.raises(CommandError):
             call_command("migrate_service_data", username=admin_user.username)
 
         # Check the output for service processing order
@@ -615,7 +615,7 @@ def test_migration_error_handling_and_summary(admin_user, capsys, service_api_ro
         mock_client_class.side_effect = mock_client_factory
 
         # Migration should fail with CommandError due to failed hub service
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(CommandError) as exc_info:
             call_command("migrate_service_data", username=admin_user.username)
 
         # Check error message contains service failure information
@@ -754,7 +754,7 @@ def test_process_migrate_resource_item_raises_on_missing_resource_data():
 def test_no_services_found_error(admin_user):
     """Test error when no DefaultServiceType services are found"""
     # In a clean test environment with no service fixtures, the command should fail
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(CommandError) as exc_info:
         call_command("migrate_service_data", username=admin_user.username)
 
     assert "No services found with expected service types" in str(exc_info.value)
@@ -1867,8 +1867,6 @@ def test_ensure_controller_gateway_superusers_scenarios(
     with patch('aap_gateway_api.utils.resources_client.GWResourceAPIClient', return_value=mock_client):
         if expected_errors:
             # Test error scenarios
-            from django.core.management.base import CommandError
-
             with pytest.raises(CommandError) as exc_info:
                 cmd._ensure_controller_gateway_superusers(service_api_route_controller, gateway_superusers, admin_user)
 

--- a/aap_gateway_api/tests/management/test_migrate_service_data_role_assignments.py
+++ b/aap_gateway_api/tests/management/test_migrate_service_data_role_assignments.py
@@ -206,7 +206,6 @@ class TestPaginateAndCreate:
 
         call_filters = list_fn.call_args[1]["filters"]
         assert call_filters["id__gt"] == "100"
-        assert call_filters["order_by"] == "id"
 
     def test_cursor_not_in_filters_when_zero(self):
         """When cursor is at 0, id__gt is not added to filters."""
@@ -222,11 +221,7 @@ class TestPaginateAndCreate:
         assert "id__gt" not in call_filters
 
     def test_cursor_advances_per_page(self):
-        """Cursor is advanced in DB after each page, not just at the end.
-
-        This ensures crash safety: if the process is killed between pages,
-        at most one page of work is lost.
-        """
+        """Cursor is advanced in DB after each page."""
         page1 = _make_api_response(
             [
                 _make_remote_assignment("user", "u1", "Role1", pk=10),
@@ -272,6 +267,23 @@ class TestPaginateAndCreate:
         # DB cursor unchanged
         new_cursor = _CursorStore("test-svc-empty", "user")
         assert new_cursor.last_pk == 50
+
+    def test_stops_when_next_has_no_cursor_or_page(self):
+        """When the next URL has neither cursor nor page parameter, pagination stops."""
+        page1 = _make_api_response(
+            [_make_remote_assignment("user", "u1", "Role1", pk=10)],
+        )
+        page1.json.return_value["next"] = "http://example.com/api/v1/role-user-assignments/?page_size=200"
+
+        cmd = self._make_cmd()
+        cursor = _CursorStore("test-svc-no-param", "user")
+        list_fn = Mock(return_value=page1)
+
+        with patch.object(cmd, "_create_assignment", return_value=True):
+            created = cmd._paginate_and_create(list_fn, "user", [], cursor)
+
+        assert created == 1
+        assert list_fn.call_count == 1
 
     def test_http_error_raises_immediately_with_body_preview(self):
         """HTTP error raises RuntimeError immediately with response body preview.

--- a/aap_gateway_api/tests/management/test_migrate_service_data_role_assignments.py
+++ b/aap_gateway_api/tests/management/test_migrate_service_data_role_assignments.py
@@ -492,13 +492,12 @@ class TestMigrateRoleAssignments:
         cmd.stdout.write.assert_any_call("Role assignment migration for controller completed (10 total created)")
 
     def test_check_for_drift_queries_beyond_cursor(self):
-        """_check_for_drift loads a fresh cursor from DB and asks the API
-        if any items exist beyond it."""
+        """_check_for_drift uses last_advanced_pk from the cursor to query
+        the API for items beyond the high-water mark."""
         cmd = self._make_cmd()
 
-        # Pre-seed cursor to PK=100
-        seed = _CursorStore("drift-check-svc", "user")
-        seed.advance(100)
+        cursor = _CursorStore("drift-check-svc", "user")
+        cursor.advance(100)
 
         # API returns results — drift detected
         drift_resp = Mock()
@@ -506,7 +505,7 @@ class TestMigrateRoleAssignments:
         drift_resp.json.return_value = {"results": [{"id": 101}, {"id": 102}, {"id": 103}], "next": None}
         list_fn = Mock(return_value=drift_resp)
 
-        assert cmd._check_for_drift(list_fn, "user", "drift-check-svc") is True
+        assert cmd._check_for_drift(list_fn, "user", "drift-check-svc", cursor) is True
         call_filters = list_fn.call_args[1]["filters"]
         assert call_filters["id__gt"] == "100"
         assert call_filters["page_size"] == "1"
@@ -515,23 +514,24 @@ class TestMigrateRoleAssignments:
         """_check_for_drift returns False when the API returns empty results."""
         cmd = self._make_cmd()
 
-        seed = _CursorStore("drift-empty-svc", "user")
-        seed.advance(50)
+        cursor = _CursorStore("drift-empty-svc", "user")
+        cursor.advance(50)
 
         no_drift_resp = Mock()
         no_drift_resp.status_code = 200
         no_drift_resp.json.return_value = {"results": [], "next": None}
         list_fn = Mock(return_value=no_drift_resp)
 
-        assert cmd._check_for_drift(list_fn, "user", "drift-empty-svc") is False
+        assert cmd._check_for_drift(list_fn, "user", "drift-empty-svc", cursor) is False
 
     def test_check_for_drift_skips_when_cursor_is_zero(self):
-        """_check_for_drift skips the API call when cursor is at 0
+        """_check_for_drift skips the API call when last_advanced_pk is 0
         (fresh install with no prior progress to check against)."""
         cmd = self._make_cmd()
+        cursor = _CursorStore("drift-zero-svc", "user")
         list_fn = Mock()
 
-        assert cmd._check_for_drift(list_fn, "user", "drift-zero-svc") is False
+        assert cmd._check_for_drift(list_fn, "user", "drift-zero-svc", cursor) is False
         list_fn.assert_not_called()
 
     def test_check_for_drift_returns_false_on_api_error(self):
@@ -542,12 +542,12 @@ class TestMigrateRoleAssignments:
         """
         cmd = self._make_cmd()
 
-        seed = _CursorStore("drift-err-svc", "user")
-        seed.advance(50)
+        cursor = _CursorStore("drift-err-svc", "user")
+        cursor.advance(50)
 
         list_fn = Mock(side_effect=RuntimeError("connection refused"))
 
-        assert cmd._check_for_drift(list_fn, "user", "drift-err-svc") is False
+        assert cmd._check_for_drift(list_fn, "user", "drift-err-svc", cursor) is False
 
 
 # =============================================================================

--- a/aap_gateway_api/tests/management/test_migrate_service_data_role_assignments.py
+++ b/aap_gateway_api/tests/management/test_migrate_service_data_role_assignments.py
@@ -20,19 +20,18 @@ from aap_gateway_api.management.commands.migrate_service_data import Command as 
 from aap_gateway_api.management.commands.migrate_service_data import _CursorStore
 
 
-def _make_api_response(results, count=None, has_next=False):
+def _make_api_response(results, has_next=False):
     """Build a mock API response with proper status_code and JSON body.
 
     The PK cursor pagination checks response.status_code before calling
     .json(), so mocks must be explicit Mock objects with status_code=200.
+    Role assignment endpoints use cursor pagination and do not return a
+    ``count`` field.
     """
-    if count is None:
-        count = len(results)
     resp = Mock()
     resp.status_code = 200
     resp.json.return_value = {
-        "count": count,
-        "next": "http://fake/next" if has_next else None,
+        "next": "http://fake/next?cursor=cD0xMA%3D%3D" if has_next else None,
         "results": results,
     }
     return resp
@@ -489,10 +488,10 @@ class TestMigrateRoleAssignments:
         seed = _CursorStore("drift-check-svc", "user")
         seed.advance(100)
 
-        # API returns count > 0 — drift detected
+        # API returns results — drift detected
         drift_resp = Mock()
         drift_resp.status_code = 200
-        drift_resp.json.return_value = {"count": 3}
+        drift_resp.json.return_value = {"results": [{"id": 101}, {"id": 102}, {"id": 103}], "next": None}
         list_fn = Mock(return_value=drift_resp)
 
         assert cmd._check_for_drift(list_fn, "user", "drift-check-svc") is True
@@ -501,7 +500,7 @@ class TestMigrateRoleAssignments:
         assert call_filters["page_size"] == "1"
 
     def test_check_for_drift_returns_false_when_no_new_items(self):
-        """_check_for_drift returns False when the API returns count=0."""
+        """_check_for_drift returns False when the API returns empty results."""
         cmd = self._make_cmd()
 
         seed = _CursorStore("drift-empty-svc", "user")
@@ -509,7 +508,7 @@ class TestMigrateRoleAssignments:
 
         no_drift_resp = Mock()
         no_drift_resp.status_code = 200
-        no_drift_resp.json.return_value = {"count": 0}
+        no_drift_resp.json.return_value = {"results": [], "next": None}
         list_fn = Mock(return_value=no_drift_resp)
 
         assert cmd._check_for_drift(list_fn, "user", "drift-empty-svc") is False

--- a/aap_gateway_api/tests/views/api/v1/ping/test_ping.py
+++ b/aap_gateway_api/tests/views/api/v1/ping/test_ping.py
@@ -112,7 +112,7 @@ def test_ping_db_check_flushes_stale_connections(mock_close, mock_conns, request
     call_order = []
     mock_close.side_effect = lambda: call_order.append("close")
     cursor_cm = mock.MagicMock()
-    cursor_cm.__enter__ = mock.Mock(side_effect=lambda: call_order.append("cursor") or mock.Mock())
+    cursor_cm.__enter__ = mock.Mock(side_effect=lambda: (call_order.append("cursor") or mock.Mock()))
     cursor_cm.__exit__ = mock.Mock(return_value=False)
     mock_conns.__getitem__.return_value.cursor.return_value = cursor_cm
 

--- a/aap_gateway_api/tests/views/api/v1/ping/test_ping.py
+++ b/aap_gateway_api/tests/views/api/v1/ping/test_ping.py
@@ -112,7 +112,7 @@ def test_ping_db_check_flushes_stale_connections(mock_close, mock_conns, request
     call_order = []
     mock_close.side_effect = lambda: call_order.append("close")
     cursor_cm = mock.MagicMock()
-    cursor_cm.__enter__ = mock.Mock(side_effect=lambda: (call_order.append("cursor") or mock.Mock()))
+    cursor_cm.__enter__ = mock.Mock(side_effect=lambda: call_order.append("cursor") or mock.Mock())
     cursor_cm.__exit__ = mock.Mock(return_value=False)
     mock_conns.__getitem__.return_value.cursor.return_value = cursor_cm
 


### PR DESCRIPTION
This is a counterpart to https://github.com/ansible/django-ansible-base/pull/1038 and https://github.com/ansible/django-ansible-base/pull/1025 (merged already)

PR 1038 should be merged first, and this is pr can do it.
Requires: https://github.com/ansible/django-ansible-base/pull/1038
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of role-assignment migration by following upstream cursor pagination and advancing cursor state correctly across pages.
  * Prevented premature termination and missed records when processing multi-page assignments.
  * Enhanced drift detection by using returned `results` data instead of relying on response count fields.
* **Tests**
  * Updated mocked API responses to reflect cursor-style pagination (`next`/`results`) and removed `count`-based assertions.
  * Added coverage ensuring pagination stops after `next` lacks cursor/page parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->