### PR TITLE
[AAP-80683] Revert dynaconf<3.3.0 pin, restore <4.0.0 upper bound

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -20,7 +20,7 @@ PyYAML
 # Not directly imported but pinned per dependabot alerts
 urllib3>=2.7.0   # CVE-2026-44431 / CVE-2026-44432
 argon2-cffi
-dynaconf>=3.2.13,<3.3.0  # CVE-2026-33154; pin <3.3.0 per AAP-80580 (breaking internal API change)
+dynaconf>=3.2.13,<4.0.0  # CVE-2026-33154; <4.0.0 because 4.x is expected to have breaking changes
 referencing<0.37.0  # consistent with DAB pin from jsonschema-path
 jsonschema<4.26  # 4.26+ requires rpds-py>=0.25, incompatible with hermeto
 rpds-py<0.25  # hermeto does not support rpds-py>=0.25

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -43,7 +43,7 @@ djangorestframework==3.15.2
     #   drf-spectacular
 drf-spectacular==0.29.0
     # via -r requirements/requirements.in
-dynaconf==3.2.13
+dynaconf==3.3.2
     # via -r requirements/requirements.in
 grpcio==1.68.1
     # via


### PR DESCRIPTION
## Description

- **What is being changed?** Reverting the dynaconf upper bound from `<3.3.0` back to `<4.0.0` in `requirements/requirements.in`.
- **Why is this change needed?** [DAB PR #1034](https://github.com/ansible/django-ansible-base/pull/1034) has merged, adding compatibility helpers (`_dynaconf_post_hooks()`, `_dynaconf_loaded_files()`) that work with both dynaconf 3.2.x and 3.3.0. Since jewel pulls DAB from `@devel` via `requirements_git.txt`, the fix is already available.
- **How does this change address the issue?** Removes the temporary pin introduced in [PR #138](https://github.com/ansible/jewel/pull/138), restoring the ability to use dynaconf 3.3.0+.

**JIRA:** AAP-80683

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites
- Local aap-dev environment or Konflux CI

### Steps to Test
1. Install dynaconf 3.3.0: `pip install 'dynaconf==3.3.0'`
2. Start gateway — it should boot successfully (DAB compat helpers handle the relocated attributes)

### Expected Results
Gateway starts and migrations run successfully with dynaconf 3.3.0.

## Additional Context

This reverts the temporary workaround from [PR #138](https://github.com/ansible/jewel/pull/138) (AAP-80580). The proper fix lives in DAB via [ansible/django-ansible-base#1034](https://github.com/ansible/django-ansible-base/pull/1034).

---
**Note:** This PR was developed with assistance from Claude AI assistant.

[AAP-80683]: https://redhat.atlassian.net/browse/AAP-80683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated the configuration dependency version constraints to allow newer compatible releases, improving upgrade flexibility and reducing version conflict risk.
  * Adjusted the pinned dependency version to align with the broadened range and expected compatibility changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->