### PR TITLE
test: sandbox marker for GATEWAY_REPO override testing

### DIFF
--- a/aap_gateway_api/__init__.py
+++ b/aap_gateway_api/__init__.py
@@ -8,6 +8,8 @@ from aap_gateway_api.version import get_api_version
 
 __version__ = get_api_version()
 
+SANDBOX_TEST_MARKER = "jewel-gateway-repo-override-test"
+
 
 def manage():
     """Run administrative tasks."""


### PR DESCRIPTION
## Summary
- Adds a `SANDBOX_TEST_MARKER` constant to verify the jewel component override works in CI pipelines

## Context
Testing PR for AAP-81941 — validating the `GATEWAY_REPO` choice parameter in yolo pipelines.

**Do not merge** — this is a temporary test PR.

Assisted-by: Claude Code