### PR TITLE
[AAP-82668] Add transaction atomicity and scaling regression tests for org delete

### DIFF
--- a/aap_gateway_api/tests/views/api/v1/organization/test_organization.py
+++ b/aap_gateway_api/tests/views/api/v1/organization/test_organization.py
@@ -1,7 +1,10 @@
+from unittest.mock import patch
+
 import pytest
 from ansible_base.lib.utils.response import get_relative_url
+from ansible_base.rbac.models import ObjectRole, RoleDefinition, RoleUserAssignment
 
-from aap_gateway_api.models import Organization
+from aap_gateway_api.models import Organization, Team
 
 
 def test_prevent_deletion_of_managed_organization(admin_api_client):
@@ -213,3 +216,74 @@ def test_managed_organization_field_manual(admin_api_client):
     response = admin_api_client.patch(url, data={"managed": False})
     assert response.status_code == 200
     assert response.data["managed"] is True
+
+
+@pytest.mark.django_db(transaction=True)
+class TestOrgDeleteCleansUpRBAC:
+    """Verify that a successful org delete removes all RBAC data consistently."""
+
+    def test_successful_delete_cleans_up_everything(self, admin_api_client, organization, team, user):
+        RoleDefinition.objects.managed.org_member.give_permission(user, organization)
+        RoleDefinition.objects.managed.team_member.give_permission(user, team)
+
+        assert RoleUserAssignment.objects.filter(user_id=user.pk, object_id=organization.pk).exists()
+        assert RoleUserAssignment.objects.filter(user_id=user.pk, object_id=team.pk).exists()
+
+        url = get_relative_url("organization-detail", kwargs={"pk": organization.pk})
+        response = admin_api_client.delete(url)
+        assert response.status_code == 204
+
+        assert not Organization.objects.filter(pk=organization.pk).exists()
+        assert not Team.objects.filter(pk=team.pk).exists()
+        assert not RoleUserAssignment.objects.filter(object_id=organization.pk).exists()
+        assert not RoleUserAssignment.objects.filter(object_id=team.pk).exists()
+        assert not ObjectRole.objects.filter(users__isnull=True, teams__isnull=True).exists()
+
+
+@pytest.mark.django_db(transaction=True)
+class TestOrgDeleteRBACFlushRollback:
+    """Verify that RBAC flush failure rolls back the entire org delete.
+
+    The call chain is:
+      dispatch() -> defer_rbac_computations [with transaction.atomic]
+        -> perform_destroy() [@transaction.atomic — savepoint]
+          -> instance.delete() -> signals fire, work deferred
+        -> defer_rbac_computations.__exit__ -> _flush_rbac()
+
+    If the flush raises, transaction.atomic must roll back the delete
+    so the org and all RBAC data remain intact.
+    """
+
+    def test_flush_failure_rolls_back_delete(self, admin_api_client, organization, team, user):
+        RoleDefinition.objects.managed.org_member.give_permission(user, organization)
+        RoleDefinition.objects.managed.team_member.give_permission(user, team)
+
+        org_assignments_before = RoleUserAssignment.objects.filter(object_id=organization.pk).count()
+        team_assignments_before = RoleUserAssignment.objects.filter(object_id=team.pk).count()
+
+        url = get_relative_url("organization-detail", kwargs={"pk": organization.pk})
+
+        with (
+            patch(
+                "ansible_base.rbac.triggers.compute_team_member_roles",
+                side_effect=RuntimeError("Simulated RBAC flush failure"),
+            ),
+            patch(
+                "ansible_base.rbac.triggers.compute_object_role_permissions",
+                side_effect=RuntimeError("Simulated RBAC flush failure"),
+            ),
+        ):
+            try:
+                response = admin_api_client.delete(url)
+                assert response.status_code == 500
+            except RuntimeError:
+                pass
+
+        assert Organization.objects.filter(pk=organization.pk).exists(), (
+            "Organization was deleted despite RBAC flush failure -- the flush is running OUTSIDE the transaction!"
+        )
+
+        assert Team.objects.filter(pk=team.pk).exists(), "Team was deleted despite RBAC flush failure -- cascade delete was not rolled back!"
+
+        assert RoleUserAssignment.objects.filter(user_id=user.pk, object_id=organization.pk).count() == org_assignments_before
+        assert RoleUserAssignment.objects.filter(user_id=user.pk, object_id=team.pk).count() == team_assignments_before

--- a/aap_gateway_api/tests/views/api/v1/organization/test_organization.py
+++ b/aap_gateway_api/tests/views/api/v1/organization/test_organization.py
@@ -265,11 +265,11 @@ class TestOrgDeleteRBACFlushRollback:
 
         with (
             patch(
-                "ansible_base.rbac.triggers.compute_team_member_roles",
+                "ansible_base.rbac.caching.compute_team_member_roles",
                 side_effect=RuntimeError("Simulated RBAC flush failure"),
             ),
             patch(
-                "ansible_base.rbac.triggers.compute_object_role_permissions",
+                "ansible_base.rbac.caching.compute_object_role_permissions",
                 side_effect=RuntimeError("Simulated RBAC flush failure"),
             ),
         ):

--- a/aap_gateway_api/tests/views/api/v1/organization/test_organization.py
+++ b/aap_gateway_api/tests/views/api/v1/organization/test_organization.py
@@ -266,10 +266,20 @@ class TestOrgDeleteRBACFlushRollback:
         with (
             patch(
                 "ansible_base.rbac.triggers.compute_team_member_roles",
+                create=True,
                 side_effect=RuntimeError("Simulated RBAC flush failure"),
             ),
             patch(
                 "ansible_base.rbac.triggers.compute_object_role_permissions",
+                create=True,
+                side_effect=RuntimeError("Simulated RBAC flush failure"),
+            ),
+            patch(
+                "ansible_base.rbac.caching.compute_team_member_roles",
+                side_effect=RuntimeError("Simulated RBAC flush failure"),
+            ),
+            patch(
+                "ansible_base.rbac.caching.compute_object_role_permissions",
                 side_effect=RuntimeError("Simulated RBAC flush failure"),
             ),
         ):

--- a/aap_gateway_api/tests/views/api/v1/organization/test_organization.py
+++ b/aap_gateway_api/tests/views/api/v1/organization/test_organization.py
@@ -265,11 +265,11 @@ class TestOrgDeleteRBACFlushRollback:
 
         with (
             patch(
-                "ansible_base.rbac.caching.compute_team_member_roles",
+                "ansible_base.rbac.triggers.compute_team_member_roles",
                 side_effect=RuntimeError("Simulated RBAC flush failure"),
             ),
             patch(
-                "ansible_base.rbac.caching.compute_object_role_permissions",
+                "ansible_base.rbac.triggers.compute_object_role_permissions",
                 side_effect=RuntimeError("Simulated RBAC flush failure"),
             ),
         ):

--- a/aap_gateway_api/tests/views/api/v1/organization/test_organization_delete_perf.py
+++ b/aap_gateway_api/tests/views/api/v1/organization/test_organization_delete_perf.py
@@ -1,0 +1,77 @@
+"""Perf tests for organization delete scaling.
+
+Detects O(n) regressions in org delete by comparing wall-clock time at
+two team counts. With RBAC deferral active, delete time should be
+roughly constant regardless of team count. Without deferral, it scales
+linearly (each team triggers a full RBAC recomputation).
+"""
+
+import time
+
+import pytest
+from ansible_base.lib.utils.response import get_relative_url
+from ansible_base.rbac.models import RoleDefinition
+
+from aap_gateway_api.models import Organization, Team, User
+
+
+def _create_org_with_teams(name_prefix, num_teams, users_per_team):
+    """Create an org with teams and user role assignments."""
+    org = Organization.objects.create(name=f"{name_prefix}-org")
+    team_member_rd = RoleDefinition.objects.get(name="Team Member")
+    org_member_rd = RoleDefinition.objects.get(name="Organization Member")
+
+    users = []
+    for i in range(num_teams):
+        team = Team.objects.create(name=f"{name_prefix}-team-{i}", organization=org)
+        for j in range(users_per_team):
+            user = User.objects.create_user(
+                username=f"{name_prefix}-user-{i}-{j}",
+                password="PerfTest1234!",
+            )
+            users.append(user)
+            org_member_rd.give_permission(user, org)
+            team_member_rd.give_permission(user, team)
+
+    return org, users
+
+
+def _time_api_delete(client, org):
+    """Delete an org via the API and return wall-clock seconds."""
+    url = get_relative_url("organization-detail", kwargs={"pk": org.pk})
+    start = time.monotonic()
+    response = client.delete(url)
+    elapsed = time.monotonic() - start
+    assert response.status_code == 204, f"Delete failed with {response.status_code}"
+    return elapsed
+
+
+@pytest.mark.django_db(transaction=True)
+def test_org_delete_time_scales_sublinearly(admin_api_client, local_authenticator):
+    """Org delete with 20 teams should take less than 3x the time of 5 teams.
+
+    With RBAC deferral (defer_rbac_computations), all per-team signal
+    work is batched into a single flush, making delete time roughly O(1).
+    Without deferral, each team triggers a full recomputation and delete
+    time scales linearly — 4x teams would take ~4x longer.
+
+    The 3x threshold allows for DB overhead that grows slightly with more
+    rows to cascade-delete, while catching true O(n) regressions where
+    the ratio would be > 4x.
+    """
+    time_small = _time_api_delete(
+        admin_api_client,
+        _create_org_with_teams("perf-small", num_teams=5, users_per_team=3)[0],
+    )
+
+    time_large = _time_api_delete(
+        admin_api_client,
+        _create_org_with_teams("perf-large", num_teams=20, users_per_team=3)[0],
+    )
+
+    ratio = time_large / max(time_small, 0.01)
+    assert ratio < 3.0, (
+        f"Org delete is scaling linearly: {time_small:.2f}s (5 teams) vs "
+        f"{time_large:.2f}s (20 teams), ratio {ratio:.1f}x. "
+        f"Expected < 3.0x with RBAC deferral active."
+    )


### PR DESCRIPTION
## Summary
Requires: ansible/django-ansible-base#1074

Adds tests verifying org delete correctness and performance:

1. **Transaction atomicity tests** — verify that RBAC flush failures during org delete roll back the entire operation (org, teams, and role assignments remain intact)
2. **Scaling perf test** — compares delete time at 5 vs 20 teams and asserts the ratio stays below 3x, catching O(n) regressions if `defer_rbac_computations` deferral is accidentally removed

**Depends on:** DAB PR #1059 (merged) for `defer_rbac_computations`

## Test plan

- [x] Successful org delete cleans up all evaluations, assignments, and orphan ObjectRoles
- [x] RBAC flush failure (mocked `compute_team_member_roles` raising) rolls back the entire delete
- [x] Perf test detects linear scaling regression (ratio > 3x = fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)