### PR TITLE
[AAP-82562] Add merge_group trigger to CI workflows

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -4,6 +4,7 @@ env:
   LC_ALL: "C.UTF-8" # prevent ERROR: Ansible could not initialize the preferred locale: unsupported locale setting
 on:
   pull_request:
+  merge_group:
   push:
 jobs:
   common-tests:

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -18,6 +18,7 @@ env:
   LC_ALL: "C.UTF-8" # prevent ERROR: Ansible could not initialize the preferred locale: unsupported locale setting
 on:
   pull_request:
+  merge_group:
 jobs:
   tox:
     name: aap_gateway_api - ${{ matrix.tests.env }}

--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -312,6 +312,7 @@ jobs:
       - name: Print SonarCloud Analysis Summary
         env:
           BRANCH_NAME: ${{ github.event.workflow_run.head_branch }}
+          EVENT_TYPE: ${{ github.event.workflow_run.event }}
         run: |
           # Find all downloaded coverage XML files
           coverage_files=$(find . -name "coverage-*.xml" -type f | tr '\n' ',' | sed 's/,$//')
@@ -320,7 +321,7 @@ jobs:
 
           echo "🔍 SonarCloud Analysis Summary"
           echo "=============================="
-          echo "├── CI Event: ✅ Push (via workflow_run)"
+          echo "├── CI Event: ✅ $EVENT_TYPE (via workflow_run)"
           echo "├── Branch: $BRANCH_NAME"
           echo "├── Coverage Files: ${coverage_files:-none}"
           echo "├── Python Changes: ➖ N/A (Full codebase scan)"

--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -78,13 +78,14 @@ jobs:
           EVENT_TYPE: ${{ github.event.workflow_run.event }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          if [ "$EVENT_TYPE" = "pull_request" ]; then
+          if [ "$EVENT_TYPE" = "pull_request" ] || [ "$EVENT_TYPE" = "merge_group" ]; then
             # workflow_run doesn't expose the PR base branch, so we can't check it here.
-            # Allow PRs through the gate; the PR analysis job resolves the base branch
-            # via the GitHub API and rechecks it against SONAR_BRANCHES before scanning.
+            # Allow PRs and merge_group events through the gate; the PR analysis job
+            # resolves the base branch via the GitHub API and rechecks it against
+            # SONAR_BRANCHES before scanning. Merge group events run a branch analysis.
             echo "branch=$HEAD_BRANCH" >> "$GITHUB_OUTPUT"
             echo "allowed=true" >> "$GITHUB_OUTPUT"
-            echo "✅ PR event — deferring base branch check to PR analysis job"
+            echo "✅ $EVENT_TYPE event — allowing through gate"
             exit 0
           fi
 
@@ -289,7 +290,7 @@ jobs:
       actions: read
     if: |
       needs.gate.outputs.allowed == 'true' &&
-      github.event.workflow_run.event == 'push'
+      (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'merge_group')
     steps:
       # Pin to the exact commit that the Unit Tests workflow ran against,
       # since workflow_run context defaults to the repo's default branch.

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,6 +2,7 @@
 name: Unit Tests
 on:
   pull_request:
+  merge_group:
   push:    # This is triggered on a PR being merged into devel or a stable branch
     branches:
       - devel


### PR DESCRIPTION
## Summary
- Add `merge_group` event trigger to sanity, linting, unit-tests, and sonar-pr workflows so CI checks run as part of GitHub merge queues
- Update SonarCloud gate job to allow `merge_group` events through, and branch analysis job to run on `merge_group` events routed via `workflow_run`

## Test plan
- [x] Validated equivalent changes in [jewel-debug PR #3](https://github.com/ansible/jewel-debug/pull/3) — CI checks ran successfully in the merge queue
- [ ] Verify no regressions on standard PR and push triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated validation workflows to run during merge queue checks.
  * Updated code quality, sanity, Sonar analysis, and unit test workflows to support merge-group events.
  * Ensured branch analysis and workflow gating operate correctly for merge queue runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->