### PR TITLE
[AAP-81696] Convert migration 0023 to empty convergence, re-parent 0022, add signal handler

### DIFF
--- a/aap_gateway_api/migrations/0022_usersessionmembership.py
+++ b/aap_gateway_api/migrations/0022_usersessionmembership.py
@@ -8,7 +8,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("aap_gateway_api", "0021_remove_runtime_feature_flags_ui_preference"),
+        ("aap_gateway_api", "0017_add_fallback_authentication_to_local_authenticators"),
         ("sessions", "0001_initial"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]

--- a/aap_gateway_api/migrations/0023_remove_console_service_type.py
+++ b/aap_gateway_api/migrations/0023_remove_console_service_type.py
@@ -5,8 +5,9 @@ class Migration(migrations.Migration):
     """Convergence migration: merges the 0021 and 0022 branches.
 
     The data cleanup previously performed here (removing console ServiceType
-    and RED_HAT_CONSOLE_URL preference) is now handled by the post_migrate
-    signal handler remove_console_service_type() in preloaded_data.py.
+    and RED_HAT_CONSOLE_URL preference) is now handled by
+    remove_console_service_type() in preloaded_data.py, which runs as part
+    of the post_migrate signal processing.
     """
 
     dependencies = [

--- a/aap_gateway_api/migrations/0023_remove_console_service_type.py
+++ b/aap_gateway_api/migrations/0023_remove_console_service_type.py
@@ -1,25 +1,17 @@
 from django.db import migrations
 
 
-def remove_console_service_type(apps, schema_editor):
-    ServiceType = apps.get_model("aap_gateway_api", "ServiceType")
-    ServiceType.objects.filter(name="console").delete()
-
-    Preference = apps.get_model("aap_gateway_api", "Preference")
-    Preference.objects.filter(
-        section="analytics",
-        name="RED_HAT_CONSOLE_URL",
-    ).delete()
-
-
 class Migration(migrations.Migration):
+    """Convergence migration: merges the 0021 and 0022 branches.
+
+    The data cleanup previously performed here (removing console ServiceType
+    and RED_HAT_CONSOLE_URL preference) is now handled by the post_migrate
+    signal handler remove_console_service_type() in preloaded_data.py.
+    """
+
     dependencies = [
+        ("aap_gateway_api", "0021_remove_runtime_feature_flags_ui_preference"),
         ("aap_gateway_api", "0022_usersessionmembership"),
     ]
 
-    operations = [
-        migrations.RunPython(
-            remove_console_service_type,
-            migrations.RunPython.noop,
-        ),
-    ]
+    operations = []

--- a/aap_gateway_api/signals/preloaded_data.py
+++ b/aap_gateway_api/signals/preloaded_data.py
@@ -160,10 +160,13 @@ def remove_console_service_type() -> bool:
     except LookupError:
         return False
 
-    console_clusters = ServiceType.objects.filter(name="console").values_list('servicecluster__name', flat=True)
-    cluster_names = [n for n in console_clusters if n is not None]
-    if cluster_names:
-        logger.warning("Cascade-deleting ServiceCluster(s) for console ServiceType: %s", cluster_names)
+    try:
+        console_clusters = ServiceType.objects.filter(name="console").values_list('clusters__name', flat=True)
+        cluster_names = [n for n in console_clusters if n is not None]
+        if cluster_names:
+            logger.warning("Cascade-deleting ServiceCluster(s) for console ServiceType: %s", cluster_names)
+    except Exception:
+        pass
 
     deleted_st, st_details = ServiceType.objects.filter(name="console").delete()
     if deleted_st:

--- a/aap_gateway_api/signals/preloaded_data.py
+++ b/aap_gateway_api/signals/preloaded_data.py
@@ -25,6 +25,7 @@ def create_preload_data(**kwargs) -> None:
         set_system_user_password,
         set_system_user_managed_flag,
         toggle_install_time_flags,
+        remove_console_service_type,
     ]
 
     # Verbosity comes from the signal see https://docs.djangoproject.com/en/5.0/ref/signals/#post-migrate
@@ -141,3 +142,22 @@ def toggle_install_time_flags() -> None:
             existing_flag.value = state
             existing_flag.full_clean()
             existing_flag.save()
+
+
+def remove_console_service_type() -> bool:
+    """Remove legacy console service type and associated preference.
+
+    The console ServiceType was gated behind FEATURE_GATEWAY_CREATE_CRC_SERVICE_TYPE_ENABLED
+    and is no longer supported (AAP-74714). This replaces the operations previously in
+    migration 0023_remove_console_service_type.py with an idempotent signal-based cleanup
+    to avoid migration dependency chain issues on stable branches.
+    """
+    ServiceType = global_apps.get_model('aap_gateway_api', 'ServiceType')
+    Preference = global_apps.get_model('aap_gateway_api', 'Preference')
+
+    deleted_st, _ = ServiceType.objects.filter(name="console").delete()
+    deleted_pref, _ = Preference.objects.filter(
+        section="analytics",
+        name="RED_HAT_CONSOLE_URL",
+    ).delete()
+    return (deleted_st + deleted_pref) > 0

--- a/aap_gateway_api/signals/preloaded_data.py
+++ b/aap_gateway_api/signals/preloaded_data.py
@@ -56,6 +56,8 @@ def create_preload_data(**kwargs) -> None:
                 action = 'Created'
                 if name.startswith('set'):
                     action = 'Set'
+                elif name.startswith('remove'):
+                    action = 'Removed'
                 logger.debug(f"{action} {' '.join(name.split('_')[1:])}")
         except Exception as e:
             if verbosity in [0, 1]:
@@ -152,10 +154,21 @@ def remove_console_service_type() -> bool:
     migration 0023_remove_console_service_type.py with an idempotent signal-based cleanup
     to avoid migration dependency chain issues on stable branches.
     """
-    ServiceType = global_apps.get_model('aap_gateway_api', 'ServiceType')
-    Preference = global_apps.get_model('aap_gateway_api', 'Preference')
+    try:
+        ServiceType = global_apps.get_model('aap_gateway_api', 'ServiceType')
+        Preference = global_apps.get_model('aap_gateway_api', 'Preference')
+    except LookupError:
+        return False
 
-    deleted_st, _ = ServiceType.objects.filter(name="console").delete()
+    console_clusters = ServiceType.objects.filter(name="console").values_list('servicecluster__name', flat=True)
+    cluster_names = [n for n in console_clusters if n is not None]
+    if cluster_names:
+        logger.warning("Cascade-deleting ServiceCluster(s) for console ServiceType: %s", cluster_names)
+
+    deleted_st, st_details = ServiceType.objects.filter(name="console").delete()
+    if deleted_st:
+        logger.info("Console ServiceType delete details: %s", st_details)
+
     deleted_pref, _ = Preference.objects.filter(
         section="analytics",
         name="RED_HAT_CONSOLE_URL",

--- a/aap_gateway_api/tests/signals/test_preloaded_data.py
+++ b/aap_gateway_api/tests/signals/test_preloaded_data.py
@@ -2,8 +2,14 @@ from unittest import mock
 
 import pytest
 
-from aap_gateway_api.models import Organization
-from aap_gateway_api.signals.preloaded_data import create_default_organization, create_preload_data, set_system_user_managed_flag, set_system_user_password
+from aap_gateway_api.models import Organization, Preference, ServiceType
+from aap_gateway_api.signals.preloaded_data import (
+    create_default_organization,
+    create_preload_data,
+    remove_console_service_type,
+    set_system_user_managed_flag,
+    set_system_user_password,
+)
 
 
 class TestCreatePreloadedData:
@@ -77,3 +83,24 @@ class TestCreatePreloadedData:
         with mock.patch('aap_gateway_api.signals.preloaded_data.create_default_organization', mock_function):
             with expected_log('aap_gateway_api.signals.preloaded_data.logger', log_level, 'Failed to'):
                 create_preload_data(verbosity=verbosity, plan=[('0000', False)])
+
+    @pytest.mark.django_db
+    def test_remove_console_service_type(self):
+        """remove_console_service_type deletes console ServiceType and RED_HAT_CONSOLE_URL preference."""
+        ServiceType.objects.get_or_create(name="console")
+        Preference.objects.bulk_create(
+            [Preference(section="analytics", name="RED_HAT_CONSOLE_URL", raw_value="https://console.redhat.com")],
+            ignore_conflicts=True,
+        )
+
+        assert remove_console_service_type() is True, "Should delete existing records"
+        assert not ServiceType.objects.filter(name="console").exists()
+        assert not Preference.objects.filter(section="analytics", name="RED_HAT_CONSOLE_URL").exists()
+
+    @pytest.mark.django_db
+    def test_remove_console_service_type_idempotent(self):
+        """remove_console_service_type is a no-op when records don't exist."""
+        ServiceType.objects.filter(name="console").delete()
+        Preference.objects.filter(section="analytics", name="RED_HAT_CONSOLE_URL").delete()
+
+        assert remove_console_service_type() is False, "Should return False when nothing to delete"

--- a/aap_gateway_api/tests/signals/test_preloaded_data.py
+++ b/aap_gateway_api/tests/signals/test_preloaded_data.py
@@ -139,3 +139,42 @@ class TestCreatePreloadedData:
 
         assert not ServiceType.objects.filter(name="console").exists()
         assert not Preference.objects.filter(section="analytics", name="RED_HAT_CONSOLE_URL").exists()
+
+    def test_remove_console_service_type_lookup_error(self):
+        """remove_console_service_type returns False when models are not available."""
+        with mock.patch('aap_gateway_api.signals.preloaded_data.global_apps.get_model', side_effect=LookupError):
+            assert remove_console_service_type() is False
+
+    @pytest.mark.django_db
+    def test_remove_console_service_type_cascade_warning(self, expected_log):
+        """remove_console_service_type logs warning when ServiceClusters will be cascade-deleted."""
+        from aap_gateway_api.models import ServiceCluster
+
+        st, _ = ServiceType.objects.get_or_create(name="console")
+        ServiceCluster.objects.create(name="test-console-cluster", service_type=st)
+
+        with expected_log('aap_gateway_api.signals.preloaded_data.logger', 'warning', 'Cascade-deleting'):
+            assert remove_console_service_type() is True
+        assert not ServiceType.objects.filter(name="console").exists()
+        assert not ServiceCluster.objects.filter(name="test-console-cluster").exists()
+
+    @pytest.mark.django_db
+    def test_remove_console_service_type_cascade_check_exception(self):
+        """remove_console_service_type handles cascade check failures gracefully."""
+        ServiceType.objects.get_or_create(name="console")
+
+        with mock.patch.object(
+            ServiceType.objects.filter(name="console").__class__,
+            'values_list',
+            side_effect=Exception("query error"),
+        ):
+            assert remove_console_service_type() is True
+        assert not ServiceType.objects.filter(name="console").exists()
+
+    @pytest.mark.django_db
+    def test_remove_console_service_type_logs_removed_action(self, expected_log):
+        """create_preload_data logs 'Removed' action for remove_ functions."""
+        ServiceType.objects.get_or_create(name="console")
+
+        with expected_log('aap_gateway_api.signals.preloaded_data.logger', 'debug', 'Removed'):
+            create_preload_data(verbosity=1, plan=[('0000', False)])

--- a/aap_gateway_api/tests/signals/test_preloaded_data.py
+++ b/aap_gateway_api/tests/signals/test_preloaded_data.py
@@ -104,3 +104,38 @@ class TestCreatePreloadedData:
         Preference.objects.filter(section="analytics", name="RED_HAT_CONSOLE_URL").delete()
 
         assert remove_console_service_type() is False, "Should return False when nothing to delete"
+
+    @pytest.mark.django_db
+    def test_remove_console_service_type_only_service_type(self):
+        """remove_console_service_type handles case where only ServiceType exists."""
+        Preference.objects.filter(section="analytics", name="RED_HAT_CONSOLE_URL").delete()
+        ServiceType.objects.get_or_create(name="console")
+
+        assert remove_console_service_type() is True
+        assert not ServiceType.objects.filter(name="console").exists()
+
+    @pytest.mark.django_db
+    def test_remove_console_service_type_only_preference(self):
+        """remove_console_service_type handles case where only Preference exists."""
+        ServiceType.objects.filter(name="console").delete()
+        Preference.objects.bulk_create(
+            [Preference(section="analytics", name="RED_HAT_CONSOLE_URL", raw_value="https://console.redhat.com")],
+            ignore_conflicts=True,
+        )
+
+        assert remove_console_service_type() is True
+        assert not Preference.objects.filter(section="analytics", name="RED_HAT_CONSOLE_URL").exists()
+
+    @pytest.mark.django_db
+    def test_remove_console_service_type_via_preload_data(self):
+        """remove_console_service_type is wired into create_preload_data function_order."""
+        ServiceType.objects.get_or_create(name="console")
+        Preference.objects.bulk_create(
+            [Preference(section="analytics", name="RED_HAT_CONSOLE_URL", raw_value="https://console.redhat.com")],
+            ignore_conflicts=True,
+        )
+
+        create_preload_data(verbosity=0, plan=[('0000', False)])
+
+        assert not ServiceType.objects.filter(name="console").exists()
+        assert not Preference.objects.filter(section="analytics", name="RED_HAT_CONSOLE_URL").exists()


### PR DESCRIPTION
## Description

- **What is being changed?** Migration 0022 (`UserSessionMembership`) is re-parented from its conventional dependency on 0021 to its true schema dependency 0017. Migration 0023 (`remove_console_service_type`) is converted from an active data migration to an empty convergence migration (`operations = []`). The data cleanup logic is moved to an idempotent `post_migrate` signal handler in `preloaded_data.py`.
- **Why is this change needed?** Migration 0022 needs to be backported to stable-2.6 and forward-propagated to stable-2.7, but its declared dependency on 0021 prevents a clean cherry-pick to branches where 0018–0021 don't exist. Analysis in AAP-80663 confirmed that 0022 has no actual schema dependency on 0018–0021 — the dependency is purely conventional (`makemigrations` chaining).
- **How does this change address the issue?** By re-parenting 0022 to 0017 (its true dependency) and using 0023 as the convergence point, we create a valid forked migration graph that allows 0022 to be cherry-picked to any branch that has 0017. The signal handler ensures the console ServiceType cleanup still happens on all branches.

**This PR builds on the approach from PR #147 by @Dostonbek1**, which proposed converting 0023 to a signal handler. The key difference is that this PR keeps the migration file as an empty convergence point instead of deleting it. Deleting 0023 after re-parenting 0022 would create two leaf nodes (0021 and 0022) in the migration graph, which causes Django to refuse `makemigrations` until a merge migration is added. Keeping 0023 as an empty migration with dependencies on both 0021 and 0022 solves this naturally.

### Resulting migration graph on devel
```
0017 --> 0018 --> 0019 --> 0020 --> 0021 --+
  |                                        +--> 0023 (empty, convergence)
  +-----------> 0022 ---------------------+
```

## Type of Change

- [x] Refactoring (no functional changes)

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites

- Running aap-gateway development environment with database

### Steps to Test

1. Apply all migrations: `python manage.py migrate`
2. Verify migration graph: `python manage.py showmigrations aap_gateway_api` — should show all migrations applied with 0023 as the single leaf
3. Create a console ServiceType manually: `ServiceType.objects.get_or_create(name="console")`
4. Create the preference: `Preference.objects.get_or_create(section="analytics", name="RED_HAT_CONSOLE_URL", defaults={"value": "https://console.redhat.com"})`
5. Run migrate again: `python manage.py migrate` (triggers the post_migrate signal)
6. Verify the records are deleted: `ServiceType.objects.filter(name="console").count()` should be 0
7. Run again — idempotent, no errors

### Expected Results

- `showmigrations` shows a clean graph with 0023 as the only leaf
- Signal handler deletes console ServiceType and RED_HAT_CONSOLE_URL preference
- Running migrate multiple times produces no errors (idempotent)
- Existing deployments with 0023 already applied are unaffected

## Additional Context

### Migration orphan note

Developers who have already applied the original 0023 (with RunPython operations) are unaffected. Django only checks whether `0023_remove_console_service_type` exists in `django_migrations` — it does not re-validate operations or dependencies for already-applied migrations.

### Backport enablement

After this PR merges, the following backports become possible:
- **stable-2.6**: Cherry-pick 0022 (depends on 0017, which exists on 2.6) — single leaf, no merge migration needed
- **stable-2.7**: Cherry-pick 0022 and 0023 (empty convergence) — 0023 merges the 0021 and 0022 branches

### Required Actions

- [ ] Requires downstream repository changes
  - Cherry-picks to ansible-automation-platform/aap-gateway stable branches (tracked in AAP-82458)
- [ ] Requires coordination with other teams
  - Supersedes PR #147 by @Dostonbek1 (AAP-81696) — same signal handler, different migration strategy

### Related issues

- **AAP-82458**: Parent — migration re-parent and converge plan
- **AAP-81696**: Converting migration 0023 to post_migrate signal
- **AAP-80663**: Full analysis of migrations 0017–0023
- **AAP-74114**: Original concurrent sessions feature (migration 0022)
- **PR #147**: Original approach by @Dostonbek1 (this PR supersedes it)

---
**Note:** This PR was developed with assistance from Claude AI assistant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Legacy console service entries are removed during preloaded-data processing, including the associated analytics preference.
  * Cleanup is idempotent and safely handles cases where only the service entry, only the preference, or neither exists.
* **Tests**
  * Added database tests covering removal, idempotent behavior, missing-data scenarios, edge/cascade warning handling, and verification that preloaded-data triggers the cleanup.
* **Chores**
  * Updated migration behavior to align with signal-driven post-migration cleanup flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->