### PR TITLE
[AAP-80609] Optimize role assignment migration to use bulk queries

### DIFF
--- a/.github/workflows/perf-tests.yml
+++ b/.github/workflows/perf-tests.yml
@@ -1,0 +1,83 @@
+---
+name: Performance Tests
+on:
+  pull_request:
+  push:
+    branches:
+      - devel
+
+jobs:
+  perf-test:
+    name: "Performance Tests"
+    runs-on: ubuntu-24.04
+    env:
+      TOX_DOCKER_GATEWAY: "0.0.0.0"
+    if: github.repository == 'ansible/jewel' || github.repository == 'ansible/jewel-debug'
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+    permissions:
+      packages: write
+      contents: read
+      actions: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install build requirements
+        run: sudo apt-get update && sudo apt-get install -y libsasl2-dev libldap2-dev libssl-dev libxmlsec1-dev
+
+      - name: Install python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install tox
+        run: pip3.12 install tox tox-docker requests
+
+      - name: Checkout dependencies
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN != '' && secrets.GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          python tools/scripts/get_pr_checkout.py \
+            --always-clone-repos 'ansible/django-ansible-base'
+
+      - name: Set tox environment name
+        id: tox-env
+        run: |
+          echo "name=py312" >> "$GITHUB_OUTPUT"
+
+      - name: Create tox environment and run setup
+        env:
+          GATEWAY_TEST_DIRS: ""
+        run: |
+          tox -e ${{ steps.tox-env.outputs.name }} \
+            -x testenv:${{ steps.tox-env.outputs.name }}.docker= \
+            -- --collect-only aap_gateway_api/tests/__init__.py
+
+      - name: Rebuild lxml and xmlsec from source
+        run: |
+          TOX_ENV="${{ steps.tox-env.outputs.name }}"
+          XMLSEC_VERSION=$(.tox/${TOX_ENV}/bin/pip freeze | grep xmlsec | sed 's:^.*=::')
+          LXML_VERSION=$(.tox/${TOX_ENV}/bin/pip freeze | grep lxml | sed 's:^.*=::')
+
+          echo "Rebuilding xmlsec==${XMLSEC_VERSION} and lxml==${LXML_VERSION} from source"
+
+          .tox/${TOX_ENV}/bin/pip install --no-cache-dir --no-binary lxml,xmlsec --force-reinstall \
+              lxml==${LXML_VERSION} xmlsec==${XMLSEC_VERSION}
+
+      - name: Run performance tests
+        env:
+          GATEWAY_TEST_DIRS: ""
+        run: |
+          tox -e ${{ steps.tox-env.outputs.name }} -- -m perf -v \
+            --junit-xml=junit-perf.xml
+
+      - name: Upload junit artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-perf
+          path: junit-perf.xml

--- a/.github/workflows/perf-tests.yml
+++ b/.github/workflows/perf-tests.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Run performance tests
         env:
-          GATEWAY_TEST_DIRS: ""
+          GATEWAY_TEST_DIRS: aap_gateway_api/tests
         run: |
           tox -e ${{ steps.tox-env.outputs.name }} -- -m perf -v \
             --junit-xml=junit-perf.xml

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -140,6 +140,7 @@ jobs:
           GATEWAY_TEST_DIRS: ""
         run: |
           tox -e ${{ steps.tox-env.outputs.name }} -- ${{ matrix.batch.test-filter }} -v \
+            -m "not perf" \
             --cov=. --cov-report=xml:coverage-${{ matrix.batch.artifact-suffix }}.xml \
             --junit-xml=junit-${{ matrix.batch.artifact-suffix }}.xml
 

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,14 @@ clean:
 check:
 	tox
 
+## Run unit tests (excludes perf tests)
+check_test:
+	GATEWAY_TEST_DIRS="" TOX_DOCKER_GATEWAY=0.0.0.0 tox -e py312 -- -m "not perf"
+
+## Run performance/scaling tests only
+check_perf:
+	GATEWAY_TEST_DIRS="" TOX_DOCKER_GATEWAY=0.0.0.0 tox -e py312 -- -m perf -v
+
 ## Run linters (and modify files if necessary)
 lint:
 	tox -m lint

--- a/aap_gateway_api/management/commands/_migrate_service_data/cursor_store.py
+++ b/aap_gateway_api/management/commands/_migrate_service_data/cursor_store.py
@@ -46,10 +46,11 @@ class CursorStore:
         " DO UPDATE SET last_pk = EXCLUDED.last_pk"
     )
 
-    def __init__(self, service_slug, assignment_type):
+    def __init__(self, service_slug, assignment_type, log_fn=None):
         """Load the cursor from DB, setting self.last_pk once (immutably)."""
         self.service_slug = service_slug
         self.assignment_type = assignment_type
+        self._log_fn = log_fn
         self.last_pk = self._load()
 
     def _ensure_table(self):
@@ -66,12 +67,11 @@ class CursorStore:
                 row = cur.fetchone()
                 return row[0] if row else 0
         except Exception:
-            logger.warning(
-                "Failed to load cursor for %s/%s, will reprocess all assignments",
-                self.service_slug,
-                self.assignment_type,
-                exc_info=True,
-            )
+            msg = f"Failed to load cursor for {self.service_slug}/{self.assignment_type}, will reprocess all assignments"
+            if self._log_fn:
+                self._log_fn(msg, logging.WARNING)
+            else:
+                logger.warning(msg, exc_info=True)
             return 0
 
     def advance(self, pk):
@@ -81,16 +81,14 @@ class CursorStore:
         id__gt filter remains consistent across all pages of a run.
         If the upsert fails, a warning is logged but the run continues --
         the next invocation will reprocess from the old position, which
-        is safe because give_permission is idempotent.
+        is safe because bulk_create with ignore_conflicts is idempotent.
         """
         try:
             with connection.cursor() as cur:
                 cur.execute(self._SQL_UPSERT, [self.service_slug, self.assignment_type, pk])
         except Exception:
-            logger.warning(
-                "Failed to advance cursor for %s/%s to %d; next run will reprocess from the old position",
-                self.service_slug,
-                self.assignment_type,
-                pk,
-                exc_info=True,
-            )
+            msg = f"Failed to advance cursor for {self.service_slug}/{self.assignment_type} to {pk}; next run will reprocess from the old position"
+            if self._log_fn:
+                self._log_fn(msg, logging.WARNING)
+            else:
+                logger.warning(msg, exc_info=True)

--- a/aap_gateway_api/management/commands/_migrate_service_data/cursor_store.py
+++ b/aap_gateway_api/management/commands/_migrate_service_data/cursor_store.py
@@ -1,4 +1,5 @@
 import logging
+import traceback
 
 from django.db import connection
 
@@ -71,7 +72,7 @@ class CursorStore:
         except Exception:
             msg = f"Failed to load cursor for {self.service_slug}/{self.assignment_type}, will reprocess all assignments"
             if self._log_fn:
-                self._log_fn(msg, logging.WARNING)
+                self._log_fn(f"{msg}\n{traceback.format_exc()}", logging.WARNING)
             else:
                 logger.warning(msg, exc_info=True)
             return 0
@@ -91,6 +92,6 @@ class CursorStore:
         except Exception:
             msg = f"Failed to advance cursor for {self.service_slug}/{self.assignment_type} to {pk}; next run will reprocess from the old position"
             if self._log_fn:
-                self._log_fn(msg, logging.WARNING)
+                self._log_fn(f"{msg}\n{traceback.format_exc()}", logging.WARNING)
             else:
                 logger.warning(msg, exc_info=True)

--- a/aap_gateway_api/management/commands/_migrate_service_data/cursor_store.py
+++ b/aap_gateway_api/management/commands/_migrate_service_data/cursor_store.py
@@ -51,6 +51,8 @@ class CursorStore:
         self.service_slug = service_slug
         self.assignment_type = assignment_type
         self._log_fn = log_fn
+        # Set once at init; not updated by advance(). Do not read mid-run
+        # as a DB failure during advance() leaves this stale at 0.
         self.last_pk = self._load()
 
     def _ensure_table(self):

--- a/aap_gateway_api/management/commands/_migrate_service_data/resource_migration.py
+++ b/aap_gateway_api/management/commands/_migrate_service_data/resource_migration.py
@@ -1,11 +1,11 @@
 import logging
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, List, Optional, Tuple
 
 from ansible_base.resource_registry.constants import SHARED_USER_RESOURCE_TYPE
 from ansible_base.resource_registry.models import Resource, service_id
 from ansible_base.resource_registry.rest_client import ResourceRequestBody
 from django.conf import settings
-from django.db import models, transaction
+from django.db import transaction
 
 
 class ResourceMigrationMixin:
@@ -21,53 +21,6 @@ class ResourceMigrationMixin:
             if data["count"] > 0:
                 return False
         return True
-
-    def get_new_resource_name(
-        self,
-        name: str,
-        unique_filter_kwargs: Dict[str, Any],
-        local_resource_model: Type[models.Model],
-        resource_type_name_field: str,
-        service_slug: str,
-    ) -> str:
-        """
-        Generate a unique name for a resource that doesn't conflict with existing resources.
-
-        When a resource name conflicts with an existing resource in the gateway, this method
-        generates a new name by prefixing with the service slug and adding a numeric suffix
-        if needed to ensure uniqueness.
-
-        Args:
-            name: Original resource name from upstream service
-            unique_filter_kwargs: Filter parameters used to check uniqueness
-            local_resource_model: Django model class for the resource type
-            resource_type_name_field: Field name used for the resource name
-
-        Returns:
-            A unique name that doesn't conflict with existing resources
-
-        Example:
-            If 'my-org' exists, will return 'service_my-org' or 'service_my-org1'
-        """
-        original_name = f'{service_slug}_{name}'
-
-        filter_kwargs = unique_filter_kwargs.copy()
-        filter_kwargs[f"{resource_type_name_field}__startswith"] = original_name
-        del filter_kwargs[resource_type_name_field]
-
-        highest = (
-            local_resource_model.objects.filter(**filter_kwargs)
-            .values_list(resource_type_name_field, flat=True)
-            .order_by(f"-{resource_type_name_field}")
-            .first()
-        )
-
-        if highest is None:
-            return original_name
-
-        suffix = highest[len(original_name) :]
-        counter = (int(suffix) + 1) if suffix.isdigit() else 1
-        return f"{original_name}{counter}"
 
     def update_resource_data(self, resource_type_name: str, original_resource_data: Any) -> Optional[Dict[str, Any]]:
         """

--- a/aap_gateway_api/management/commands/_migrate_service_data/resource_migration.py
+++ b/aap_gateway_api/management/commands/_migrate_service_data/resource_migration.py
@@ -139,41 +139,10 @@ class ResourceMigrationMixin:
 
         return updated_resource_data
 
-    def _initialize_resource_sync_payloads(self, upstream_resource: Dict[str, Any], user_partial_migration: bool) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        """
-        Prepare payloads for creating Gateway resources and updating upstream resources.
-
-        This method sets up the data structures needed to:
-        1. Create a new resource in the gateway
-        2. Update the corresponding resource in the upstream service
-
-        For partially migrated users, the gateway resource retains the upstream
-        service_id to indicate it's not fully migrated.
-
-        Args:
-            upstream_resource: Complete resource data from upstream service
-            user_partial_migration: True if this is a user being partially migrated
-
-        Returns:
-            Tuple of (resource_creation_kwargs, updated_service_resource)
-            - resource_creation_kwargs: Data for creating Gateway resource
-            - updated_service_resource: Data for updating upstream resource
-        """
-        resource_creation_kwargs = {}
-        updated_service_resource = {}
-
-        resource_creation_kwargs["ansible_id"] = upstream_resource["ansible_id"]
-
-        if user_partial_migration:
-            # We do not update the service_id of a user on the service, only mark is_partially_migrated to True to exclude it from the
-            # while loop in migrate_resource()
-            updated_service_resource["is_partially_migrated"] = True
-            # The resource to be created in Gateway needs to show as unmigrated by having the original service_id
-            resource_creation_kwargs["service_id"] = self.upstream_service_id
-        else:
-            # if current resource is not shared.user or user is not partially migrated, we update the 'service_id' to Gateway's service_id
-            updated_service_resource["service_id"] = str(service_id())
-
+    def _initialize_resource_sync_payloads(self, upstream_resource: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        """Prepare payloads for creating Gateway resources and updating upstream resources."""
+        resource_creation_kwargs = {"ansible_id": upstream_resource["ansible_id"]}
+        updated_service_resource = {"service_id": str(service_id())}
         return resource_creation_kwargs, updated_service_resource
 
     def _reconcile_existing_resource(
@@ -317,11 +286,7 @@ class ResourceMigrationMixin:
             # Re-validate after potential superuser flag changes
             validated_resource_data = self._deserialize_and_validate_resource_data(upstream_resource, resource_context["type_serializer"])
 
-        # 'shared.user' type is treated differently
-        # If the user being migrated is not the current user (admin user), we need to check if we should partially migrate the user
-        user_partial_migration = False
-
-        resource_creation_kwargs, updated_service_resource = self._initialize_resource_sync_payloads(upstream_resource, user_partial_migration)
+        resource_creation_kwargs, updated_service_resource = self._initialize_resource_sync_payloads(upstream_resource)
 
         # handles case with existing resource and figure out if we should create a new resource in gateway or not
         create_gateway_resource = self._reconcile_existing_resource(upstream_resource, resource_context, validated_resource_data, updated_service_resource)

--- a/aap_gateway_api/management/commands/_migrate_service_data/resource_migration.py
+++ b/aap_gateway_api/management/commands/_migrate_service_data/resource_migration.py
@@ -50,18 +50,24 @@ class ResourceMigrationMixin:
             If 'my-org' exists, will return 'service_my-org' or 'service_my-org1'
         """
         original_name = f'{service_slug}_{name}'
-        name = original_name
 
         filter_kwargs = unique_filter_kwargs.copy()
-        filter_kwargs[resource_type_name_field] = name
+        filter_kwargs[f"{resource_type_name_field}__startswith"] = original_name
+        del filter_kwargs[resource_type_name_field]
 
-        counter = 1
-        while local_resource_model.objects.filter(**filter_kwargs).exists():
-            name = original_name + str(counter)
-            filter_kwargs[resource_type_name_field] = name
-            counter += 1
+        highest = (
+            local_resource_model.objects.filter(**filter_kwargs)
+            .values_list(resource_type_name_field, flat=True)
+            .order_by(f"-{resource_type_name_field}")
+            .first()
+        )
 
-        return name
+        if highest is None:
+            return original_name
+
+        suffix = highest[len(original_name) :]
+        counter = (int(suffix) + 1) if suffix.isdigit() else 1
+        return f"{original_name}{counter}"
 
     def update_resource_data(self, resource_type_name: str, original_resource_data: Any) -> Optional[Dict[str, Any]]:
         """
@@ -374,7 +380,6 @@ class ResourceMigrationMixin:
             "type_serializer": resource_type.serializer_class,
             "type_name_field": resource_type.get_resource_config().name_field,
             "unique_fields": self.resource_types_to_migrate[resource_type_name]["unique_fields"],
-            "merge_option": self.resource_types_to_migrate[resource_type_name]["merge"],
             "LocalResourceModel": resource_type.content_type.model_class(),
         }
 

--- a/aap_gateway_api/management/commands/_migrate_service_data/role_assignments.py
+++ b/aap_gateway_api/management/commands/_migrate_service_data/role_assignments.py
@@ -274,12 +274,13 @@ class RoleAssignmentsMixin:
                 all_object_roles.update(object_roles)
                 self._log(f"  {assignment_type}: {created} assignments created", logging.INFO)
         finally:
-            if all_object_roles:
+            if total_created:
                 self._log(
-                    f"Rebuilding RBAC cache for {len(all_object_roles)} object roles",
+                    f"Rebuilding RBAC cache ({total_created} assignments created, {len(all_object_roles)} object roles)",
                     logging.INFO,
                 )
                 compute_team_member_roles()
-                compute_object_role_permissions(object_roles=all_object_roles)
+                if all_object_roles:
+                    compute_object_role_permissions(object_roles=all_object_roles)
 
         self._log(f"Role assignment migration for {service_slug} completed ({total_created} total created)", logging.INFO)

--- a/aap_gateway_api/management/commands/_migrate_service_data/role_assignments.py
+++ b/aap_gateway_api/management/commands/_migrate_service_data/role_assignments.py
@@ -238,7 +238,7 @@ class RoleAssignmentsMixin:
         try:
             for assignment_type in ('user', 'team'):
                 list_fn = self.client.list_user_assignments if assignment_type == 'user' else self.client.list_team_assignments
-                cursor = CursorStore(service_slug, assignment_type)
+                cursor = CursorStore(service_slug, assignment_type, log_fn=self._log)
                 created, object_roles = self._paginate_and_create(list_fn, assignment_type, roles_to_exclude, cursor)
                 total_created += created
                 all_object_roles.update(object_roles)

--- a/aap_gateway_api/management/commands/_migrate_service_data/role_assignments.py
+++ b/aap_gateway_api/management/commands/_migrate_service_data/role_assignments.py
@@ -209,6 +209,7 @@ class RoleAssignmentsMixin:
         actor_field = 'user_id' if assignment_type == 'user' else 'team_id'
 
         # Build the set of (actor_pk, role_def_id) we want to create
+        # Cast actor_pk to int for comparison since values_list returns int FKs
         desired = {(actor_pk, rd.id) for actor_pk, rd, _, _, _ in assignments}
 
         # Query existing global assignments (object_role=None) for these combos
@@ -221,7 +222,8 @@ class RoleAssignmentsMixin:
         )
 
         # Only create ones that don't exist
-        new_assignments = [(a, rd, ct, oid, aid) for a, rd, ct, oid, aid in assignments if (a, rd.id) not in existing]
+        # Cast actor_pk to match the int type returned by values_list
+        new_assignments = [(a, rd, ct, oid, aid) for a, rd, ct, oid, aid in assignments if (int(a), rd.id) not in existing]
 
         assignment_objs = [
             AssignmentModel(

--- a/aap_gateway_api/management/commands/_migrate_service_data/role_assignments.py
+++ b/aap_gateway_api/management/commands/_migrate_service_data/role_assignments.py
@@ -1,9 +1,10 @@
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Tuple
 
-from ansible_base.rbac.models import RoleDefinition
-from ansible_base.rbac.remote import RemoteObject
+from ansible_base.rbac.caching import compute_object_role_permissions, compute_team_member_roles
+from ansible_base.rbac.models import ObjectRole, RoleDefinition, RoleTeamAssignment, RoleUserAssignment
 from ansible_base.resource_registry.models import Resource
+from django.db.models import Q
 
 from aap_gateway_api.management.commands._migrate_service_data.cursor_store import CursorStore
 from aap_gateway_api.models.service_type import DefaultServiceType
@@ -14,24 +15,16 @@ logger = logging.getLogger('aap.gateway.management.commands.migrate_service_data
 class RoleAssignmentsMixin:
     @staticmethod
     def _get_role_definitions_to_exclude(service_type: str) -> List[str]:
-        # Since the goal is to honor controller's assignments platform roles, we do not want to consider
-        # roles like 'Organization Admin' or 'Team Admin' from other services, just controller
         DEFAULT_EXCLUSION_SET = {'Platform Auditor', 'Organization Admin', 'Organization Member', 'Team Admin', 'Team Member'}
         ROLE_EXCLUSION_SETS = {
-            # For controller, exclude nothing
             DefaultServiceType.CONTROLLER.value: {},
-            # For hub, exclude platform roles but don't exclude 'Team Member'
             DefaultServiceType.HUB.value: DEFAULT_EXCLUSION_SET - {'Team Member'},
         }
         return sorted(ROLE_EXCLUSION_SETS.get(service_type, DEFAULT_EXCLUSION_SET))
 
     @staticmethod
     def _raise_fetch_error(response, assignment_type: str, page: int) -> None:
-        """Log and raise RuntimeError for a failed assignment page fetch.
-
-        Captures up to 500 characters of the response body so operators
-        can diagnose upstream errors without searching service logs.
-        """
+        """Log and raise RuntimeError for a failed assignment page fetch."""
         body_preview = ""
         try:
             body_preview = response.text[:500]
@@ -45,277 +38,218 @@ class RoleAssignmentsMixin:
         )
         raise RuntimeError(f"Failed to fetch {assignment_type} assignments page {page}: HTTP {response.status_code}\n{body_preview}")
 
-    def _paginate_and_create(self, list_fn, assignment_type: str, roles_to_exclude: List[str], cursor: 'CursorStore') -> int:
-        """Paginate one assignment endpoint using a PK cursor, creating assignments per page.
+    def _paginate_and_create(self, list_fn, assignment_type: str, roles_to_exclude: List[str], cursor: 'CursorStore') -> Tuple[int, set]:
+        """Paginate one assignment endpoint using id__gt sliding window,
+        bulk-creating assignments per page.
 
-        Queries with ``order_by=id&id__gt=<snapshot_pk>`` so only
-        assignments newer than the cursor are fetched.  The snapshot_pk
-        is captured once and stays immutable for the entire run, preventing
-        items from being skipped when the DB cursor advances between pages.
+        Always requests with ``id__gt=<last_pk>`` so the window slides
+        forward after each batch.  This is stable against mid-run
+        deletions and doubles as crash recovery since the cursor is
+        persisted to the database after each page.
 
-        On a reinstall where the cursor is already past the last PK,
-        the first page returns zero results and the method returns
-        immediately.
-
-        No per-page retry -- the PK cursor provides crash recovery.
-        If the command fails on an HTTP error, the installer re-runs
-        it and the cursor resumes from the last completed page.
-
-        Crash safety: the cursor is advanced in the database after each
-        fully-processed page, so at most one page of work is lost.
+        Returns (created_count, object_roles_set) for deferred cache rebuild.
         """
-        page = 1
         created = 0
+        all_object_roles: set = set()
 
-        # Build base filters once -- only 'page' changes between iterations.
-        # snapshot_pk is immutable (set once in CursorStore.__init__).
-        base_filters: Dict[str, Any] = {'order_by': 'id', **self.BIG_PAGE_FILTERS}
+        base_filters: Dict[str, Any] = {'order_by': 'id', 'id__gt': str(cursor.last_pk), **self.BIG_PAGE_FILTERS}
         if roles_to_exclude:
             base_filters['not__role_definition__name__in'] = ','.join(roles_to_exclude)
-        if cursor.last_pk > 0:
-            base_filters['id__gt'] = str(cursor.last_pk)
 
         while True:
-            response = list_fn(filters={**base_filters, 'page': page})
+            response = list_fn(filters=base_filters)
             if response.status_code != 200:
-                self._raise_fetch_error(response, assignment_type, page)
+                self._raise_fetch_error(response, assignment_type, 0)
 
             data = response.json()
             results = data.get('results') or []
             if not results:
                 break
 
-            created += self._create_page_assignments(results, assignment_type)
+            page_created, page_object_roles = self._bulk_resolve_and_create_page(results, assignment_type)
+            created += page_created
+            all_object_roles.update(page_object_roles)
 
-            # Advance cursor in DB for crash recovery.  cursor.last_pk
-            # is NOT mutated -- base_filters stays consistent.
             last_pk_on_page = results[-1].get('id')
-            if last_pk_on_page is None:
-                raise RuntimeError(
-                    f"API returned {assignment_type} assignment without 'id' field -- "
-                    f"cannot advance cursor. Check that the upstream service "
-                    f"is running a compatible DAB version (requires PR 1032+)."
-                )
-            cursor.advance(last_pk_on_page)
-
-            if not data.get('next'):
+            if last_pk_on_page is not None:
+                cursor.advance(last_pk_on_page)
+                base_filters['id__gt'] = str(last_pk_on_page)
+            else:
                 break
-            page += 1
 
-        return created
+        return created, all_object_roles
 
-    def _create_page_assignments(self, results: List[Dict[str, Any]], assignment_type: str) -> int:
-        """Create assignments from one page of API results.
+    def _bulk_resolve_and_create_page(self, results: List[Dict[str, Any]], assignment_type: str) -> Tuple[int, set]:
+        """Resolve all assignments on a page using bulk queries and bulk-create them.
 
-        Returns the number of assignments successfully created.
-        give_permission is idempotent (uses get_or_create internally),
-        so duplicates from cursor overlap are harmless.
+        Returns (created_count, object_roles_set) for deferred cache rebuild.
         """
-        created = 0
+        actor_field = f'{assignment_type}_ansible_id'
+
+        role_names: set = set()
+        actor_ansible_ids: set = set()
+        object_ansible_ids: set = set()
+
         for item in results:
-            if self._create_assignment(item, assignment_type):
-                created += 1
-        return created
+            rn = item.get('role_definition')
+            if rn:
+                role_names.add(rn)
+            aid = item.get(actor_field)
+            if aid:
+                actor_ansible_ids.add(str(aid))
+            oid = item.get('object_ansible_id')
+            if oid:
+                object_ansible_ids.add(str(oid))
 
-    def _create_assignment(self, assignment: Dict[str, Any], assignment_type: str) -> bool:
-        """Resolve and create a single role assignment from a raw API response dict.
+        role_map = {rd.name: rd for rd in RoleDefinition.objects.filter(name__in=role_names)}
+        actor_resource_map = {str(r.ansible_id): r for r in Resource.objects.filter(ansible_id__in=actor_ansible_ids)} if actor_ansible_ids else {}
+        object_resource_map = {str(r.ansible_id): r for r in Resource.objects.filter(ansible_id__in=object_ansible_ids)} if object_ansible_ids else {}
 
-        Extracts actor, role, and content object identifiers from the API
-        response, resolves them against the local database, and calls
-        give_permission to create the assignment.
+        global_assignments: List[Tuple] = []
+        object_assignments: List[Tuple] = []
 
-        Each resolution step has its own error handling with specific
-        operator-facing messages that include actor, role, and object
-        identifiers so failures can be debugged at scale.
+        for item in results:
+            actor_ansible_id = item.get(actor_field)
+            role_name = item.get('role_definition')
+            if not actor_ansible_id or not role_name:
+                continue
 
-        Returns True if the assignment was created, False if skipped.
-        """
-        # --- Extract actor and role from the API response ---
-        actor_ansible_id = assignment.get(f'{assignment_type}_ansible_id')
-        role_name = assignment.get('role_definition')
-        if not actor_ansible_id or not role_name:
-            return False
+            rd = role_map.get(role_name)
+            if rd is None:
+                self._log(f"Warning: Unable to find role definition '{role_name}', skipping assignment", logging.WARNING)
+                continue
 
-        # --- Resolve the content object identifier ---
-        # org/team content types use object_ansible_id (looked up via
-        # Resource), everything else uses the raw object_id (wrapped
-        # in RemoteObject), and global assignments use None.
-        content_type_str = assignment.get('content_type', '')
-        model = content_type_str.split('.')[-1] if content_type_str else ''
-
-        if model in ('organization', 'team'):
-            object_ref = assignment.get('object_ansible_id')
-        else:
-            obj_id = assignment.get('object_id')
-            object_ref = str(obj_id) if obj_id is not None else None
-
-        # --- Look up the RoleDefinition ---
-        try:
-            role_definition = RoleDefinition.objects.get(name=role_name)
-        except RoleDefinition.DoesNotExist:
-            self._log(
-                f"Warning: Unable to find role definition '{role_name}', skipping {assignment_type} assignment for actor {actor_ansible_id}",
-                logging.WARNING,
-            )
-            return False
-
-        # --- Resolve the actor via Resource ---
-        try:
-            actor_resource = Resource.objects.get(ansible_id=actor_ansible_id)
-            actor = actor_resource.content_object
-            # content_object is None when the underlying object was deleted
-            # but the Resource row still exists (stale generic FK).
-            if actor is None:
+            actor_resource = actor_resource_map.get(str(actor_ansible_id))
+            if actor_resource is None:
                 self._log(
-                    f"Warning: Resource {actor_ansible_id} exists but its {assignment_type} object was deleted, skipping assignment for role '{role_name}'",
+                    f"Warning: Unable to find {assignment_type} with ansible_id {actor_ansible_id}, skipping assignment",
                     logging.WARNING,
                 )
-                return False
-        except Resource.DoesNotExist:
-            self._log(
-                f"Warning: Unable to find {assignment_type} with ansible_id {actor_ansible_id}, skipping assignment for role '{role_name}'",
-                logging.WARNING,
+                continue
+            actor_pk = actor_resource.object_id
+
+            object_ansible_id = item.get('object_ansible_id')
+            object_id = item.get('object_id')
+
+            if object_ansible_id:
+                obj_resource = object_resource_map.get(str(object_ansible_id))
+                if obj_resource is None:
+                    self._log(
+                        f"Warning: Unable to find object with ansible_id {object_ansible_id}, skipping assignment",
+                        logging.WARNING,
+                    )
+                    continue
+                object_assignments.append((actor_pk, rd, rd.content_type_id, str(obj_resource.object_id), actor_ansible_id))
+            elif object_id is not None:
+                object_assignments.append((actor_pk, rd, rd.content_type_id, str(object_id), actor_ansible_id))
+            else:
+                global_assignments.append((actor_pk, rd, None, None, actor_ansible_id))
+
+        created = 0
+        object_roles_used: set = set()
+
+        if global_assignments:
+            created += self._bulk_create_global_assignments(global_assignments, assignment_type)
+
+        if object_assignments:
+            count, obj_roles = self._bulk_create_object_assignments(object_assignments, assignment_type)
+            created += count
+            object_roles_used.update(obj_roles)
+
+        return created, object_roles_used
+
+    def _bulk_create_global_assignments(self, assignments: List[Tuple], assignment_type: str) -> int:
+        """Bulk-create global (system-wide) role assignments."""
+        AssignmentModel = RoleUserAssignment if assignment_type == 'user' else RoleTeamAssignment  # NOSONAR
+        actor_field = 'user_id' if assignment_type == 'user' else 'team_id'
+
+        assignment_objs = [
+            AssignmentModel(
+                **{actor_field: actor_pk},
+                object_role=None,
+                role_definition_id=rd.id,
+                content_type_id=None,
+                object_id=None,
             )
-            return False
+            for actor_pk, rd, _, _, _ in assignments
+        ]
 
-        # --- Create the assignment ---
-        return self._give_assignment_permission(role_definition, actor, object_ref, assignment_type, actor_ansible_id, role_name)
+        result = AssignmentModel.objects.bulk_create(assignment_objs, ignore_conflicts=True)
+        return len(result)
 
-    def _give_assignment_permission(
-        self, role_definition: RoleDefinition, actor, object_ref: Optional[str], assignment_type: str, actor_ansible_id: str, role_name: str
-    ) -> bool:
-        """Resolve the content object and call give_permission.
+    def _bulk_create_object_assignments(self, assignments: List[Tuple], assignment_type: str) -> Tuple[int, set]:
+        """Bulk-create ObjectRoles and object-scoped role assignments."""
+        unique_or_keys: set = set()
+        for _, rd, content_type_id, object_id, _ in assignments:
+            unique_or_keys.add((rd.id, content_type_id, object_id))
 
-        Handles three assignment patterns:
-        - Global (object_ref is None): give_global_permission
-        - Org/team (content_type.model in organization/team): resolve
-          via Resource ansible_id
-        - Service-specific: wrap in RemoteObject
-        """
-        try:
-            if object_ref is None:
-                role_definition.give_global_permission(actor)
-                return True
-            if role_definition.content_type and role_definition.content_type.model in ('organization', 'team'):
-                return self._give_org_team_permission(role_definition, actor, object_ref, assignment_type, actor_ansible_id, role_name)
-            remote_obj = RemoteObject(role_definition.content_type, object_ref)
-            role_definition.give_permission(actor, remote_obj)
-            return True
-        except Resource.DoesNotExist:
-            self._log(
-                f"Warning: Unable to find content object with "
-                f"ansible_id {object_ref}, "
-                f"skipping {assignment_type} assignment for actor {actor_ansible_id} "
-                f"with role '{role_name}'",
-                logging.WARNING,
+        or_objs_to_create = [ObjectRole(role_definition_id=rd_id, content_type_id=ct_id, object_id=obj_id) for rd_id, ct_id, obj_id in unique_or_keys]
+        ObjectRole.objects.bulk_create(or_objs_to_create, ignore_conflicts=True)
+
+        or_query = Q()
+        for rd_id, ct_id, obj_id in unique_or_keys:
+            or_query |= Q(role_definition_id=rd_id, content_type_id=ct_id, object_id=obj_id)
+
+        or_map: Dict[Tuple, ObjectRole] = {}
+        for obj_role in ObjectRole.objects.filter(or_query):
+            key = (obj_role.role_definition_id, obj_role.content_type_id, obj_role.object_id)
+            or_map[key] = obj_role
+
+        AssignmentModel = RoleUserAssignment if assignment_type == 'user' else RoleTeamAssignment  # NOSONAR
+        actor_field = 'user_id' if assignment_type == 'user' else 'team_id'
+
+        assignment_objs = []
+        for actor_pk, rd, content_type_id, object_id, actor_ansible_id in assignments:
+            or_key = (rd.id, content_type_id, object_id)
+            object_role = or_map.get(or_key)
+            if object_role is None:
+                self._log(
+                    f"Warning: ObjectRole not found for (rd={rd.name}, ct={content_type_id}, "
+                    f"object={object_id}), skipping assignment for actor {actor_ansible_id}",
+                    logging.WARNING,
+                )
+                continue
+
+            assignment_objs.append(
+                AssignmentModel(
+                    **{actor_field: actor_pk},
+                    object_role=object_role,
+                    role_definition_id=object_role.role_definition_id,
+                    content_type_id=object_role.content_type_id,
+                    object_id=object_role.object_id,
+                )
             )
-            return False
-        except Exception as e:
-            self._log(
-                f"Warning: Unable to give permission for {assignment_type} assignment "
-                f"(actor={actor_ansible_id}, role='{role_name}', object={object_ref}), "
-                f"skipping: {e}",
-                logging.WARNING,
-            )
-            return False
 
-    def _give_org_team_permission(
-        self, role_definition: RoleDefinition, actor, object_ref: str, assignment_type: str, actor_ansible_id: str, role_name: str
-    ) -> bool:
-        """Resolve an org/team content object via Resource and call give_permission.
-
-        Returns False if the Resource exists but its content_object was
-        deleted (stale generic FK).
-        """
-        obj_resource = Resource.objects.get(ansible_id=object_ref)
-        content_object = obj_resource.content_object
-        if content_object is None:
-            self._log(
-                f"Warning: Resource {object_ref} exists but its "
-                f"content object was deleted, "
-                f"skipping {assignment_type} assignment for actor {actor_ansible_id} "
-                f"with role '{role_name}'",
-                logging.WARNING,
-            )
-            return False
-        role_definition.give_permission(actor, content_object)
-        return True
+        result = AssignmentModel.objects.bulk_create(assignment_objs, ignore_conflicts=True)
+        return len(result), set(or_map.values())
 
     def migrate_role_assignments(self, service_slug: str, service_type_name: str) -> None:
-        """Migrate role assignments from a service using a PK-based cursor.
+        """Migrate role assignments from a service using bulk queries.
 
-        For each assignment type (user, team), fetches only assignments with
-        PKs higher than the stored cursor using ``id__gt=<last_pk>&order_by=id``.
-        On a reinstall where the cursor is already past the last PK, the API
-        returns zero results and migration completes immediately.
-
-        The cursor is persisted per page, so a crash or kill loses at most
-        one page of work.  HTTP errors raise RuntimeError to fail the
-        service (non-zero exit for the installer to retry the whole command).
-
-        After all pages are processed, a post-run drift check detects
-        assignments created during the run.  If drift is found, RuntimeError
-        is raised so the installer retries and the cursor picks up the
-        new items.
-
-        give_permission is idempotent (uses get_or_create), so replaying
-        a partial page after a crash is safe.
-
+        The RBAC cache is rebuilt once at the end in a finally block,
+        not per-assignment.
         """
         self._log(f"Migrating role assignments from {service_slug} (type {service_type_name})", logging.INFO)
         roles_to_exclude = self._get_role_definitions_to_exclude(service_type_name)
 
         total_created = 0
-        drift_detected = False
-        for assignment_type in ('user', 'team'):
-            list_fn = self.client.list_user_assignments if assignment_type == 'user' else self.client.list_team_assignments
-            cursor = CursorStore(service_slug, assignment_type)
-            created = self._paginate_and_create(list_fn, assignment_type, roles_to_exclude, cursor)
-            total_created += created
-            self._log(f"  {assignment_type}: {created} assignments created", logging.INFO)
-
-            # Post-run drift check: detect assignments created on the
-            # upstream service since the last page was fetched.  This is
-            # one extra API call per type -- negligible overhead -- but it
-            # restores the installer's ability to detect incomplete state.
-            #
-            # Note: this only captures items created between "last page
-            # fetched" and "this check."  A tiny window remains between
-            # this check and the migration flag being set, but that gap
-            # is milliseconds and practically negligible.
-            if self._check_for_drift(list_fn, assignment_type, service_slug):
-                drift_detected = True
-
-        self._log(f"Role assignment migration for {service_slug} completed ({total_created} total created)", logging.INFO)
-
-        if drift_detected:
-            raise RuntimeError(
-                f"Role assignment migration for {service_slug} completed "
-                f"({total_created} created) but concurrent modifications were "
-                f"detected. Re-run to process remaining assignments."
-            )
-
-    def _check_for_drift(self, list_fn, assignment_type: str, service_slug: str) -> bool:
-        """Check if new assignments appeared since the cursor was last advanced.
-
-        Loads a fresh cursor from the DB (reflecting the last advance()
-        call) and asks the API if any items exist beyond it.  Returns
-        True if drift is detected, False otherwise.
-        """
-        db_cursor = CursorStore(service_slug, assignment_type)
-        if db_cursor.last_pk <= 0:
-            return False
+        all_object_roles: set = set()
 
         try:
-            check_resp = list_fn(filters={'order_by': 'id', 'id__gt': str(db_cursor.last_pk), 'page_size': '1'})
-            if check_resp.status_code == 200 and check_resp.json().get('count', 0) > 0:
-                self._log(f"Warning: new {assignment_type} assignments appeared during migration of {service_slug} (concurrent modification)", logging.WARNING)
-                return True
-        except Exception:
-            logger.warning(
-                "Drift check failed for %s/%s, assuming no drift",
-                service_slug,
-                assignment_type,
-                exc_info=True,
-            )
-        return False
+            for assignment_type in ('user', 'team'):
+                list_fn = self.client.list_user_assignments if assignment_type == 'user' else self.client.list_team_assignments
+                cursor = CursorStore(service_slug, assignment_type)
+                created, object_roles = self._paginate_and_create(list_fn, assignment_type, roles_to_exclude, cursor)
+                total_created += created
+                all_object_roles.update(object_roles)
+                self._log(f"  {assignment_type}: {created} assignments created", logging.INFO)
+        finally:
+            if all_object_roles:
+                self._log(
+                    f"Rebuilding RBAC cache for {len(all_object_roles)} object roles",
+                    logging.INFO,
+                )
+                compute_team_member_roles()
+                compute_object_role_permissions(object_roles=all_object_roles)
+
+        self._log(f"Role assignment migration for {service_slug} completed ({total_created} total created)", logging.INFO)

--- a/aap_gateway_api/management/commands/_migrate_service_data/role_assignments.py
+++ b/aap_gateway_api/management/commands/_migrate_service_data/role_assignments.py
@@ -1,4 +1,5 @@
 import logging
+import traceback
 from typing import Any, Dict, List, Tuple
 
 from ansible_base.rbac.caching import compute_object_role_permissions, compute_team_member_roles
@@ -321,7 +322,7 @@ class RoleAssignmentsMixin:
                     compute_team_member_roles()
                     if all_object_roles:
                         compute_object_role_permissions(object_roles=all_object_roles)
-                except Exception:
-                    self._log("Warning: RBAC cache rebuild failed, it will be rebuilt on next request", logging.WARNING)
+                except Exception:  # noqa: BLE001 — intentionally broad to avoid masking the original migration exception
+                    self._log(f"Warning: RBAC cache rebuild failed, it will be rebuilt on next request\n{traceback.format_exc()}", logging.WARNING)
 
         self._log(f"Role assignment migration for {service_slug} completed ({total_created} total created)", logging.INFO)

--- a/aap_gateway_api/management/commands/_migrate_service_data/role_assignments.py
+++ b/aap_gateway_api/management/commands/_migrate_service_data/role_assignments.py
@@ -79,13 +79,9 @@ class RoleAssignmentsMixin:
 
         return created, all_object_roles
 
-    def _bulk_resolve_and_create_page(self, results: List[Dict[str, Any]], assignment_type: str) -> Tuple[int, set]:
-        """Resolve all assignments on a page using bulk queries and bulk-create them.
-
-        Returns (created_count, object_roles_set) for deferred cache rebuild.
-        """
-        actor_field = f'{assignment_type}_ansible_id'
-
+    @staticmethod
+    def _collect_unique_ids(results: List[Dict[str, Any]], actor_field: str) -> Tuple[set, set, set]:
+        """Extract unique role names, actor IDs, and object IDs from a results page."""
         role_names: set = set()
         actor_ansible_ids: set = set()
         object_ansible_ids: set = set()
@@ -101,6 +97,67 @@ class RoleAssignmentsMixin:
             if oid:
                 object_ansible_ids.add(str(oid))
 
+        return role_names, actor_ansible_ids, object_ansible_ids
+
+    def _resolve_single_assignment(
+        self,
+        item: Dict[str, Any],
+        actor_field: str,
+        assignment_type: str,
+        role_map: Dict[str, Any],
+        actor_resource_map: Dict[str, Any],
+        object_resource_map: Dict[str, Any],
+    ) -> 'Tuple[str, Tuple] | None':
+        """Resolve one API assignment item into a classified tuple.
+
+        Returns ``('global', tuple)`` or ``('object', tuple)`` on success,
+        or ``None`` when the item must be skipped.
+        """
+        actor_ansible_id = item.get(actor_field)
+        role_name = item.get('role_definition')
+        if not actor_ansible_id or not role_name:
+            return None
+
+        rd = role_map.get(role_name)
+        if rd is None:
+            self._log(f"Warning: Unable to find role definition '{role_name}', skipping assignment", logging.WARNING)
+            return None
+
+        actor_resource = actor_resource_map.get(str(actor_ansible_id))
+        if actor_resource is None:
+            self._log(
+                f"Warning: Unable to find {assignment_type} with ansible_id {actor_ansible_id}, skipping assignment",
+                logging.WARNING,
+            )
+            return None
+        actor_pk = actor_resource.object_id
+
+        object_ansible_id = item.get('object_ansible_id')
+        object_id = item.get('object_id')
+
+        if object_ansible_id:
+            obj_resource = object_resource_map.get(str(object_ansible_id))
+            if obj_resource is None:
+                self._log(
+                    f"Warning: Unable to find object with ansible_id {object_ansible_id}, skipping assignment",
+                    logging.WARNING,
+                )
+                return None
+            return ('object', (actor_pk, rd, rd.content_type_id, str(obj_resource.object_id), actor_ansible_id))
+        elif object_id is not None:
+            return ('object', (actor_pk, rd, rd.content_type_id, str(object_id), actor_ansible_id))
+        else:
+            return ('global', (actor_pk, rd, None, None, actor_ansible_id))
+
+    def _bulk_resolve_and_create_page(self, results: List[Dict[str, Any]], assignment_type: str) -> Tuple[int, set]:
+        """Resolve all assignments on a page using bulk queries and bulk-create them.
+
+        Returns (created_count, object_roles_set) for deferred cache rebuild.
+        """
+        actor_field = f'{assignment_type}_ansible_id'
+
+        role_names, actor_ansible_ids, object_ansible_ids = self._collect_unique_ids(results, actor_field)
+
         role_map = {rd.name: rd for rd in RoleDefinition.objects.filter(name__in=role_names)}
         actor_resource_map = {str(r.ansible_id): r for r in Resource.objects.filter(ansible_id__in=actor_ansible_ids)} if actor_ansible_ids else {}
         object_resource_map = {str(r.ansible_id): r for r in Resource.objects.filter(ansible_id__in=object_ansible_ids)} if object_ansible_ids else {}
@@ -109,41 +166,14 @@ class RoleAssignmentsMixin:
         object_assignments: List[Tuple] = []
 
         for item in results:
-            actor_ansible_id = item.get(actor_field)
-            role_name = item.get('role_definition')
-            if not actor_ansible_id or not role_name:
+            resolved = self._resolve_single_assignment(item, actor_field, assignment_type, role_map, actor_resource_map, object_resource_map)
+            if resolved is None:
                 continue
-
-            rd = role_map.get(role_name)
-            if rd is None:
-                self._log(f"Warning: Unable to find role definition '{role_name}', skipping assignment", logging.WARNING)
-                continue
-
-            actor_resource = actor_resource_map.get(str(actor_ansible_id))
-            if actor_resource is None:
-                self._log(
-                    f"Warning: Unable to find {assignment_type} with ansible_id {actor_ansible_id}, skipping assignment",
-                    logging.WARNING,
-                )
-                continue
-            actor_pk = actor_resource.object_id
-
-            object_ansible_id = item.get('object_ansible_id')
-            object_id = item.get('object_id')
-
-            if object_ansible_id:
-                obj_resource = object_resource_map.get(str(object_ansible_id))
-                if obj_resource is None:
-                    self._log(
-                        f"Warning: Unable to find object with ansible_id {object_ansible_id}, skipping assignment",
-                        logging.WARNING,
-                    )
-                    continue
-                object_assignments.append((actor_pk, rd, rd.content_type_id, str(obj_resource.object_id), actor_ansible_id))
-            elif object_id is not None:
-                object_assignments.append((actor_pk, rd, rd.content_type_id, str(object_id), actor_ansible_id))
+            kind, assignment_tuple = resolved
+            if kind == 'global':
+                global_assignments.append(assignment_tuple)
             else:
-                global_assignments.append((actor_pk, rd, None, None, actor_ansible_id))
+                object_assignments.append(assignment_tuple)
 
         created = 0
         object_roles_used: set = set()

--- a/aap_gateway_api/management/commands/_migrate_service_data/role_assignments.py
+++ b/aap_gateway_api/management/commands/_migrate_service_data/role_assignments.py
@@ -51,10 +51,13 @@ class RoleAssignmentsMixin:
         """
         created = 0
         all_object_roles: set = set()
+        total = None
 
         base_filters: Dict[str, Any] = {'order_by': 'id', 'id__gt': str(cursor.last_pk), **self.BIG_PAGE_FILTERS}
         if roles_to_exclude:
             base_filters['not__role_definition__name__in'] = ','.join(roles_to_exclude)
+
+        progress_label = f"{assignment_type} role assignments"
 
         while True:
             response = list_fn(filters=base_filters)
@@ -66,9 +69,15 @@ class RoleAssignmentsMixin:
             if not results:
                 break
 
+            if total is None:
+                total = data.get('count', 0)
+
             page_created, page_object_roles = self._bulk_resolve_and_create_page(results, assignment_type)
             created += page_created
             all_object_roles.update(page_object_roles)
+
+            if total:
+                self._log_progress(progress_label, created, total)
 
             last_pk_on_page = results[-1].get('id')
             if last_pk_on_page is not None:

--- a/aap_gateway_api/management/commands/_migrate_service_data/role_assignments.py
+++ b/aap_gateway_api/management/commands/_migrate_service_data/role_assignments.py
@@ -84,7 +84,7 @@ class RoleAssignmentsMixin:
                 cursor.advance(last_pk_on_page)
                 base_filters['id__gt'] = str(last_pk_on_page)
             else:
-                break
+                raise RuntimeError(f"API returned {assignment_type} assignment without 'id' field — cannot advance cursor")
 
         return created, all_object_roles
 
@@ -198,9 +198,30 @@ class RoleAssignmentsMixin:
         return created, object_roles_used
 
     def _bulk_create_global_assignments(self, assignments: List[Tuple], assignment_type: str) -> int:
-        """Bulk-create global (system-wide) role assignments."""
+        """Bulk-create global (system-wide) role assignments.
+
+        Because PostgreSQL treats NULL != NULL, the unique constraint on
+        (user, object_role) does not prevent duplicates when object_role
+        is None.  We therefore query for existing global assignments and
+        filter them out before calling bulk_create.
+        """
         AssignmentModel = RoleUserAssignment if assignment_type == 'user' else RoleTeamAssignment  # NOSONAR
         actor_field = 'user_id' if assignment_type == 'user' else 'team_id'
+
+        # Build the set of (actor_pk, role_def_id) we want to create
+        desired = {(actor_pk, rd.id) for actor_pk, rd, _, _, _ in assignments}
+
+        # Query existing global assignments (object_role=None) for these combos
+        existing = set(
+            AssignmentModel.objects.filter(
+                object_role__isnull=True,
+                **{f'{actor_field}__in': {a[0] for a in desired}},
+                role_definition_id__in={a[1] for a in desired},
+            ).values_list(actor_field, 'role_definition_id')
+        )
+
+        # Only create ones that don't exist
+        new_assignments = [(a, rd, ct, oid, aid) for a, rd, ct, oid, aid in assignments if (a, rd.id) not in existing]
 
         assignment_objs = [
             AssignmentModel(
@@ -210,7 +231,7 @@ class RoleAssignmentsMixin:
                 content_type_id=None,
                 object_id=None,
             )
-            for actor_pk, rd, _, _, _ in assignments
+            for actor_pk, rd, _, _, _ in new_assignments
         ]
 
         result = AssignmentModel.objects.bulk_create(assignment_objs, ignore_conflicts=True)
@@ -267,6 +288,12 @@ class RoleAssignmentsMixin:
 
         The RBAC cache is rebuilt once at the end in a finally block,
         not per-assignment.
+
+        Drift detection (checking for new assignments created during migration)
+        was removed because the id__gt sliding window naturally handles this:
+        new assignments get higher PKs and appear on subsequent pages. The only
+        undetected window is assignments created during the final page's
+        processing, which is sub-second.
         """
         self._log(f"Migrating role assignments from {service_slug} (type {service_type_name})", logging.INFO)
         roles_to_exclude = self._get_role_definitions_to_exclude(service_type_name)
@@ -284,12 +311,15 @@ class RoleAssignmentsMixin:
                 self._log(f"  {assignment_type}: {created} assignments created", logging.INFO)
         finally:
             if total_created:
-                self._log(
-                    f"Rebuilding RBAC cache ({total_created} assignments created, {len(all_object_roles)} object roles)",
-                    logging.INFO,
-                )
-                compute_team_member_roles()
-                if all_object_roles:
-                    compute_object_role_permissions(object_roles=all_object_roles)
+                try:
+                    self._log(
+                        f"Rebuilding RBAC cache ({total_created} assignments created, {len(all_object_roles)} object roles)",
+                        logging.INFO,
+                    )
+                    compute_team_member_roles()
+                    if all_object_roles:
+                        compute_object_role_permissions(object_roles=all_object_roles)
+                except Exception:
+                    self._log("Warning: RBAC cache rebuild failed, it will be rebuilt on next request", logging.WARNING)
 
         self._log(f"Role assignment migration for {service_slug} completed ({total_created} total created)", logging.INFO)

--- a/aap_gateway_api/management/commands/_migrate_service_data/service_orchestration.py
+++ b/aap_gateway_api/management/commands/_migrate_service_data/service_orchestration.py
@@ -90,9 +90,6 @@ class ServiceOrchestrationMixin:
         service_api.service_cluster.service_id = self.upstream_service_id
         service_api.service_cluster.save()
 
-        # No-op if legacy authenticators were already deleted on a previous run
-        self.delete_legacy_authenticators()
-
         if self._is_service_already_synced():
             self._log(f"Service {service_slug} is already synchronized — skipping resource migration.", logging.INFO)
         else:

--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -117,6 +117,12 @@ class Command(
             required=False,
             default=None,
         )
+        parser.add_argument(
+            "--rerun",
+            action="store_true",
+            help="Force migration to run even if it has already completed. Useful for testing and benchmarking.",
+            default=False,
+        )
 
     def _warn_ignored_flags(self, options: dict) -> None:
         if options.get("api_slug"):
@@ -150,7 +156,7 @@ class Command(
         self._warn_ignored_flags(options)
         self._configure_logging(options.get("log_file"))
 
-        if MigrateServiceDataHasRan.has_migration_completed():
+        if MigrateServiceDataHasRan.has_migration_completed() and not options.get("rerun"):
             self._log("Migration has already completed. Skipping.", logging.INFO)
             return
 

--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -100,7 +100,7 @@ class Command(
             "--merge-teams",
             type=bool,
             help=("[IGNORED] If true, teams with the same names on different services will be combined. This flag is now ignored and defaults to True."),
-            default=True,
+            default=None,
         )
         parser.add_argument(
             "--merge-organizations",
@@ -108,7 +108,7 @@ class Command(
             help=(
                 "[IGNORED] If true, organizations with the same names on different services will be combined. This flag is now ignored and defaults to True."
             ),
-            default=True,
+            default=None,
         )
         parser.add_argument(
             "--log-file",
@@ -124,10 +124,10 @@ class Command(
                 self.style.WARNING("Warning: --api-slug flag is ignored. The command now processes all services with DefaultServiceType (excluding gateway).")
             )
 
-        if "merge_teams" in options:
+        if options.get("merge_teams") is not None:
             self.stderr.write(self.style.WARNING("Warning: --merge-teams flag is ignored. The default value is now True."))
 
-        if "merge_organizations" in options:
+        if options.get("merge_organizations") is not None:
             self.stderr.write(self.style.WARNING("Warning: --merge-organizations flag is ignored. The default value is now True."))
 
     def handle(self, *args, **options) -> None:

--- a/aap_gateway_api/management/commands/migrate_service_data.py
+++ b/aap_gateway_api/management/commands/migrate_service_data.py
@@ -14,6 +14,7 @@ from ansible_base.resource_registry.models import ResourceType
 from ansible_base.rest_pagination.default_paginator import DEFAULT_MAX_PAGE_SIZE
 from django.contrib.auth.models import AbstractUser
 from django.core.management.base import BaseCommand, CommandError
+from django.db import models
 
 from aap_gateway_api.management.commands._migrate_service_data.cursor_store import CursorStore as _CursorStore  # noqa: F401 — re-export for test compat
 from aap_gateway_api.management.commands._migrate_service_data.legacy_authenticators import LegacyAuthenticatorsMixin
@@ -160,63 +161,41 @@ class Command(
             self._log("Migration has already completed. Skipping.", logging.INFO)
             return
 
-        # Force merge options to True as per requirements
-        merge_teams = True
-        merge_organizations = True
         username = options["username"]
 
         # The order here matters. Organizations need to be migrated first.
-        self.resource_types_to_migrate = OrderedDict()
-
-        self.resource_types_to_migrate[SHARED_ORGANIZATION_RESOURCE_TYPE] = {
-            "merge": merge_organizations,
-            "type": ResourceType.objects.get(name=SHARED_ORGANIZATION_RESOURCE_TYPE),
-            "unique_fields": [
-                "name",
-            ],
-        }
-        self.resource_types_to_migrate[SHARED_TEAM_RESOURCE_TYPE] = {
-            "merge": merge_teams,
-            "type": ResourceType.objects.get(name=SHARED_TEAM_RESOURCE_TYPE),
-            "unique_fields": [
-                "name",
-                "organization",
-            ],
-        }
-        self.resource_types_to_migrate[SHARED_USER_RESOURCE_TYPE] = {
-            "merge": True,  # only indicates we merge the admin user
-            "type": ResourceType.objects.get(name=SHARED_USER_RESOURCE_TYPE),
-            "unique_fields": [
-                "username",
-            ],
-        }
-        self.resource_types_to_migrate[SHARED_ROLE_DEFINITION_RESOURCE_TYPE] = {
-            "merge": True,  # the JWT roles are already shared effectively
-            "type": ResourceType.objects.get(name=SHARED_ROLE_DEFINITION_RESOURCE_TYPE),
-            "unique_fields": [
-                "name",
-            ],
-        }
-        self.resource_types_to_migrate[SHARED_AAP_FLAG_RESOURCE_TYPE] = {
-            "merge": True,
-            "type": ResourceType.objects.get(name=SHARED_AAP_FLAG_RESOURCE_TYPE),
-            "unique_fields": [
-                "name",
-                "condition",
-            ],
-        }
+        self.resource_types_to_migrate = OrderedDict(
+            {
+                SHARED_ORGANIZATION_RESOURCE_TYPE: {
+                    "type": ResourceType.objects.get(name=SHARED_ORGANIZATION_RESOURCE_TYPE),
+                    "unique_fields": ["name"],
+                },
+                SHARED_TEAM_RESOURCE_TYPE: {
+                    "type": ResourceType.objects.get(name=SHARED_TEAM_RESOURCE_TYPE),
+                    "unique_fields": ["name", "organization"],
+                },
+                SHARED_USER_RESOURCE_TYPE: {
+                    "type": ResourceType.objects.get(name=SHARED_USER_RESOURCE_TYPE),
+                    "unique_fields": ["username"],
+                },
+                SHARED_ROLE_DEFINITION_RESOURCE_TYPE: {
+                    "type": ResourceType.objects.get(name=SHARED_ROLE_DEFINITION_RESOURCE_TYPE),
+                    "unique_fields": ["name"],
+                },
+                SHARED_AAP_FLAG_RESOURCE_TYPE: {
+                    "type": ResourceType.objects.get(name=SHARED_AAP_FLAG_RESOURCE_TYPE),
+                    "unique_fields": ["name", "condition"],
+                },
+            }
+        )
 
         user = self._get_gateway_user(username)
         if user is None:
             raise CommandError(f"Username {username} does not exist")
 
         # Get all services with DefaultServiceType in exact order: controller, hub, eda
-        service_apis_dict = {
-            api.service_cluster.service_type.name: api
-            for api in ServiceAPIRoute.objects.filter(service_cluster__service_type__name__in=self.SERVICE_TYPE_ORDER)
-        }
-
-        service_apis = [service_apis_dict[service_type] for service_type in self.SERVICE_TYPE_ORDER if service_type in service_apis_dict]
+        ordering = models.Case(*[models.When(service_cluster__service_type__name=name, then=pos) for pos, name in enumerate(self.SERVICE_TYPE_ORDER)])
+        service_apis = list(ServiceAPIRoute.objects.filter(service_cluster__service_type__name__in=self.SERVICE_TYPE_ORDER).order_by(ordering))
 
         if not service_apis:
             raise CommandError(f"No services found with expected service types: {', '.join(self.SERVICE_TYPE_ORDER)}")
@@ -232,22 +211,25 @@ class Command(
 
         self._progress_thresholds = {}
 
+        # Clean up legacy authenticators once before processing services
+        self.delete_legacy_authenticators()
+
         # Merge all partially migrated users before proceeding with migration
         self._log("\n=== Merging partially migrated users ===", logging.INFO)
         self._merge_partially_migrated_users(service_apis, user)
 
         # Process each service and report results
         successful_services, failed_services = self._process_all_services(service_apis, user)
-        self._report_migration_summary(service_apis, user, successful_services, failed_services)
+        self._report_migration_summary(service_apis, successful_services, failed_services)
+
+        self._ensure_superuser_consistency(service_apis, user)
+
+        self._log("\n=== Re-enabling service authentication ===", logging.INFO)
+        MigrateServiceDataHasRan.mark_migration_completed()
+        self._log("Migration flag updated: Service authentication is now enabled.", logging.INFO)
 
     def _process_all_services(self, service_apis: List[ServiceAPIRoute], user: AbstractUser) -> Tuple[List[str], Dict[str, str]]:
-        """
-        Process migration for all services, returning success/failure lists.
-
-        Returns:
-            Tuple of (successful_service_slugs, failed_services_with_errors)
-            where failed_services_with_errors is a dict of {slug: error_message}
-        """
+        """Process migration for all services, returning success/failure lists."""
         successful_services: List[str] = []
         failed_services: Dict[str, str] = {}
 
@@ -272,14 +254,12 @@ class Command(
     def _report_migration_summary(
         self,
         service_apis: List[ServiceAPIRoute],
-        user: AbstractUser,
         successful_services: List[str],
         failed_services: Dict[str, str],
     ) -> None:
-        """Report migration results and finalize state."""
-        total = len(successful_services) + len(failed_services)
+        """Report migration results. Raises CommandError if any service failed."""
         self._log("\n=== Migration Summary ===", logging.INFO)
-        self._log(f"Total services processed: {total}", logging.INFO)
+        self._log(f"Total services processed: {len(service_apis)}", logging.INFO)
         self._log(f"Successful migrations: {len(successful_services)}", logging.INFO)
         self._log(f"Failed migrations: {len(failed_services)}", logging.INFO)
 
@@ -291,10 +271,3 @@ class Command(
             for service_slug, error in failed_services.items():
                 self._log(f"  - {service_slug}: {error}", logging.WARNING)
             raise CommandError(f"Migration failed for {len(failed_services)} service(s): {', '.join(failed_services)}. See error details above.")
-
-        self._ensure_superuser_consistency(service_apis, user)
-
-        self._log("\n=== Re-enabling service authentication ===", logging.INFO)
-        MigrateServiceDataHasRan.mark_migration_completed()
-        self._log("✓ Migration flag updated: Service authentication is now enabled.", logging.INFO)
-        self._log("\nAll services migration completed successfully!", logging.INFO)

--- a/aap_gateway_api/tests/conftest.py
+++ b/aap_gateway_api/tests/conftest.py
@@ -113,6 +113,12 @@ def pytest_configure():
         pass
 
 
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if "_perf" in item.module.__name__:
+            item.add_marker(pytest.mark.perf)
+
+
 # set_preference fixture has been REMOVED!
 # All tests have been migrated to use preference_manager for better isolation and cleanup.
 #

--- a/aap_gateway_api/tests/management/commands/_migrate_service_data/test_cursor_store.py
+++ b/aap_gateway_api/tests/management/commands/_migrate_service_data/test_cursor_store.py
@@ -94,7 +94,7 @@ class TestCursorStore:
 
     def test_load_failure_uses_custom_log_fn(self):
         """When log_fn is provided, _load failures route warnings through it
-        instead of the module-level logger."""
+        instead of the module-level logger, and include the traceback."""
         log_fn = Mock()
         cursor_mod = "aap_gateway_api.management.commands._migrate_service_data.cursor_store.connection"
         with patch(cursor_mod) as mock_conn:
@@ -105,11 +105,12 @@ class TestCursorStore:
         log_fn.assert_called_once()
         msg, level = log_fn.call_args[0]
         assert "Failed to load cursor" in msg
+        assert "Traceback" in msg
         assert level == logging.WARNING
 
     def test_advance_failure_uses_custom_log_fn(self):
         """When log_fn is provided, advance() failures route warnings through it
-        instead of the module-level logger."""
+        instead of the module-level logger, and include the traceback."""
         cursor = CursorStore("controller-adv-log", "user")
         log_fn = Mock()
         cursor._log_fn = log_fn
@@ -122,6 +123,7 @@ class TestCursorStore:
         log_fn.assert_called_once()
         msg, level = log_fn.call_args[0]
         assert "Failed to advance cursor" in msg
+        assert "Traceback" in msg
         assert level == logging.WARNING
 
     def test_default_log_writes_to_logger_on_failure(self):

--- a/aap_gateway_api/tests/management/commands/_migrate_service_data/test_cursor_store.py
+++ b/aap_gateway_api/tests/management/commands/_migrate_service_data/test_cursor_store.py
@@ -5,7 +5,8 @@ never mutated.  advance() only persists to the database.  This ensures
 the HTTP id__gt filter stays immutable across all pages of a single run.
 """
 
-from unittest.mock import patch
+import logging
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -90,3 +91,48 @@ class TestCursorStore:
         # The advance failed, so a new cursor should still read 0
         new_cursor = CursorStore("controller-adv-err", "user")
         assert new_cursor.last_pk == 0
+
+    def test_load_failure_uses_custom_log_fn(self):
+        """When log_fn is provided, _load failures route warnings through it
+        instead of the module-level logger."""
+        log_fn = Mock()
+        cursor_mod = "aap_gateway_api.management.commands._migrate_service_data.cursor_store.connection"
+        with patch(cursor_mod) as mock_conn:
+            mock_conn.cursor.side_effect = RuntimeError("DB unavailable")
+            cursor = CursorStore("controller", "user", log_fn=log_fn)
+
+        assert cursor.last_pk == 0
+        log_fn.assert_called_once()
+        msg, level = log_fn.call_args[0]
+        assert "Failed to load cursor" in msg
+        assert level == logging.WARNING
+
+    def test_advance_failure_uses_custom_log_fn(self):
+        """When log_fn is provided, advance() failures route warnings through it
+        instead of the module-level logger."""
+        cursor = CursorStore("controller-adv-log", "user")
+        log_fn = Mock()
+        cursor._log_fn = log_fn
+
+        cursor_mod = "aap_gateway_api.management.commands._migrate_service_data.cursor_store.connection"
+        with patch(cursor_mod) as mock_conn:
+            mock_conn.cursor.side_effect = RuntimeError("DB unavailable")
+            cursor.advance(100)
+
+        log_fn.assert_called_once()
+        msg, level = log_fn.call_args[0]
+        assert "Failed to advance cursor" in msg
+        assert level == logging.WARNING
+
+    def test_default_log_writes_to_logger_on_failure(self):
+        """When no log_fn is provided, _load failures go through the module-level logger."""
+        cursor_mod = "aap_gateway_api.management.commands._migrate_service_data.cursor_store.connection"
+        logger_mod = "aap_gateway_api.management.commands._migrate_service_data.cursor_store.logger"
+        with patch(cursor_mod) as mock_conn, patch(logger_mod) as mock_logger:
+            mock_conn.cursor.side_effect = RuntimeError("DB unavailable")
+            cursor = CursorStore("controller", "user")
+
+        assert cursor.last_pk == 0
+        mock_logger.warning.assert_called_once()
+        msg = mock_logger.warning.call_args[0][0]
+        assert "Failed to load cursor" in msg

--- a/aap_gateway_api/tests/management/commands/_migrate_service_data/test_resource_migration.py
+++ b/aap_gateway_api/tests/management/commands/_migrate_service_data/test_resource_migration.py
@@ -1,6 +1,6 @@
 """Tests for ResourceMigrationMixin: migrate_conflicting_user, merge_users,
 correcting_user_service_id, migrating_user_with_invalid_email,
-updating_resource_data_for_invalid_resource, use_given_name_*,
+updating_resource_data_for_invalid_resource,
 process_migrate_resource_item_*, reconcile_existing_resource_*.
 """
 
@@ -162,24 +162,6 @@ def test_updating_resource_data_for_invalid_resource(migration_service_invalid_u
 
         assert not User.objects.filter(username="invaliduser").exists()
         assert not User.objects.filter(username="bademailuser1").exists()
-
-
-@pytest.mark.django_db
-def test_use_given_name_first_found(cmd):
-    assert cmd.get_new_resource_name('foouser', {'username': 'bob'}, User, 'username', 'controller') == 'controller_foouser'
-
-    User.objects.create(username='bob')
-    assert cmd.get_new_resource_name('foouser', {'username': 'bob'}, User, 'username', 'controller') == 'controller_foouser'
-
-
-@pytest.mark.django_db
-def test_use_given_name_iteration(cmd):
-    User.objects.create(username='controller_foouser')
-    assert cmd.get_new_resource_name('foouser', {'username': 'bob'}, User, 'username', 'controller') == 'controller_foouser1'
-
-    User.objects.create(username='controller_foouser1')
-    User.objects.create(username='controller_foouser2')
-    assert cmd.get_new_resource_name('foouser', {'username': 'bob'}, User, 'username', 'controller') == 'controller_foouser3'
 
 
 @pytest.mark.django_db

--- a/aap_gateway_api/tests/management/commands/_migrate_service_data/test_resource_migration.py
+++ b/aap_gateway_api/tests/management/commands/_migrate_service_data/test_resource_migration.py
@@ -257,3 +257,158 @@ def test_reconcile_existing_resource_matching_ansible_id_different_data():
     assert updated_service_resource["resource_data"] == local_data
     combined_output = cmd.stdout.getvalue() + cmd.stderr.getvalue()
     assert "Updating already-merged" in combined_output
+
+
+def test_deserialize_and_validate_resource_data_valid():
+    """When the serializer reports valid data, the validated_data dict is returned directly."""
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+
+    validated = {"username": "tony", "email": "tony@stark.invalid"}
+    mock_serializer_instance = Mock()
+    mock_serializer_instance.is_valid.return_value = True
+    mock_serializer_instance.validated_data = validated
+
+    mock_serializer_cls = Mock(return_value=mock_serializer_instance)
+
+    upstream_resource = {
+        "ansible_id": "test-aid-001",
+        "resource_type": "shared.user",
+        "resource_data": {"username": "tony", "email": "tony@stark.invalid"},
+    }
+
+    result = cmd._deserialize_and_validate_resource_data(upstream_resource, mock_serializer_cls)
+
+    assert result == validated
+    mock_serializer_cls.assert_called_once_with(data=upstream_resource["resource_data"])
+    mock_serializer_instance.is_valid.assert_called_once_with(raise_exception=False)
+
+
+def test_deserialize_and_validate_resource_data_invalid_then_fixed():
+    """When validation fails but update_resource_data returns a fix, the fixed data is returned."""
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+
+    fixed_data = {"username": "baduser", "email": ""}
+
+    mock_serializer_instance = Mock()
+    mock_serializer_instance.is_valid.return_value = False
+    mock_serializer_instance.errors = {"email": ["Enter a valid email address."]}
+    mock_serializer_instance.data = {"username": "baduser", "email": "not-an-email"}
+
+    mock_serializer_cls = Mock(return_value=mock_serializer_instance)
+
+    upstream_resource = {
+        "ansible_id": "test-aid-002",
+        "resource_type": "shared.user",
+        "resource_data": {"username": "baduser", "email": "not-an-email"},
+    }
+
+    with patch.object(MigrateCommand, "update_resource_data", return_value=fixed_data):
+        result = cmd._deserialize_and_validate_resource_data(upstream_resource, mock_serializer_cls)
+
+    assert result == fixed_data
+    # The upstream_resource should have its resource_data updated to the fixed data
+    assert upstream_resource["resource_data"] == fixed_data
+
+
+def test_deserialize_and_validate_resource_data_invalid_unfixable():
+    """When validation fails and update_resource_data returns None, RuntimeError is raised."""
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+
+    mock_serializer_instance = Mock()
+    mock_serializer_instance.is_valid.return_value = False
+    mock_serializer_instance.errors = {"username": ["This field is required."]}
+    mock_serializer_instance.data = {}
+
+    mock_serializer_cls = Mock(return_value=mock_serializer_instance)
+
+    upstream_resource = {
+        "ansible_id": "test-aid-003",
+        "resource_type": "shared.user",
+        "resource_data": {},
+    }
+
+    with patch.object(MigrateCommand, "update_resource_data", return_value=None):
+        with pytest.raises(RuntimeError, match="invalid, non-correctable"):
+            cmd._deserialize_and_validate_resource_data(upstream_resource, mock_serializer_cls)
+
+
+def test_initialize_resource_sync_payloads():
+    """Payloads contain the upstream ansible_id and the gateway service_id."""
+    cmd = MigrateCommand()
+
+    upstream_resource = {
+        "ansible_id": "test-aid-100",
+        "resource_data": {"username": "pepper"},
+    }
+
+    with patch("aap_gateway_api.management.commands._migrate_service_data.resource_migration.service_id", return_value="gw-service-id-42"):
+        creation_kwargs, service_resource = cmd._initialize_resource_sync_payloads(upstream_resource)
+
+    assert creation_kwargs == {"ansible_id": "test-aid-100"}
+    assert service_resource == {"service_id": "gw-service-id-42"}
+
+
+def test_get_filtered_resources_excludes_system_user():
+    """For shared.user resources, the system user (settings.SYSTEM_USERNAME) is excluded."""
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+    cmd.RESOURCE_DATA_FILTERS = {"extra_fields": "resource_data"}
+
+    system_username = "_system"
+    mock_response = Mock()
+    mock_response.json.return_value = {
+        "count": 3,
+        "results": [
+            {"name": "tony", "ansible_id": "a1"},
+            {"name": system_username, "ansible_id": "a2"},
+            {"name": "pepper", "ansible_id": "a3"},
+        ],
+    }
+
+    cmd.client = Mock()
+    cmd.client.list_resources.return_value = mock_response
+
+    with patch("aap_gateway_api.management.commands._migrate_service_data.resource_migration.settings") as mock_settings:
+        mock_settings.SYSTEM_USERNAME = system_username
+        results, count = cmd._get_filtered_resources({}, "shared.user")
+
+    assert count == 3
+    assert len(results) == 2
+    names = [r["name"] for r in results]
+    assert system_username not in names
+    assert "tony" in names
+    assert "pepper" in names
+
+
+def test_get_filtered_resources_non_user_type():
+    """For non-user resource types, no filtering is applied and all results are returned."""
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+    cmd.RESOURCE_DATA_FILTERS = {"extra_fields": "resource_data"}
+
+    mock_response = Mock()
+    mock_response.json.return_value = {
+        "count": 2,
+        "results": [
+            {"name": "Org1", "ansible_id": "o1"},
+            {"name": "Org2", "ansible_id": "o2"},
+        ],
+    }
+
+    cmd.client = Mock()
+    cmd.client.list_resources.return_value = mock_response
+
+    results, count = cmd._get_filtered_resources({}, "shared.organization")
+
+    assert count == 2
+    assert len(results) == 2
+    assert results[0]["name"] == "Org1"
+    assert results[1]["name"] == "Org2"

--- a/aap_gateway_api/tests/management/commands/_migrate_service_data/test_role_assignments.py
+++ b/aap_gateway_api/tests/management/commands/_migrate_service_data/test_role_assignments.py
@@ -80,6 +80,7 @@ class TestPaginateAndCreate:
         cmd.client = Mock()
         cmd.stdout = Mock()
         cmd.stderr = Mock()
+        cmd._progress_thresholds = {}
         return cmd
 
     def test_first_run_creates_all(self):
@@ -319,6 +320,7 @@ class TestMigrateRoleAssignments:
         cmd.client = Mock()
         cmd.stdout = Mock()
         cmd.stderr = Mock()
+        cmd._progress_thresholds = {}
         return cmd
 
     def test_processes_user_and_team(self):
@@ -454,6 +456,7 @@ class TestBulkResolveAndCreatePage:
         cmd.client = Mock()
         cmd.stdout = Mock()
         cmd.stderr = Mock()
+        cmd._progress_thresholds = {}
         return cmd
 
     def test_empty_results_returns_zero(self):
@@ -629,11 +632,15 @@ class TestBulkResolveAndCreatePage:
         assert len(obj_roles) > 0
 
     def test_idempotent_via_ignore_conflicts(self):
-        """Calling twice with the same data does not duplicate rows."""
-        from aap_gateway_api.models import User
+        """Calling twice with the same data does not duplicate object-scoped rows."""
+        from ansible_base.rbac.models import DABContentType
+
+        from aap_gateway_api.models import Organization, User
 
         user = User.objects.create(username="bulk-idempotent-user")
-        RoleDefinition.objects.get_or_create(name="Test Bulk Idempotent Role", defaults={"managed": False})
+        org = Organization.objects.create(name="bulk-idempotent-org")
+        ct = DABContentType.objects.get_for_model(org)
+        RoleDefinition.objects.get_or_create(name="Test Bulk Idempotent Role", defaults={"managed": False, "content_type": ct})
 
         cmd = self._make_cmd()
         results = [
@@ -642,6 +649,8 @@ class TestBulkResolveAndCreatePage:
                 str(user.resource.ansible_id),
                 "Test Bulk Idempotent Role",
                 pk=1,
+                content_type="shared.organization",
+                object_ansible_id=str(org.resource.ansible_id),
             )
         ]
         created1, _ = cmd._bulk_resolve_and_create_page(results, "user")

--- a/aap_gateway_api/tests/management/commands/_migrate_service_data/test_role_assignments.py
+++ b/aap_gateway_api/tests/management/commands/_migrate_service_data/test_role_assignments.py
@@ -362,12 +362,13 @@ class TestMigrateRoleAssignments:
         cmd.stdout.write.assert_any_call("Role assignment migration for controller completed (10 total created)")
 
     def test_rbac_cache_rebuilt_when_object_roles_exist(self):
-        """RBAC cache is rebuilt when object roles are returned from pagination."""
+        """RBAC cache is rebuilt with union of object roles from both user and team calls."""
         cmd = self._make_cmd()
-        mock_or = Mock()
+        mock_user_or = Mock()
+        mock_team_or = Mock()
 
         with (
-            patch.object(cmd, "_paginate_and_create", return_value=(5, {mock_or})),
+            patch.object(cmd, "_paginate_and_create", side_effect=[(5, {mock_user_or}), (4, {mock_team_or})]),
             patch("aap_gateway_api.management.commands._migrate_service_data.role_assignments.compute_team_member_roles") as mock_team,
             patch("aap_gateway_api.management.commands._migrate_service_data.role_assignments.compute_object_role_permissions") as mock_perms,
         ):
@@ -375,12 +376,25 @@ class TestMigrateRoleAssignments:
 
         mock_team.assert_called_once()
         mock_perms.assert_called_once()
-        # The set should be the union from both user and team calls
         call_kwargs = mock_perms.call_args[1]
-        assert mock_or in call_kwargs["object_roles"]
+        assert call_kwargs["object_roles"] == {mock_user_or, mock_team_or}
 
-    def test_rbac_cache_skipped_when_no_object_roles(self):
-        """RBAC cache rebuild is skipped when no object roles are returned."""
+    def test_rbac_cache_team_member_roles_called_for_global_only(self):
+        """compute_team_member_roles is called even when only global assignments are created."""
+        cmd = self._make_cmd()
+
+        with (
+            patch.object(cmd, "_paginate_and_create", return_value=(3, set())),
+            patch("aap_gateway_api.management.commands._migrate_service_data.role_assignments.compute_team_member_roles") as mock_team,
+            patch("aap_gateway_api.management.commands._migrate_service_data.role_assignments.compute_object_role_permissions") as mock_perms,
+        ):
+            cmd.migrate_role_assignments("controller", "controller")
+
+        mock_team.assert_called_once()
+        mock_perms.assert_not_called()
+
+    def test_rbac_cache_skipped_when_nothing_created(self):
+        """RBAC cache rebuild is skipped when no assignments are created."""
         cmd = self._make_cmd()
 
         with (
@@ -615,7 +629,7 @@ class TestBulkResolveAndCreatePage:
         assert len(obj_roles) > 0
 
     def test_idempotent_via_ignore_conflicts(self):
-        """Calling twice with the same data does not raise an error."""
+        """Calling twice with the same data does not duplicate rows."""
         from aap_gateway_api.models import User
 
         user = User.objects.create(username="bulk-idempotent-user")
@@ -633,10 +647,9 @@ class TestBulkResolveAndCreatePage:
         created1, _ = cmd._bulk_resolve_and_create_page(results, "user")
         assert created1 == 1
 
-        # Second call should not raise
         created2, _ = cmd._bulk_resolve_and_create_page(results, "user")
-        # bulk_create with ignore_conflicts may return 0 on second call
-        assert created2 >= 0
+        assert created2 in {0, 1}
+        assert RoleUserAssignment.objects.filter(user__username="bulk-idempotent-user").count() == 1
 
 
 # =============================================================================

--- a/aap_gateway_api/tests/management/commands/_migrate_service_data/test_role_assignments.py
+++ b/aap_gateway_api/tests/management/commands/_migrate_service_data/test_role_assignments.py
@@ -1,5 +1,5 @@
 """Tests for RoleAssignmentsMixin: TestPaginateAndCreate, TestMigrateRoleAssignments,
-TestCreateAssignment, TestRaiseFetchError, TestGetRoleDefinitionsToExclude,
+TestBulkResolveAndCreatePage, TestRaiseFetchError, TestGetRoleDefinitionsToExclude,
 and integration tests for role assignment migration with live services.
 """
 
@@ -8,7 +8,6 @@ from unittest.mock import Mock, patch
 
 import pytest
 from ansible_base.rbac.models import RemoteObject, RoleTeamAssignment, RoleUserAssignment
-from ansible_base.resource_registry.models import Resource
 from django.core.management import call_command
 
 from aap_gateway_api.management.commands._migrate_service_data.cursor_store import CursorStore
@@ -94,10 +93,11 @@ class TestPaginateAndCreate:
 
         cmd = self._make_cmd()
         cursor = CursorStore("test-svc", "user")
-        list_fn = Mock(return_value=resp)
+        empty_resp = _make_api_response([])
+        list_fn = Mock(side_effect=[resp, empty_resp])
 
-        with patch.object(cmd, "_create_assignment", return_value=True):
-            created = cmd._paginate_and_create(list_fn, "user", [], cursor)
+        with patch.object(cmd, "_bulk_resolve_and_create_page", return_value=(2, set())):
+            created, obj_roles = cmd._paginate_and_create(list_fn, "user", [], cursor)
 
         assert created == 2
         new_cursor = CursorStore("test-svc", "user")
@@ -119,8 +119,8 @@ class TestPaginateAndCreate:
         assert call_filters["id__gt"] == "100"
         assert call_filters["order_by"] == "id"
 
-    def test_cursor_not_in_filters_when_zero(self):
-        """When cursor is at 0, id__gt is not added to filters."""
+    def test_cursor_zero_in_filters_when_fresh(self):
+        """When cursor is at 0, id__gt is set to '0' in filters."""
         resp = _make_api_response([])
 
         cmd = self._make_cmd()
@@ -130,19 +130,20 @@ class TestPaginateAndCreate:
         cmd._paginate_and_create(list_fn, "user", [], cursor)
 
         call_filters = list_fn.call_args[1]["filters"]
-        assert "id__gt" not in call_filters
+        assert call_filters["id__gt"] == "0"
 
     def test_cursor_advances_per_page(self):
         """Cursor is advanced in DB after each page for crash safety."""
         page1 = _make_api_response([_make_remote_assignment("user", "u1", "Role1", pk=10)], has_next=True)
         page2 = _make_api_response([_make_remote_assignment("user", "u2", "Role1", pk=20)])
+        empty = _make_api_response([])
 
         cmd = self._make_cmd()
         cursor = CursorStore("test-svc-pages", "user")
-        list_fn = Mock(side_effect=[page1, page2])
+        list_fn = Mock(side_effect=[page1, page2, empty])
 
-        with patch.object(cmd, "_create_assignment", return_value=True):
-            created = cmd._paginate_and_create(list_fn, "user", [], cursor)
+        with patch.object(cmd, "_bulk_resolve_and_create_page", return_value=(1, set())):
+            created, obj_roles = cmd._paginate_and_create(list_fn, "user", [], cursor)
 
         assert created == 2
         assert cursor.last_pk == 0
@@ -159,11 +160,11 @@ class TestPaginateAndCreate:
         cursor = CursorStore("test-svc-empty", "user")
         list_fn = Mock(return_value=resp)
 
-        with patch.object(cmd, "_create_assignment") as mock_create:
-            created = cmd._paginate_and_create(list_fn, "user", [], cursor)
+        with patch.object(cmd, "_bulk_resolve_and_create_page") as mock_bulk:
+            created, obj_roles = cmd._paginate_and_create(list_fn, "user", [], cursor)
 
         assert created == 0
-        mock_create.assert_not_called()
+        mock_bulk.assert_not_called()
         new_cursor = CursorStore("test-svc-empty", "user")
         assert new_cursor.last_pk == 50
 
@@ -177,7 +178,7 @@ class TestPaginateAndCreate:
         cursor = CursorStore("test-svc-err", "user")
         list_fn = Mock(return_value=error_resp)
 
-        with pytest.raises(RuntimeError, match="Failed to fetch user assignments page 1: HTTP 500"):
+        with pytest.raises(RuntimeError, match="Failed to fetch user assignments page 0: HTTP 500"):
             cmd._paginate_and_create(list_fn, "user", [], cursor)
 
         assert list_fn.call_count == 1
@@ -193,24 +194,26 @@ class TestPaginateAndCreate:
         cursor = CursorStore("test-svc-mid", "user")
         list_fn = Mock(side_effect=[page1, error_resp])
 
-        with patch.object(cmd, "_create_assignment", return_value=True):
+        with patch.object(cmd, "_bulk_resolve_and_create_page", return_value=(1, set())):
             with pytest.raises(RuntimeError, match="Failed to fetch"):
                 cmd._paginate_and_create(list_fn, "user", [], cursor)
 
         new_cursor = CursorStore("test-svc-mid", "user")
         assert new_cursor.last_pk == 10
 
-    def test_missing_pk_raises_runtime_error(self):
-        """If the API returns an assignment without an 'id' field, raise RuntimeError."""
+    def test_missing_pk_stops_pagination(self):
+        """If the API returns an assignment without an 'id' field, pagination stops gracefully."""
         resp = _make_api_response([{"user_ansible_id": "u1", "role_definition": "Role1"}])
 
         cmd = self._make_cmd()
         cursor = CursorStore("test-svc-nopk", "user")
         list_fn = Mock(return_value=resp)
 
-        with patch.object(cmd, "_create_assignment", return_value=True):
-            with pytest.raises(RuntimeError, match="without 'id' field"):
-                cmd._paginate_and_create(list_fn, "user", [], cursor)
+        with patch.object(cmd, "_bulk_resolve_and_create_page", return_value=(1, set())):
+            created, obj_roles = cmd._paginate_and_create(list_fn, "user", [], cursor)
+
+        assert created == 1
+        assert obj_roles == set()
 
     def test_role_exclusion_filter_applied(self):
         """Role exclusion filter is passed to the API when non-empty."""
@@ -226,24 +229,82 @@ class TestPaginateAndCreate:
         assert "not__role_definition__name__in" in call_filters
 
     def test_multi_page_snapshot_prevents_skipping(self):
-        """Verify that id__gt filter uses the snapshot value, not the advancing DB cursor."""
+        """Verify that id__gt filter uses the sliding window value correctly."""
         page1 = _make_api_response([_make_remote_assignment("user", "u1", "Role1", pk=10)], has_next=True)
         page2 = _make_api_response([_make_remote_assignment("user", "u2", "Role1", pk=20)])
+        empty = _make_api_response([])
 
         cmd = self._make_cmd()
         cursor = CursorStore("test-svc-snapshot", "user")
-        list_fn = Mock(side_effect=[page1, page2])
 
-        with patch.object(cmd, "_create_assignment", return_value=True):
+        captured_id_gts = []
+        pages = iter([page1, page2, empty])
+
+        def capture_filters(**kwargs):
+            captured_id_gts.append(kwargs["filters"]["id__gt"])
+            return next(pages)
+
+        list_fn = Mock(side_effect=capture_filters)
+
+        with patch.object(cmd, "_bulk_resolve_and_create_page", return_value=(1, set())):
             cmd._paginate_and_create(list_fn, "user", [], cursor)
 
-        page1_filters = list_fn.call_args_list[0][1]["filters"]
-        page2_filters = list_fn.call_args_list[1][1]["filters"]
-        assert "id__gt" not in page1_filters
-        assert "id__gt" not in page2_filters
+        assert captured_id_gts[0] == "0"
+        assert captured_id_gts[1] == "10"
 
         new_cursor = CursorStore("test-svc-snapshot", "user")
         assert new_cursor.last_pk == 20
+
+    def test_deletion_during_pagination_does_not_skip_items(self):
+        """Sliding window using id__gt is stable against mid-run deletions."""
+        page1 = _make_api_response(
+            [
+                _make_remote_assignment("user", "u1", "Role1", pk=5),
+                _make_remote_assignment("user", "u2", "Role1", pk=10),
+            ],
+            has_next=True,
+        )
+        # Between pages, items with lower PKs "disappear" -- doesn't matter
+        # because we use id__gt=10 (last PK from page 1)
+        page2 = _make_api_response(
+            [
+                _make_remote_assignment("user", "u3", "Role1", pk=15),
+                _make_remote_assignment("user", "u4", "Role1", pk=20),
+            ],
+            has_next=True,
+        )
+        page3 = _make_api_response(
+            [
+                _make_remote_assignment("user", "u5", "Role1", pk=25),
+            ],
+        )
+        empty = _make_api_response([])
+
+        cmd = self._make_cmd()
+        cursor = CursorStore("test-svc-deletion", "user")
+
+        captured_id_gts = []
+        pages = iter([page1, page2, page3, empty])
+
+        def capture_filters(**kwargs):
+            captured_id_gts.append(kwargs["filters"]["id__gt"])
+            return next(pages)
+
+        list_fn = Mock(side_effect=capture_filters)
+
+        with patch.object(cmd, "_bulk_resolve_and_create_page", return_value=(1, set())):
+            created, obj_roles = cmd._paginate_and_create(list_fn, "user", [], cursor)
+
+        assert list_fn.call_count == 4
+        assert created == 3  # 1 per page from mock
+
+        # Verify sliding window: page1 id__gt=0, page2 id__gt=10, page3 id__gt=20
+        assert captured_id_gts[0] == "0"
+        assert captured_id_gts[1] == "10"
+        assert captured_id_gts[2] == "20"
+
+        new_cursor = CursorStore("test-svc-deletion", "user")
+        assert new_cursor.last_pk == 25
 
 
 # =============================================================================
@@ -264,10 +325,7 @@ class TestMigrateRoleAssignments:
         """Both user and team assignment types are processed with separate cursors."""
         cmd = self._make_cmd()
 
-        with (
-            patch.object(cmd, "_paginate_and_create", return_value=3) as mock_paginate,
-            patch.object(cmd, "_check_for_drift", return_value=False),
-        ):
+        with patch.object(cmd, "_paginate_and_create", return_value=(3, set())) as mock_paginate:
             cmd.migrate_role_assignments("controller", "controller")
 
         assert mock_paginate.call_count == 2
@@ -278,10 +336,7 @@ class TestMigrateRoleAssignments:
         """Each service gets its own cursor records in the DB."""
         cmd = self._make_cmd()
 
-        with (
-            patch.object(cmd, "_paginate_and_create", return_value=0),
-            patch.object(cmd, "_check_for_drift", return_value=False),
-        ):
+        with patch.object(cmd, "_paginate_and_create", return_value=(0, set())):
             cmd.migrate_role_assignments("controller", "controller")
 
         user_cursor = CursorStore("controller", "user")
@@ -297,314 +352,291 @@ class TestMigrateRoleAssignments:
             with pytest.raises(RuntimeError, match="HTTP 500"):
                 cmd.migrate_role_assignments("controller", "controller")
 
-    def test_drift_detected_raises_runtime_error(self):
-        """When post-run drift check detects new assignments, RuntimeError is raised."""
-        cmd = self._make_cmd()
-
-        with (
-            patch.object(cmd, "_paginate_and_create", return_value=5),
-            patch.object(cmd, "_check_for_drift", return_value=True),
-        ):
-            with pytest.raises(RuntimeError, match="concurrent modifications were detected"):
-                cmd.migrate_role_assignments("controller", "controller")
-
     def test_no_drift_completes_normally(self):
-        """When post-run drift check finds no new items, method completes without raising."""
+        """When migration completes successfully, completion message is logged."""
         cmd = self._make_cmd()
 
-        with (
-            patch.object(cmd, "_paginate_and_create", return_value=5),
-            patch.object(cmd, "_check_for_drift", return_value=False),
-        ):
+        with patch.object(cmd, "_paginate_and_create", return_value=(5, set())):
             cmd.migrate_role_assignments("controller", "controller")
 
         cmd.stdout.write.assert_any_call("Role assignment migration for controller completed (10 total created)")
 
-    def test_check_for_drift_queries_beyond_cursor(self):
-        """_check_for_drift loads a fresh cursor from DB and asks the API."""
+    def test_rbac_cache_rebuilt_when_object_roles_exist(self):
+        """RBAC cache is rebuilt when object roles are returned from pagination."""
+        cmd = self._make_cmd()
+        mock_or = Mock()
+
+        with (
+            patch.object(cmd, "_paginate_and_create", return_value=(5, {mock_or})),
+            patch("aap_gateway_api.management.commands._migrate_service_data.role_assignments.compute_team_member_roles") as mock_team,
+            patch("aap_gateway_api.management.commands._migrate_service_data.role_assignments.compute_object_role_permissions") as mock_perms,
+        ):
+            cmd.migrate_role_assignments("controller", "controller")
+
+        mock_team.assert_called_once()
+        mock_perms.assert_called_once()
+        # The set should be the union from both user and team calls
+        call_kwargs = mock_perms.call_args[1]
+        assert mock_or in call_kwargs["object_roles"]
+
+    def test_rbac_cache_skipped_when_no_object_roles(self):
+        """RBAC cache rebuild is skipped when no object roles are returned."""
         cmd = self._make_cmd()
 
-        seed = CursorStore("drift-check-svc", "user")
-        seed.advance(100)
+        with (
+            patch.object(cmd, "_paginate_and_create", return_value=(0, set())),
+            patch("aap_gateway_api.management.commands._migrate_service_data.role_assignments.compute_team_member_roles") as mock_team,
+            patch("aap_gateway_api.management.commands._migrate_service_data.role_assignments.compute_object_role_permissions") as mock_perms,
+        ):
+            cmd.migrate_role_assignments("controller", "controller")
 
-        drift_resp = Mock()
-        drift_resp.status_code = 200
-        drift_resp.json.return_value = {"count": 3}
-        list_fn = Mock(return_value=drift_resp)
+        mock_team.assert_not_called()
+        mock_perms.assert_not_called()
 
-        assert cmd._check_for_drift(list_fn, "user", "drift-check-svc") is True
-        call_filters = list_fn.call_args[1]["filters"]
-        assert call_filters["id__gt"] == "100"
-        assert call_filters["page_size"] == "1"
+    def test_rbac_cache_rebuilt_even_on_exception(self):
+        """RBAC cache is rebuilt in finally block even when an exception occurs."""
+        cmd = self._make_cmd()
+        mock_or = Mock()
 
-    def test_check_for_drift_returns_false_when_no_new_items(self):
-        """_check_for_drift returns False when the API returns count=0."""
+        with (
+            patch.object(
+                cmd,
+                "_paginate_and_create",
+                side_effect=[(1, {mock_or}), RuntimeError("HTTP 500")],
+            ),
+            patch("aap_gateway_api.management.commands._migrate_service_data.role_assignments.compute_team_member_roles") as mock_team,
+            patch("aap_gateway_api.management.commands._migrate_service_data.role_assignments.compute_object_role_permissions") as mock_perms,
+        ):
+            with pytest.raises(RuntimeError, match="HTTP 500"):
+                cmd.migrate_role_assignments("controller", "controller")
+
+        mock_team.assert_called_once()
+        mock_perms.assert_called_once()
+
+    def test_cursor_store_receives_log_fn(self):
+        """CursorStore is instantiated with log_fn=cmd._log."""
         cmd = self._make_cmd()
 
-        seed = CursorStore("drift-empty-svc", "user")
-        seed.advance(50)
+        with (
+            patch.object(cmd, "_paginate_and_create", return_value=(0, set())),
+            patch("aap_gateway_api.management.commands._migrate_service_data.role_assignments.CursorStore") as mock_cursor_cls,
+        ):
+            mock_cursor_cls.return_value = Mock(last_pk=0)
+            cmd.migrate_role_assignments("controller", "controller")
 
-        no_drift_resp = Mock()
-        no_drift_resp.status_code = 200
-        no_drift_resp.json.return_value = {"count": 0}
-        list_fn = Mock(return_value=no_drift_resp)
-
-        assert cmd._check_for_drift(list_fn, "user", "drift-empty-svc") is False
-
-    def test_check_for_drift_skips_when_cursor_is_zero(self):
-        """_check_for_drift skips the API call when cursor is at 0."""
-        cmd = self._make_cmd()
-        list_fn = Mock()
-
-        assert cmd._check_for_drift(list_fn, "user", "drift-zero-svc") is False
-        list_fn.assert_not_called()
-
-    def test_check_for_drift_returns_false_on_api_error(self):
-        """If the drift check API call fails, assume no drift and continue."""
-        cmd = self._make_cmd()
-
-        seed = CursorStore("drift-err-svc", "user")
-        seed.advance(50)
-
-        list_fn = Mock(side_effect=RuntimeError("connection refused"))
-
-        assert cmd._check_for_drift(list_fn, "user", "drift-err-svc") is False
+        for call_obj in mock_cursor_cls.call_args_list:
+            assert call_obj[1]["log_fn"] == cmd._log
 
 
 # =============================================================================
-# TestCreateAssignment
+# TestBulkResolveAndCreatePage
 # =============================================================================
 
 
 @pytest.mark.django_db
-class TestCreateAssignment:
-    def test_missing_actor_returns_false_silently(self):
+class TestBulkResolveAndCreatePage:
+    def _make_cmd(self):
         cmd = MigrateCommand()
+        cmd.client = Mock()
+        cmd.stdout = Mock()
         cmd.stderr = Mock()
-        assignment = {"role_definition": "Some Role", "user_ansible_id": None}
-        assert cmd._create_assignment(assignment, "user") is False
-        cmd.stderr.write.assert_not_called()
+        return cmd
 
-    def test_missing_role_returns_false_silently(self):
-        cmd = MigrateCommand()
-        cmd.stderr = Mock()
-        assignment = {"user_ansible_id": "user-uuid-1", "role_definition": None}
-        assert cmd._create_assignment(assignment, "user") is False
-        cmd.stderr.write.assert_not_called()
+    def test_empty_results_returns_zero(self):
+        """Empty results list returns (0, set())."""
+        cmd = self._make_cmd()
+        created, obj_roles = cmd._bulk_resolve_and_create_page([], "user")
+        assert created == 0
+        assert obj_roles == set()
 
-    def test_missing_role_definition_returns_false(self):
-        cmd = MigrateCommand()
-        cmd.stderr = Mock()
-        assignment = _make_remote_assignment("user", "user-uuid", "NonexistentRole")
-        assert cmd._create_assignment(assignment, "user") is False
+    def test_missing_actor_id_skipped(self):
+        """Assignment with user_ansible_id=None is skipped."""
+        cmd = self._make_cmd()
+        results = [_make_remote_assignment("user", None, "SomeRole", pk=1)]
+        created, obj_roles = cmd._bulk_resolve_and_create_page(results, "user")
+        assert created == 0
+        assert obj_roles == set()
+
+    def test_missing_role_name_skipped(self):
+        """Assignment with role_definition=None is skipped."""
+        cmd = self._make_cmd()
+        results = [_make_remote_assignment("user", str(uuid.uuid4()), None, pk=1)]
+        created, obj_roles = cmd._bulk_resolve_and_create_page(results, "user")
+        assert created == 0
+        assert obj_roles == set()
+
+    def test_unknown_role_definition_warns(self):
+        """Non-existent role definition produces a warning."""
+        cmd = self._make_cmd()
+        results = [_make_remote_assignment("user", str(uuid.uuid4()), "NonexistentRoleXYZ", pk=1)]
+        created, obj_roles = cmd._bulk_resolve_and_create_page(results, "user")
+        assert created == 0
         msg = cmd.stderr.write.call_args[0][0]
-        assert "Unable to find role definition 'NonexistentRole'" in msg
-        assert "actor user-uuid" in msg
+        assert "Unable to find role definition 'NonexistentRoleXYZ'" in msg
 
-    def test_missing_actor_resource_returns_false(self):
-        cmd = MigrateCommand()
-        cmd.stderr = Mock()
-        RoleDefinition.objects.get_or_create(name="Test Role Create", defaults={"managed": False})
-        fake_id = str(uuid.uuid4())
-        assignment = _make_remote_assignment("user", fake_id, "Test Role Create")
-        assert cmd._create_assignment(assignment, "user") is False
+    def test_missing_actor_resource_warns(self):
+        """Valid role but fake actor UUID produces a warning."""
+
+        cmd = self._make_cmd()
+        RoleDefinition.objects.get_or_create(name="Test Bulk Actor Role", defaults={"managed": False})
+        fake_actor_id = str(uuid.uuid4())
+        results = [_make_remote_assignment("user", fake_actor_id, "Test Bulk Actor Role", pk=1)]
+        created, obj_roles = cmd._bulk_resolve_and_create_page(results, "user")
+        assert created == 0
         msg = cmd.stderr.write.call_args[0][0]
-        assert f"Unable to find user with ansible_id {fake_id}" in msg
-        assert "role 'Test Role Create'" in msg
+        assert f"Unable to find user with ansible_id {fake_actor_id}" in msg
+
+    def test_missing_object_resource_warns(self):
+        """Valid actor but fake object UUID produces a warning."""
+        from aap_gateway_api.models import User
+
+        user = User.objects.create(username="bulk-obj-missing-user")
+        rd, _ = RoleDefinition.objects.get_or_create(name="Test Bulk Obj Role", defaults={"managed": False})
+        fake_obj_id = str(uuid.uuid4())
+        cmd = self._make_cmd()
+        results = [
+            _make_remote_assignment(
+                "user",
+                str(user.resource.ansible_id),
+                "Test Bulk Obj Role",
+                pk=1,
+                object_ansible_id=fake_obj_id,
+            )
+        ]
+        created, obj_roles = cmd._bulk_resolve_and_create_page(results, "user")
+        assert created == 0
+        msg = cmd.stderr.write.call_args[0][0]
+        assert f"Unable to find object with ansible_id {fake_obj_id}" in msg
 
     def test_global_assignment_created(self):
+        """Global assignment (no object_ansible_id/object_id) creates successfully."""
         from aap_gateway_api.models import User
 
-        user = User.objects.create(username="global-perm-user")
-        RoleDefinition.objects.get_or_create(name="Test Global Role", defaults={"managed": False})
+        user = User.objects.create(username="bulk-global-user")
+        RoleDefinition.objects.get_or_create(name="Test Bulk Global Role", defaults={"managed": False})
 
-        cmd = MigrateCommand()
-        cmd.stderr = Mock()
-        assignment = _make_remote_assignment("user", str(user.resource.ansible_id), "Test Global Role")
-        assert cmd._create_assignment(assignment, "user") is True
+        cmd = self._make_cmd()
+        results = [
+            _make_remote_assignment(
+                "user",
+                str(user.resource.ansible_id),
+                "Test Bulk Global Role",
+                pk=1,
+            )
+        ]
+        created, obj_roles = cmd._bulk_resolve_and_create_page(results, "user")
+        assert created == 1
+        assert obj_roles == set()
 
-    def test_org_assignment_created(self):
+    def test_object_assignment_created(self):
+        """Object-scoped assignment creates successfully with non-empty object roles set."""
         from ansible_base.rbac.models import DABContentType
 
         from aap_gateway_api.models import Organization, User
 
-        user = User.objects.create(username="org-perm-user")
-        org = Organization.objects.create(name="test-perm-org")
+        user = User.objects.create(username="bulk-obj-user")
+        org = Organization.objects.create(name="bulk-obj-org")
         ct = DABContentType.objects.get_for_model(org)
-        RoleDefinition.objects.get_or_create(name="Test Org Role", defaults={"managed": False, "content_type": ct})
-
-        cmd = MigrateCommand()
-        cmd.stderr = Mock()
-        assignment = _make_remote_assignment(
-            "user",
-            str(user.resource.ansible_id),
-            "Test Org Role",
-            content_type="shared.organization",
-            object_ansible_id=str(org.resource.ansible_id),
+        RoleDefinition.objects.get_or_create(
+            name="Test Bulk Obj Assign Role",
+            defaults={"managed": False, "content_type": ct},
         )
-        assert cmd._create_assignment(assignment, "user") is True
 
-    def test_team_assignment_created(self):
-        from ansible_base.rbac.models import DABContentType
+        cmd = self._make_cmd()
+        results = [
+            _make_remote_assignment(
+                "user",
+                str(user.resource.ansible_id),
+                "Test Bulk Obj Assign Role",
+                pk=1,
+                content_type="shared.organization",
+                object_ansible_id=str(org.resource.ansible_id),
+            )
+        ]
+        created, obj_roles = cmd._bulk_resolve_and_create_page(results, "user")
+        assert created == 1
+        assert len(obj_roles) > 0
 
-        from aap_gateway_api.models import Organization, Team, User
-
-        user = User.objects.create(username="team-perm-user")
-        org = Organization.objects.create(name="test-team-perm-org")
-        team = Team.objects.create(name="test-perm-team", organization=org)
-        ct = DABContentType.objects.get_for_model(team)
-        RoleDefinition.objects.get_or_create(name="Test Team Role", defaults={"managed": False, "content_type": ct})
-
-        cmd = MigrateCommand()
-        cmd.stderr = Mock()
-        assignment = _make_remote_assignment(
-            "user",
-            str(user.resource.ansible_id),
-            "Test Team Role",
-            content_type="shared.team",
-            object_ansible_id=str(team.resource.ansible_id),
-        )
-        assert cmd._create_assignment(assignment, "user") is True
-
-    def test_team_actor_global_assignment_created(self):
+    def test_team_assignment_type(self):
+        """Team assignment type uses RoleTeamAssignment model."""
         from aap_gateway_api.models import Organization, Team
 
-        org = Organization.objects.create(name="team-actor-org")
-        team = Team.objects.create(name="team-actor-team", organization=org)
-        RoleDefinition.objects.get_or_create(name="Test Team Actor Role", defaults={"managed": False})
+        org = Organization.objects.create(name="bulk-team-org")
+        team = Team.objects.create(name="bulk-team-actor", organization=org)
+        RoleDefinition.objects.get_or_create(name="Test Bulk Team Role", defaults={"managed": False})
 
-        cmd = MigrateCommand()
-        cmd.stderr = Mock()
-        assignment = _make_remote_assignment("team", str(team.resource.ansible_id), "Test Team Actor Role")
-        assert cmd._create_assignment(assignment, "team") is True
-
-    def test_remote_object_assignment_created(self):
-        from ansible_base.rbac.models import DABContentType
-
-        from aap_gateway_api.models import User
-
-        user = User.objects.create(username="remote-perm-user")
-        ct = DABContentType.objects.create(service="controller", model="inventory")
-        RoleDefinition.objects.get_or_create(name="Test Remote Role", defaults={"managed": False, "content_type": ct})
-
-        cmd = MigrateCommand()
-        cmd.stderr = Mock()
-        assignment = _make_remote_assignment(
-            "user",
-            str(user.resource.ansible_id),
-            "Test Remote Role",
-            content_type="controller.inventory",
-            object_id="12345",
-        )
-        assert cmd._create_assignment(assignment, "user") is True
-
-    def test_content_object_not_found_returns_false(self):
-        from ansible_base.rbac.models import DABContentType
-
-        from aap_gateway_api.models import Organization, User
-
-        user = User.objects.create(username="obj-notfound-user")
-        org = Organization.objects.create(name="obj-notfound-org")
-        ct = DABContentType.objects.get_for_model(org)
-        RoleDefinition.objects.get_or_create(
-            name="Test ObjNotFound Role",
-            defaults={"managed": False, "content_type": ct},
-        )
-
-        fake_obj_id = str(uuid.uuid4())
-        cmd = MigrateCommand()
-        cmd.stderr = Mock()
-        assignment = _make_remote_assignment(
-            "user",
-            str(user.resource.ansible_id),
-            "Test ObjNotFound Role",
-            content_type="shared.organization",
-            object_ansible_id=fake_obj_id,
-        )
-        assert cmd._create_assignment(assignment, "user") is False
-        msg = cmd.stderr.write.call_args[0][0]
-        assert f"Unable to find content object with ansible_id {fake_obj_id}" in msg
-        assert "role 'Test ObjNotFound Role'" in msg
-
-    def test_give_permission_failure_includes_all_identifiers(self):
-        from aap_gateway_api.models import User
-
-        user = User.objects.create(username="fail-perm-user")
-        rd, _ = RoleDefinition.objects.get_or_create(name="Test Fail Role", defaults={"managed": False})
-
-        cmd = MigrateCommand()
-        cmd.stderr = Mock()
-        actor_id = str(user.resource.ansible_id)
-        assignment = _make_remote_assignment("user", actor_id, "Test Fail Role")
-
-        with patch.object(rd, "give_global_permission", side_effect=RuntimeError("DB constraint")):
-            with patch.object(RoleDefinition.objects, "get", return_value=rd):
-                result = cmd._create_assignment(assignment, "user")
-
-        assert result is False
-        cmd.stderr.write.assert_called_once()
-        msg = cmd.stderr.write.call_args[0][0]
-        assert "Unable to give permission for user assignment" in msg
-        assert f"actor={actor_id}" in msg
-        assert "role='Test Fail Role'" in msg
-
-    def test_stale_actor_content_object_returns_false(self):
-        from aap_gateway_api.models import User
-
-        user = User.objects.create(username="stale-actor-user")
-        actor_ansible_id = str(user.resource.ansible_id)
-        RoleDefinition.objects.get_or_create(name="Test Stale Actor Role", defaults={"managed": False})
-        cmd = MigrateCommand()
-        cmd.stdout = Mock()
-        cmd.stderr = Mock()
-
-        with patch.object(Resource.objects, "get") as mock_get:
-            mock_resource = Mock()
-            mock_resource.content_object = None
-            mock_get.return_value = mock_resource
-            result = cmd._create_assignment(
-                {
-                    "user_ansible_id": actor_ansible_id,
-                    "role_definition": "Test Stale Actor Role",
-                    "content_type": "",
-                    "object_id": None,
-                },
-                "user",
+        cmd = self._make_cmd()
+        results = [
+            _make_remote_assignment(
+                "team",
+                str(team.resource.ansible_id),
+                "Test Bulk Team Role",
+                pk=1,
             )
+        ]
+        created, obj_roles = cmd._bulk_resolve_and_create_page(results, "team")
+        assert created == 1
+        assert RoleTeamAssignment.objects.filter(team=team, role_definition__name="Test Bulk Team Role").exists()
 
-        assert result is False
-
-    def test_stale_org_content_object_returns_false(self):
+    def test_mixed_global_and_object(self):
+        """Mix of global and object-scoped assignments returns correct totals."""
         from ansible_base.rbac.models import DABContentType
 
         from aap_gateway_api.models import Organization, User
 
-        user = User.objects.create(username="stale-obj-user")
-        org = Organization.objects.create(name="stale-obj-org")
+        user = User.objects.create(username="bulk-mixed-user")
+        org = Organization.objects.create(name="bulk-mixed-org")
         ct = DABContentType.objects.get_for_model(org)
+        RoleDefinition.objects.get_or_create(name="Test Bulk Mixed Global", defaults={"managed": False})
         RoleDefinition.objects.get_or_create(
-            name="Test Stale Obj Role",
+            name="Test Bulk Mixed Obj",
             defaults={"managed": False, "content_type": ct},
         )
 
-        cmd = MigrateCommand()
-        cmd.stdout = Mock()
-        cmd.stderr = Mock()
-        obj_ansible_id = str(org.resource.ansible_id)
+        cmd = self._make_cmd()
+        results = [
+            _make_remote_assignment(
+                "user",
+                str(user.resource.ansible_id),
+                "Test Bulk Mixed Global",
+                pk=1,
+            ),
+            _make_remote_assignment(
+                "user",
+                str(user.resource.ansible_id),
+                "Test Bulk Mixed Obj",
+                pk=2,
+                content_type="shared.organization",
+                object_ansible_id=str(org.resource.ansible_id),
+            ),
+        ]
+        created, obj_roles = cmd._bulk_resolve_and_create_page(results, "user")
+        assert created == 2
+        assert len(obj_roles) > 0
 
-        org.delete()
-        result = cmd._create_assignment(
-            {
-                "user_ansible_id": str(user.resource.ansible_id),
-                "role_definition": "Test Stale Obj Role",
-                "content_type": "shared.organization",
-                "object_ansible_id": obj_ansible_id,
-                "object_id": None,
-            },
-            "user",
-        )
+    def test_idempotent_via_ignore_conflicts(self):
+        """Calling twice with the same data does not raise an error."""
+        from aap_gateway_api.models import User
 
-        assert result is False
+        user = User.objects.create(username="bulk-idempotent-user")
+        RoleDefinition.objects.get_or_create(name="Test Bulk Idempotent Role", defaults={"managed": False})
+
+        cmd = self._make_cmd()
+        results = [
+            _make_remote_assignment(
+                "user",
+                str(user.resource.ansible_id),
+                "Test Bulk Idempotent Role",
+                pk=1,
+            )
+        ]
+        created1, _ = cmd._bulk_resolve_and_create_page(results, "user")
+        assert created1 == 1
+
+        # Second call should not raise
+        created2, _ = cmd._bulk_resolve_and_create_page(results, "user")
+        # bulk_create with ignore_conflicts may return 0 on second call
+        assert created2 >= 0
 
 
 # =============================================================================
@@ -978,4 +1010,4 @@ def test_role_assignment_migration_skips_object_not_found(admin_user, capsys, se
         assert RoleUserAssignment.objects.count() == 0
 
         captured = capsys.readouterr()
-        assert f"Unable to find content object with ansible_id {invalid_object_ansible_id}" in captured.err
+        assert f"Unable to find object with ansible_id {invalid_object_ansible_id}" in captured.err

--- a/aap_gateway_api/tests/management/commands/_migrate_service_data/test_role_assignments.py
+++ b/aap_gateway_api/tests/management/commands/_migrate_service_data/test_role_assignments.py
@@ -202,8 +202,8 @@ class TestPaginateAndCreate:
         new_cursor = CursorStore("test-svc-mid", "user")
         assert new_cursor.last_pk == 10
 
-    def test_missing_pk_stops_pagination(self):
-        """If the API returns an assignment without an 'id' field, pagination stops gracefully."""
+    def test_missing_pk_raises_runtime_error(self):
+        """If the API returns an assignment without an 'id' field, RuntimeError is raised."""
         resp = _make_api_response([{"user_ansible_id": "u1", "role_definition": "Role1"}])
 
         cmd = self._make_cmd()
@@ -211,10 +211,8 @@ class TestPaginateAndCreate:
         list_fn = Mock(return_value=resp)
 
         with patch.object(cmd, "_bulk_resolve_and_create_page", return_value=(1, set())):
-            created, obj_roles = cmd._paginate_and_create(list_fn, "user", [], cursor)
-
-        assert created == 1
-        assert obj_roles == set()
+            with pytest.raises(RuntimeError, match="without 'id' field"):
+                cmd._paginate_and_create(list_fn, "user", [], cursor)
 
     def test_role_exclusion_filter_applied(self):
         """Role exclusion filter is passed to the API when non-empty."""
@@ -410,7 +408,8 @@ class TestMigrateRoleAssignments:
         mock_perms.assert_not_called()
 
     def test_rbac_cache_rebuilt_even_on_exception(self):
-        """RBAC cache is rebuilt in finally block even when an exception occurs."""
+        """RBAC cache is rebuilt in finally block even when an exception occurs.
+        When the cache rebuild itself fails, the original exception still propagates."""
         cmd = self._make_cmd()
         mock_or = Mock()
 
@@ -428,6 +427,25 @@ class TestMigrateRoleAssignments:
 
         mock_team.assert_called_once()
         mock_perms.assert_called_once()
+
+    def test_rbac_cache_failure_does_not_mask_original_exception(self):
+        """When cache rebuild fails, the original exception propagates (not the cache error)."""
+        cmd = self._make_cmd()
+        mock_or = Mock()
+
+        with (
+            patch.object(
+                cmd,
+                "_paginate_and_create",
+                side_effect=[(1, {mock_or}), RuntimeError("HTTP 500")],
+            ),
+            patch(
+                "aap_gateway_api.management.commands._migrate_service_data.role_assignments.compute_team_member_roles",
+                side_effect=RuntimeError("cache rebuild exploded"),
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="HTTP 500"):
+                cmd.migrate_role_assignments("controller", "controller")
 
     def test_cursor_store_receives_log_fn(self):
         """CursorStore is instantiated with log_fn=cmd._log."""
@@ -526,7 +544,8 @@ class TestBulkResolveAndCreatePage:
         assert f"Unable to find object with ansible_id {fake_obj_id}" in msg
 
     def test_global_assignment_created(self):
-        """Global assignment (no object_ansible_id/object_id) creates successfully."""
+        """Global assignment (no object_ansible_id/object_id) creates successfully
+        and is idempotent — calling twice does not duplicate."""
         from aap_gateway_api.models import User
 
         user = User.objects.create(username="bulk-global-user")
@@ -544,6 +563,11 @@ class TestBulkResolveAndCreatePage:
         created, obj_roles = cmd._bulk_resolve_and_create_page(results, "user")
         assert created == 1
         assert obj_roles == set()
+
+        # Second call should be idempotent — no new rows created
+        created2, _ = cmd._bulk_resolve_and_create_page(results, "user")
+        assert created2 == 0
+        assert RoleUserAssignment.objects.filter(user=user, role_definition__name="Test Bulk Global Role", object_role__isnull=True).count() == 1
 
     def test_object_assignment_created(self):
         """Object-scoped assignment creates successfully with non-empty object roles set."""

--- a/aap_gateway_api/tests/management/commands/_migrate_service_data/test_role_assignments.py
+++ b/aap_gateway_api/tests/management/commands/_migrate_service_data/test_role_assignments.py
@@ -640,6 +640,125 @@ class TestBulkResolveAndCreatePage:
 
 
 # =============================================================================
+# TestCollectUniqueIds
+# =============================================================================
+
+
+class TestCollectUniqueIds:
+    def test_extracts_all_fields(self):
+        results = [
+            {"user_ansible_id": "u1", "role_definition": "Role A", "object_ansible_id": "obj1"},
+            {"user_ansible_id": "u2", "role_definition": "Role B", "object_ansible_id": "obj2"},
+            {"user_ansible_id": "u1", "role_definition": "Role A", "object_ansible_id": None},
+        ]
+        role_names, actor_ids, object_ids = MigrateCommand._collect_unique_ids(results, "user_ansible_id")
+        assert role_names == {"Role A", "Role B"}
+        assert actor_ids == {"u1", "u2"}
+        assert object_ids == {"obj1", "obj2"}
+
+    def test_empty_results(self):
+        role_names, actor_ids, object_ids = MigrateCommand._collect_unique_ids([], "user_ansible_id")
+        assert role_names == set()
+        assert actor_ids == set()
+        assert object_ids == set()
+
+    def test_skips_none_values(self):
+        results = [
+            {"user_ansible_id": None, "role_definition": None, "object_ansible_id": None},
+        ]
+        role_names, actor_ids, object_ids = MigrateCommand._collect_unique_ids(results, "user_ansible_id")
+        assert role_names == set()
+        assert actor_ids == set()
+        assert object_ids == set()
+
+    def test_team_actor_field(self):
+        results = [
+            {"team_ansible_id": "t1", "role_definition": "Role A", "object_ansible_id": None},
+        ]
+        role_names, actor_ids, object_ids = MigrateCommand._collect_unique_ids(results, "team_ansible_id")
+        assert actor_ids == {"t1"}
+
+
+# =============================================================================
+# TestResolveSingleAssignment
+# =============================================================================
+
+
+@pytest.mark.django_db
+class TestResolveSingleAssignment:
+    def _make_cmd(self):
+        cmd = MigrateCommand()
+        cmd.stdout = Mock()
+        cmd.stderr = Mock()
+        return cmd
+
+    def test_missing_actor_returns_none(self):
+        cmd = self._make_cmd()
+        item = {"user_ansible_id": None, "role_definition": "Some Role"}
+        result = cmd._resolve_single_assignment(item, "user_ansible_id", "user", {}, {}, {})
+        assert result is None
+
+    def test_missing_role_returns_none(self):
+        cmd = self._make_cmd()
+        item = {"user_ansible_id": "u1", "role_definition": None}
+        result = cmd._resolve_single_assignment(item, "user_ansible_id", "user", {}, {}, {})
+        assert result is None
+
+    def test_unknown_role_returns_none_and_warns(self):
+        cmd = self._make_cmd()
+        item = {"user_ansible_id": "u1", "role_definition": "FakeRole"}
+        result = cmd._resolve_single_assignment(item, "user_ansible_id", "user", {}, {}, {})
+        assert result is None
+        cmd.stderr.write.assert_called_once()
+        assert "Unable to find role definition 'FakeRole'" in cmd.stderr.write.call_args[0][0]
+
+    def test_unknown_actor_returns_none_and_warns(self):
+        cmd = self._make_cmd()
+        rd = Mock()
+        item = {"user_ansible_id": "u-missing", "role_definition": "TestRole"}
+        result = cmd._resolve_single_assignment(item, "user_ansible_id", "user", {"TestRole": rd}, {}, {})
+        assert result is None
+        assert "Unable to find user with ansible_id u-missing" in cmd.stderr.write.call_args[0][0]
+
+    def test_global_assignment_classified(self):
+        cmd = self._make_cmd()
+        rd = Mock(content_type_id=None)
+        actor_resource = Mock(object_id=42)
+        item = {"user_ansible_id": "u1", "role_definition": "TestRole", "object_ansible_id": None, "object_id": None}
+        result = cmd._resolve_single_assignment(item, "user_ansible_id", "user", {"TestRole": rd}, {"u1": actor_resource}, {})
+        assert result[0] == "global"
+        assert result[1][0] == 42
+
+    def test_object_assignment_by_ansible_id(self):
+        cmd = self._make_cmd()
+        rd = Mock(content_type_id=5)
+        actor_resource = Mock(object_id=42)
+        obj_resource = Mock(object_id=99)
+        item = {"user_ansible_id": "u1", "role_definition": "TestRole", "object_ansible_id": "obj1", "object_id": None}
+        result = cmd._resolve_single_assignment(item, "user_ansible_id", "user", {"TestRole": rd}, {"u1": actor_resource}, {"obj1": obj_resource})
+        assert result[0] == "object"
+        assert result[1][3] == str(99)
+
+    def test_object_assignment_by_object_id(self):
+        cmd = self._make_cmd()
+        rd = Mock(content_type_id=5)
+        actor_resource = Mock(object_id=42)
+        item = {"user_ansible_id": "u1", "role_definition": "TestRole", "object_ansible_id": None, "object_id": "777"}
+        result = cmd._resolve_single_assignment(item, "user_ansible_id", "user", {"TestRole": rd}, {"u1": actor_resource}, {})
+        assert result[0] == "object"
+        assert result[1][3] == "777"
+
+    def test_missing_object_resource_returns_none_and_warns(self):
+        cmd = self._make_cmd()
+        rd = Mock(content_type_id=5)
+        actor_resource = Mock(object_id=42)
+        item = {"user_ansible_id": "u1", "role_definition": "TestRole", "object_ansible_id": "missing-obj", "object_id": None}
+        result = cmd._resolve_single_assignment(item, "user_ansible_id", "user", {"TestRole": rd}, {"u1": actor_resource}, {})
+        assert result is None
+        assert "Unable to find object with ansible_id missing-obj" in cmd.stderr.write.call_args[0][0]
+
+
+# =============================================================================
 # TestRaiseFetchError
 # =============================================================================
 

--- a/aap_gateway_api/tests/management/commands/_migrate_service_data/test_role_assignments_perf.py
+++ b/aap_gateway_api/tests/management/commands/_migrate_service_data/test_role_assignments_perf.py
@@ -1,0 +1,212 @@
+"""Performance and scaling tests for RoleAssignmentsMixin.
+
+These tests verify that the bulk migration code scales correctly:
+- Query count is O(pages), not O(items)
+- Memory stays bounded by page size, not total record count
+"""
+
+import tracemalloc
+from unittest.mock import Mock
+
+import pytest
+from ansible_base.rbac.models import RoleDefinition
+
+from aap_gateway_api.management.commands._migrate_service_data.cursor_store import CursorStore
+from aap_gateway_api.management.commands.migrate_service_data import Command as MigrateCommand
+
+
+def _make_remote_assignment(
+    assignment_type,
+    actor_ansible_id,
+    role_name,
+    pk=None,
+    content_type=None,
+    object_ansible_id=None,
+    object_id=None,
+):
+    """Build a dict matching the service API assignment response format."""
+    d = {
+        f"{assignment_type}_ansible_id": actor_ansible_id,
+        "role_definition": role_name,
+        "content_type": content_type or "",
+        "object_ansible_id": object_ansible_id,
+        "object_id": object_id,
+    }
+    if pk is not None:
+        d["id"] = pk
+    return d
+
+
+def _make_cmd():
+    cmd = MigrateCommand()
+    cmd.stdout = Mock()
+    cmd.stderr = Mock()
+    return cmd
+
+
+def _create_test_data(user_count, org_count):
+    """Create users and orgs for scaling tests. Returns (users, orgs, role_definition)."""
+    from django.contrib.auth import get_user_model
+
+    from aap_gateway_api.models import Organization
+
+    User = get_user_model()
+
+    users = [User.objects.create(username=f"perf-user-{i:04d}") for i in range(user_count)]
+    orgs = [Organization.objects.create(name=f"perf-org-{i:04d}") for i in range(org_count)]
+
+    from ansible_base.rbac.models import DABContentType
+
+    org_ct = DABContentType.objects.get_for_model(Organization)
+    rd, _ = RoleDefinition.objects.get_or_create(
+        name="Organization Admin",
+        defaults={"managed": True, "content_type": org_ct},
+    )
+
+    return users, orgs, rd
+
+
+def _build_assignments(users, orgs, count):
+    """Build mock assignment results distributing users across orgs."""
+    results = []
+    for i in range(count):
+        user = users[i % len(users)]
+        org = orgs[i % len(orgs)]
+        results.append(
+            _make_remote_assignment(
+                "user",
+                str(user.resource.ansible_id),
+                "Organization Admin",
+                pk=i + 1,
+                content_type="shared.organization",
+                object_ansible_id=str(org.resource.ansible_id),
+            )
+        )
+    return results
+
+
+# =============================================================================
+# Query count — absolute bound per page
+# =============================================================================
+
+
+@pytest.mark.django_db
+def test_bulk_resolve_query_count_bounded_per_page():
+    """Verify that _bulk_resolve_and_create_page uses a fixed number of DB
+    queries regardless of how many assignments are on the page.
+
+    With 200 assignments, the old per-assignment approach would use 600+
+    queries (3+ per assignment).  The bulk approach should use ~6 queries:
+      1. RoleDefinition lookup
+      2. Resource lookup (actors)
+      3. Resource lookup (objects)
+      4. ObjectRole bulk_create
+      5. ObjectRole fetch
+      6. RoleUserAssignment bulk_create
+    """
+    from django.db import connection
+    from django.test.utils import CaptureQueriesContext
+
+    cmd = _make_cmd()
+    users, orgs, _ = _create_test_data(user_count=200, org_count=10)
+    results = _build_assignments(users, orgs, 200)
+
+    with CaptureQueriesContext(connection) as ctx:
+        created, object_roles = cmd._bulk_resolve_and_create_page(results, "user")
+
+    assert created == 200
+    assert len(object_roles) > 0
+    assert len(ctx.captured_queries) < 20, (
+        f"Expected fewer than 20 queries for 200 assignments, got {len(ctx.captured_queries)}. Queries: {[q['sql'][:80] for q in ctx.captured_queries]}"
+    )
+
+
+# =============================================================================
+# Query count — O(1) per page, not O(items)
+# =============================================================================
+
+
+@pytest.mark.django_db
+def test_query_count_scales_with_pages_not_items():
+    """Doubling items on a page should NOT double queries.
+
+    Runs _bulk_resolve_and_create_page at two scales and asserts the
+    query-count ratio stays near 1.0, proving O(pages) not O(items).
+    """
+    from django.db import connection
+    from django.test.utils import CaptureQueriesContext
+
+    users, orgs, _ = _create_test_data(user_count=400, org_count=20)
+
+    def _count_queries(n_items):
+        cmd = _make_cmd()
+        results = _build_assignments(users, orgs, n_items)
+        with CaptureQueriesContext(connection) as ctx:
+            cmd._bulk_resolve_and_create_page(results, "user")
+        return len(ctx.captured_queries)
+
+    queries_100 = _count_queries(100)
+    queries_400 = _count_queries(400)
+
+    ratio = queries_400 / max(queries_100, 1)
+    assert ratio < 1.5, (
+        f"Query count scaled {ratio:.1f}x for 4x items — expected ~1x (O(1) per page). 100 items: {queries_100} queries, 400 items: {queries_400} queries"
+    )
+
+
+# =============================================================================
+# Memory — bounded by page size, not total record count
+# =============================================================================
+
+
+def _measure_pagination_memory(users, orgs, num_assignments, page_size=50):
+    """Run _paginate_and_create and return peak memory delta in bytes."""
+    cmd = _make_cmd()
+    cmd.BIG_PAGE_FILTERS = {"page_size": str(page_size)}
+
+    all_results = _build_assignments(users, orgs, num_assignments)
+    pages = [all_results[i : i + page_size] for i in range(0, len(all_results), page_size)]
+
+    page_iter = iter(pages)
+
+    def fake_list(filters=None):
+        try:
+            page = next(page_iter)
+        except StopIteration:
+            page = []
+        resp = Mock(status_code=200)
+        resp.json.return_value = {"results": page, "count": num_assignments}
+        return resp
+
+    cursor = CursorStore("perf-test", "user", log_fn=cmd._log)
+
+    tracemalloc.start()
+    snapshot_before = tracemalloc.take_snapshot()
+
+    cmd._paginate_and_create(fake_list, "user", [], cursor)
+
+    snapshot_after = tracemalloc.take_snapshot()
+    tracemalloc.stop()
+
+    stats = snapshot_after.compare_to(snapshot_before, "lineno")
+    return sum(s.size_diff for s in stats if s.size_diff > 0)
+
+
+@pytest.mark.django_db
+def test_pagination_memory_scales_with_page_size_not_total():
+    """Memory during pagination should stay proportional to page size,
+    not grow with total record count.
+
+    Runs at two scales (500 vs 2000 total assignments, same page size)
+    and asserts the memory ratio stays well below the data ratio.
+    A load-everything regression would show ~4x memory growth.
+    """
+    users, orgs, _ = _create_test_data(user_count=500, org_count=20)
+
+    mem_500 = _measure_pagination_memory(users, orgs, num_assignments=500)
+    mem_2000 = _measure_pagination_memory(users, orgs, num_assignments=2000)
+
+    ratio = mem_2000 / max(mem_500, 1)
+    assert ratio < 2.5, (
+        f"Memory scaled {ratio:.1f}x for 4x data — expected ~1x (bounded by page size). 500 items: {mem_500:,} bytes, 2000 items: {mem_2000:,} bytes"
+    )

--- a/aap_gateway_api/tests/management/commands/_migrate_service_data/test_role_assignments_perf.py
+++ b/aap_gateway_api/tests/management/commands/_migrate_service_data/test_role_assignments_perf.py
@@ -41,6 +41,7 @@ def _make_cmd():
     cmd = MigrateCommand()
     cmd.stdout = Mock()
     cmd.stderr = Mock()
+    cmd._progress_thresholds = {}
     return cmd
 
 

--- a/aap_gateway_api/tests/management/commands/_migrate_service_data/test_service_orchestration.py
+++ b/aap_gateway_api/tests/management/commands/_migrate_service_data/test_service_orchestration.py
@@ -269,3 +269,136 @@ def test_migration_uses_bulk_fetch(admin_user, capsys, service_api_route_control
         captured = capsys.readouterr()
         assert "Migration Summary" in captured.out
         assert "Migrating data for" in captured.out
+
+
+@pytest.mark.django_db
+def test_load_types_and_permissions_success(admin_user):
+    """When all services respond 200 with no pagination, returns empty failure list."""
+    cmd = MigrateCommand()
+    cmd._progress_thresholds = {}
+
+    service_api = Mock()
+    service_api.api_slug = "controller"
+
+    mock_client = Mock()
+
+    types_response = Mock()
+    types_response.status_code = 200
+    types_response.json.return_value = {"next": None, "results": []}
+    mock_client.list_role_types.return_value = types_response
+
+    perms_response = Mock()
+    perms_response.status_code = 200
+    perms_response.json.return_value = {"next": None, "results": []}
+    mock_client.list_role_permissions.return_value = perms_response
+
+    with patch(_ORCH_CLIENT, return_value=mock_client):
+        failed = cmd.load_types_and_permissions([service_api], admin_user)
+
+    assert failed == []
+    mock_client.list_role_types.assert_called_once()
+    mock_client.list_role_permissions.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_load_types_and_permissions_partial_failure(admin_user, capsys):
+    """When one service succeeds and another raises, only the failing slug is returned."""
+    cmd = MigrateCommand()
+    cmd._progress_thresholds = {}
+
+    good_service = Mock()
+    good_service.api_slug = "controller"
+
+    bad_service = Mock()
+    bad_service.api_slug = "hub"
+
+    good_client = Mock()
+    types_resp = Mock()
+    types_resp.status_code = 200
+    types_resp.json.return_value = {"next": None, "results": []}
+    good_client.list_role_types.return_value = types_resp
+    perms_resp = Mock()
+    perms_resp.status_code = 200
+    perms_resp.json.return_value = {"next": None, "results": []}
+    good_client.list_role_permissions.return_value = perms_resp
+
+    bad_client = Mock()
+    bad_client.list_role_types.side_effect = RuntimeError("connection refused")
+
+    def client_factory(service_api, **kwargs):
+        if service_api is good_service:
+            return good_client
+        return bad_client
+
+    with patch(_ORCH_CLIENT, side_effect=client_factory):
+        failed = cmd.load_types_and_permissions([good_service, bad_service], admin_user)
+
+    assert "hub" in failed
+    assert "controller" not in failed
+
+    captured = capsys.readouterr()
+    assert "Failed to load types and permissions from hub" in captured.err
+
+
+@pytest.mark.django_db
+def test_load_types_and_permissions_pagination_warning(admin_user, capsys):
+    """When list_role_types returns a non-None next URL, a warning is logged."""
+    cmd = MigrateCommand()
+    cmd._progress_thresholds = {}
+
+    service_api = Mock()
+    service_api.api_slug = "controller"
+
+    mock_client = Mock()
+    types_response = Mock()
+    types_response.status_code = 200
+    types_response.json.return_value = {"next": "http://service/api/v1/role_types/?page=2", "results": []}
+    mock_client.list_role_types.return_value = types_response
+
+    with patch(_ORCH_CLIENT, return_value=mock_client):
+        failed = cmd.load_types_and_permissions([service_api], admin_user)
+
+    assert "controller" in failed
+
+    captured = capsys.readouterr()
+    assert "has extra pages of types" in captured.err
+    assert "Failed to load types and permissions from controller" in captured.err
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "types_status,types_next,perms_status,perms_next,expected_err",
+    [
+        pytest.param(503, None, 200, None, "role types gave 503", id="types_non_200"),
+        pytest.param(200, None, 500, None, "permissions gave 500", id="perms_non_200"),
+        pytest.param(200, None, 200, "http://service/?page=2", "has extra pages of types", id="perms_pagination"),
+    ],
+)
+def test_load_types_and_permissions_error_scenarios(admin_user, capsys, types_status, types_next, perms_status, perms_next, expected_err):
+    """Various error responses from role types/permissions APIs mark the service as failed."""
+    cmd = MigrateCommand()
+    cmd._progress_thresholds = {}
+
+    service_api = Mock()
+    service_api.api_slug = "controller"
+
+    mock_client = Mock()
+
+    types_response = Mock()
+    types_response.status_code = types_status
+    types_response.data = "error"
+    types_response.json.return_value = {"next": types_next, "results": []}
+    mock_client.list_role_types.return_value = types_response
+
+    perms_response = Mock()
+    perms_response.status_code = perms_status
+    perms_response.data = "error"
+    perms_response.json.return_value = {"next": perms_next, "results": []}
+    mock_client.list_role_permissions.return_value = perms_response
+
+    with patch(_ORCH_CLIENT, return_value=mock_client):
+        failed = cmd.load_types_and_permissions([service_api], admin_user)
+
+    assert "controller" in failed
+    captured = capsys.readouterr()
+    assert expected_err in captured.err

--- a/aap_gateway_api/tests/management/commands/_migrate_service_data/test_superuser_sync.py
+++ b/aap_gateway_api/tests/management/commands/_migrate_service_data/test_superuser_sync.py
@@ -101,7 +101,6 @@ def test_multi_service_migration(
     assert f"Processing service: {service_api_route_eda.api_slug}" in captured.out
     assert "Successful migrations: 3" in captured.out
     assert "Failed migrations: 0" in captured.out
-    assert "All services migration completed successfully!" in captured.out
 
     assert "Gateway superusers: ['admin', 'controller_super']" in captured.out
     assert "Controller superusers: ['admin', 'controller_super']" in captured.out

--- a/aap_gateway_api/tests/management/commands/_migrate_service_data/test_user_merge.py
+++ b/aap_gateway_api/tests/management/commands/_migrate_service_data/test_user_merge.py
@@ -3,7 +3,7 @@ merge_partially_migrated_users, merge_user_group.
 """
 
 import uuid
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from ansible_base.resource_registry.models import Resource, service_id
@@ -94,7 +94,6 @@ def test_comprehensive_multi_service_migration(
     assert "Merging partially migrated users" in captured.out
     assert "Successful migrations: 3" in captured.out
     assert "Failed migrations: 0" in captured.out
-    assert "All services migration completed successfully!" in captured.out
 
     # === Test Case 1: controller-only-user ===
     gateway_user_list = User.objects.filter(username__endswith="controller-only-user")
@@ -336,3 +335,78 @@ def test_merge_user_group_successful(capsys):
     assert "Successfully merged hub user" in captured.out
     assert "Migrating main user" in captured.out
     assert "Successfully migrated main user" in captured.out
+
+
+# =============================================================================
+# _correlate_users_across_services tests
+# =============================================================================
+
+
+def test_correlate_users_strips_galaxy_prefix():
+    """The galaxy_ prefix is stripped to produce the base username."""
+    cmd = MigrateCommand()
+    mock_user = MagicMock()
+    all_users = {"hub": [("galaxy_john", mock_user)]}
+
+    result = cmd._correlate_users_across_services(all_users)
+
+    assert "john" in result
+    assert len(result["john"]) == 1
+    service_type, user_obj, original_username = result["john"][0]
+    assert service_type == "hub"
+    assert user_obj is mock_user
+    assert original_username == "galaxy_john"
+
+
+def test_correlate_users_strips_eda_prefix():
+    """The eda_ prefix is stripped to produce the base username."""
+    cmd = MigrateCommand()
+    mock_user = MagicMock()
+    all_users = {"eda": [("eda_john", mock_user)]}
+
+    result = cmd._correlate_users_across_services(all_users)
+
+    assert "john" in result
+    assert len(result["john"]) == 1
+    service_type, user_obj, original_username = result["john"][0]
+    assert service_type == "eda"
+    assert user_obj is mock_user
+    assert original_username == "eda_john"
+
+
+def test_correlate_users_no_prefix_kept_as_is():
+    """A username without a known prefix is kept unchanged."""
+    cmd = MigrateCommand()
+    mock_user = MagicMock()
+    all_users = {"controller": [("john", mock_user)]}
+
+    result = cmd._correlate_users_across_services(all_users)
+
+    assert "john" in result
+    assert len(result["john"]) == 1
+    service_type, user_obj, original_username = result["john"][0]
+    assert service_type == "controller"
+    assert user_obj is mock_user
+    assert original_username == "john"
+
+
+def test_correlate_users_groups_across_services():
+    """Users from different services with the same base name are grouped together."""
+    cmd = MigrateCommand()
+    controller_user = MagicMock()
+    hub_user = MagicMock()
+    eda_user = MagicMock()
+    all_users = {
+        "controller": [("john", controller_user)],
+        "hub": [("galaxy_john", hub_user)],
+        "eda": [("eda_john", eda_user)],
+    }
+
+    result = cmd._correlate_users_across_services(all_users)
+
+    assert "john" in result
+    assert len(result["john"]) == 3
+    # Verify ordering follows SERVICE_TYPE_ORDER: controller, hub, eda
+    assert result["john"][0] == ("controller", controller_user, "john")
+    assert result["john"][1] == ("hub", hub_user, "galaxy_john")
+    assert result["john"][2] == ("eda", eda_user, "eda_john")

--- a/aap_gateway_api/tests/management/commands/test_migrate_service_data.py
+++ b/aap_gateway_api/tests/management/commands/test_migrate_service_data.py
@@ -168,8 +168,6 @@ def test_single_service_migration(admin_user, capsys, service_api_route_controll
         assert f"Processing service: {service_api_route_controller.api_slug}" in captured.out
         assert "Successful migrations: 1" in captured.out
         assert "Failed migrations: 0" in captured.out
-        assert "All services migration completed successfully!" in captured.out
-
         assert "hub" not in captured.out
         assert "eda" not in captured.out
 
@@ -181,3 +179,58 @@ def test_no_services_found_error(admin_user):
         call_command("migrate_service_data", username=admin_user.username)
 
     assert "No services found with expected service types" in str(exc_info.value)
+
+
+def test_report_migration_summary_raises_on_failures():
+    """Test that _report_migration_summary raises CommandError when failed_services is non-empty."""
+    cmd = MigrateCommand()
+    cmd.stdout = Mock()
+    cmd.stderr = Mock()
+
+    with pytest.raises(CommandError) as exc_info:
+        cmd._report_migration_summary(service_apis=[], successful_services=[], failed_services={"my-svc": "some error"})
+
+    assert "my-svc" in str(exc_info.value)
+
+
+def test_report_migration_summary_no_error_on_success():
+    """Test that _report_migration_summary does not raise when all services succeed."""
+    cmd = MigrateCommand()
+    cmd.stdout = Mock()
+    cmd.stderr = Mock()
+
+    # Should not raise
+    cmd._report_migration_summary(service_apis=[], successful_services=["controller"], failed_services={})
+
+    # Verify the summary was written to stdout
+    written_output = " ".join(str(call) for call in cmd.stdout.write.call_args_list)
+    assert "Successful migrations: 1" in written_output
+
+
+@pytest.mark.django_db
+def test_add_arguments_registers_expected_args():
+    """Test that add_arguments registers all expected CLI arguments."""
+    cmd = MigrateCommand()
+    parser = cmd.create_parser("manage.py", "migrate_service_data")
+
+    expected_flags = ["--api-slug", "--username", "--merge-teams", "--merge-organizations", "--log-file", "--rerun"]
+    for flag in expected_flags:
+        assert flag in parser._option_string_actions, f"Expected argument {flag} not found in parser"
+
+    # Verify parsing works with known args
+    args = parser.parse_args(["--username", "admin"])
+    assert args.username == "admin"
+
+
+def test_warn_ignored_flags_partial():
+    """Test that _warn_ignored_flags only warns about the flags that are actually set."""
+    cmd = MigrateCommand()
+    cmd.stderr = Mock()
+
+    cmd._warn_ignored_flags({"api_slug": "controller"})
+
+    assert cmd.stderr.write.call_count == 1
+    warning_text = str(cmd.stderr.write.call_args_list[0])
+    assert "--api-slug" in warning_text
+    assert "--merge-teams" not in warning_text
+    assert "--merge-organizations" not in warning_text

--- a/aap_gateway_api/tests/views/api/v1/docs/test_docs.py
+++ b/aap_gateway_api/tests/views/api/v1/docs/test_docs.py
@@ -134,6 +134,10 @@ class ApiSpecs:
             # TODO fix in DAB and remove this exception
             if '/o/' in endpoint and not endpoint.endswith('o/'):
                 continue
+            # /.well-known/ catch-all returns JSON 404 for unhandled paths,
+            # not an API endpoint
+            if '.well-known' in endpoint:
+                continue
             # control plane endpoints intentionally hidden
             if 'discovery' in endpoint:
                 continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ DJANGO_SETTINGS_MODULE = "aap_gateway_api.tests.settings_overrides"
 addopts = "--strict-markers --reuse-db --create-db --migrations -s -vvv"
 pythonpath = ". aap_gateway_api"
 markers = [
+    "perf: performance and scaling tests (query counts, memory bounds, O-complexity)",
 ]
 
 [tool.tox]


### PR DESCRIPTION
Requires: https://github.com/ansible/django-ansible-base/pull/1047

## Summary

Optimize `migrate_service_data` role assignment migration from O(N*3) queries to O(pages*~10), reducing migration time from hours to minutes for large installations (340k+ assignments).

### Bug Fixes
- **Fix merge flag warnings firing on every run**: `--merge-teams` and `--merge-organizations` defaulted to `True`, so argparse always populated them and the deprecation warning fired even when the user never passed the flag. Changed defaults to `None` and check with `is not None`.
- **Move `delete_legacy_authenticators` out of per-service loop**: This method cleans up gateway-local authenticator records and is idempotent. It was called once per service (3x as no-op) but only needs to run once per invocation.

### New Features
- **Add `--rerun` flag**: Bypasses the `has_migration_completed()` check so operators can re-run the command without manually resetting the migration flag via shell_plus. Useful for testing and benchmarking.

### Performance Optimizations
- **Bulk role assignment creation**: Replace per-assignment DB lookups and `give_permission` calls with batch processing — collect all unique role names, actor IDs, and object IDs from each page and resolve them in 3 bulk queries instead of 3+ per assignment. Bulk-create ObjectRoles and assignments via `bulk_create` with `ignore_conflicts`.
- **Deferred RBAC cache rebuild**: Rebuild `compute_team_member_roles()` and `compute_object_role_permissions()` once at the end (in a `finally` block) instead of per-assignment.
- **id__gt sliding window pagination**: Replace page-number pagination with `id__gt` sliding window. Page-number pagination is unstable when items are deleted mid-run (offsets shift, items get skipped). The sliding window always requests items after the last processed PK, which is stable against deletions and doubles as crash recovery.
- **Replace `get_new_resource_name` loop with single query**: The while loop called `.filter().exists()` per iteration to find a unique name suffix. Replaced with a single query using `order_by/first` to find the highest existing suffix.
- **DB-side service ordering**: Replace Python-side dict reordering with `Case/When` so the DB returns services in the correct order directly.

### Code Cleanup
- **Remove dead `merge_option` code**: The `merge` key was set in `resource_types_to_migrate` and copied into `resource_context` as `merge_option` but never read. Removed the dead keys and consolidated the declaration into the `OrderedDict` constructor.
- **Clean up `_report_migration_summary`**: Move `_ensure_superuser_consistency` and `mark_migration_completed` out of the reporting method into `handle` where they belong. Use `len(service_apis)` consistently instead of recomputing from success + failure counts.

## Dependencies
- Requires PR #151 (code refactor) — merged ✅
- Requires PR #152 (test refactor) — in review

## Test plan
- [ ] Existing test suite passes
- [ ] Benchmark with 100k role assignments shows significant speedup
- [ ] `--rerun` flag bypasses migration-completed check
- [ ] Merge flag warnings only fire when flags are explicitly passed
- [ ] Legacy authenticator cleanup runs once, not per-service

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a safer, resumable service migration run with a `--rerun` option and clearer progress reporting.
  * Migration now processes services in a predictable order and finishes with a summary of successes and failures.
  * Role assignments are migrated in bulk for faster, more reliable runs.

* **Bug Fixes**
  * Improved handling of duplicate names, partially migrated users, and stale service IDs.
  * Legacy authenticator cleanup and superuser syncing now behave more consistently across services.

* **Tests**
  * Expanded automated coverage for logging, migration flows, role assignments, user merging, and superuser synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->