### PR TITLE
AAP-83321 - Auto-populate service_id on first auth for services registered post-migration

### DIFF
--- a/aap_gateway_api/tests/authentication/test_service_token_auth.py
+++ b/aap_gateway_api/tests/authentication/test_service_token_auth.py
@@ -9,7 +9,7 @@ from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.resource_registry.models import service_id
 from rest_framework.test import APIClient
 
-from aap_gateway_api.models import ServiceKey
+from aap_gateway_api.models import ServiceCluster, ServiceKey
 
 
 def _create_jwt(user, key, additional_payload=None, service=None, expiration=60):
@@ -376,6 +376,105 @@ def test_migration_not_complete_blocks_auth(service_cluster_gateway, user):
         assert resp.status_code == 423
     finally:
         MigrateServiceDataHasRan.mark_migration_completed()
+
+
+@pytest.mark.parametrize(
+    "auth_backend,expected",
+    [
+        (None, None),
+        ("django.contrib.auth.backends.ModelBackend", "local"),
+        ("ansible_base.authentication.backends.PrefixedUserAuthBackend", "local"),
+        ("ansible_base.authentication.backends.LDAPBackend", "ldap"),
+        ("ansible_base.authentication.backends.RADIUSBackend", "radius"),
+        ("ansible_base.authentication.backends.TACACSPlusBackend", "tacacs+"),
+        ("some.unknown.backend", "some.unknown.backend"),
+    ],
+)
+def test_classify_backend(auth_backend, expected):
+    """classify_backend maps known auth backend strings to canonical type names."""
+    from aap_gateway_api.utils.service_token import classify_backend
+
+    assert classify_backend(auth_backend) == expected
+
+
+@pytest.mark.django_db
+def test_validate_service_token_required_type_mismatch(service_jwt_token):
+    """validate_service_token raises ValidationError when required_type does not match the token."""
+    from django.core.exceptions import ValidationError
+
+    from aap_gateway_api.utils.service_token import validate_service_token
+
+    with pytest.raises(ValidationError, match="Expected token of type"):
+        validate_service_token(service_jwt_token, required_type="expected_type")
+
+
+@pytest.mark.django_db
+def test_verify_token_signature_iss_mismatch(service_cluster_gateway, user, service_jwt_token):
+    """_verify_token_signature raises ValidationError when the verified iss differs from unverified."""
+    from django.core.exceptions import ValidationError
+
+    from aap_gateway_api.utils.service_token import _verify_token_signature
+
+    tampered_payload = {"iss": str(uuid.uuid4()), "exp": 9999999999, "sub": "anything"}
+    with mock.patch("aap_gateway_api.utils.service_token.jwt.api_jwt.decode_complete") as mock_dec:
+        mock_dec.return_value = {"payload": tampered_payload, "header": {}, "signature": b""}
+        with pytest.raises(ValidationError, match="Verified token data does not match unverified data"):
+            _verify_token_signature(service_jwt_token, service_cluster_gateway, "original-issuer-uuid")
+
+
+# ---------------------------------------------------------------------------
+# Auto-populate service_id fallback in validate_service_token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_auto_populate_succeeds_allows_auth(service_cluster_controller, user):
+    """When service_id is null, auto-populate finds the cluster and auth succeeds."""
+    from aap_gateway_api.utils.service_token import validate_service_token
+
+    target_id = str(uuid.uuid4())
+    key = service_cluster_controller.generate_key()
+    token = _create_jwt(user, key, service=target_id)
+
+    def _populate_and_set(uid):
+        ServiceCluster.objects.filter(pk=service_cluster_controller.pk).update(service_id=uid)
+        service_cluster_controller.service_id = uid
+        return service_cluster_controller
+
+    with mock.patch("aap_gateway_api.utils.service_token.populate_service_id", side_effect=_populate_and_set):
+        result = validate_service_token(token)
+
+    assert result["service_cluster"].pk == service_cluster_controller.pk
+    assert result["user"] == user
+
+
+@pytest.mark.django_db
+def test_auto_populate_fails_raises_validation_error(service_cluster_controller, user):
+    """When service_id is null and auto-populate fails, a ValidationError is raised."""
+    from django.core.exceptions import ValidationError
+
+    from aap_gateway_api.utils.service_token import validate_service_token
+
+    target_id = str(uuid.uuid4())
+    key = service_cluster_controller.generate_key()
+    token = _create_jwt(user, key, service=target_id)
+
+    with mock.patch("aap_gateway_api.utils.service_token.populate_service_id", return_value=None):
+        with pytest.raises(ValidationError, match="does not exist"):
+            validate_service_token(token)
+
+
+@pytest.mark.django_db
+def test_auto_populate_not_called_when_service_id_set(service_cluster_gateway, user, service_jwt_token):
+    """populate_service_id is never called when the cluster already has a service_id."""
+    client = APIClient(headers={"X-ANSIBLE-SERVICE-AUTH": service_jwt_token})
+    url = get_relative_url("resource-list")
+
+    with mock.patch("aap_gateway_api.utils.service_token.populate_service_id") as mock_pop:
+        resp = client.get(url)
+
+    mock_pop.assert_not_called()
+    assert resp.status_code == 200
 
 
 def test_ca_certificate_with_service_token_auth(service_jwt_client, ca_certificate):

--- a/aap_gateway_api/tests/utils/test_service_id_sync.py
+++ b/aap_gateway_api/tests/utils/test_service_id_sync.py
@@ -5,7 +5,13 @@ from unittest import mock
 import pytest
 
 from aap_gateway_api.models import ServiceCluster
-from aap_gateway_api.utils.service_id_sync import _check_and_set_cooldown, _fetch_service_id_for_route, _populate_cooldown, populate_service_id
+from aap_gateway_api.utils.service_id_sync import (
+    _POPULATE_MAX_COOLDOWN_ENTRIES,
+    _check_and_set_cooldown,
+    _fetch_service_id_for_route,
+    _populate_cooldown,
+    populate_service_id,
+)
 
 MOCK_TARGET = "aap_gateway_api.utils.service_id_sync._fetch_service_id_for_route"
 
@@ -80,19 +86,36 @@ def test_cooldown_hit_returns_true():
 
 
 def test_cooldown_pruning_removes_expired_entries():
-    """When the dict exceeds the cap, expired entries are pruned."""
-    from aap_gateway_api.utils.service_id_sync import _POPULATE_MAX_COOLDOWN_ENTRIES
-
+    """When the dict is at cap with expired entries, they are pruned and the new issuer is admitted."""
     issuer = str(uuid.uuid4())
     original = dict(_populate_cooldown)
     try:
         far_past = time.monotonic() - 120
-        for i in range(_POPULATE_MAX_COOLDOWN_ENTRIES + 1):
+        for i in range(_POPULATE_MAX_COOLDOWN_ENTRIES):
             _populate_cooldown[f"expired-{i}"] = far_past
 
-        _check_and_set_cooldown(issuer)
+        result = _check_and_set_cooldown(issuer)
 
+        assert result is False  # admitted after pruning
         assert all(not k.startswith("expired-") for k in _populate_cooldown)
+    finally:
+        _populate_cooldown.clear()
+        _populate_cooldown.update(original)
+
+
+def test_cooldown_full_of_fresh_entries_blocks_new_issuer():
+    """When the dict is at cap with fresh entries and pruning frees nothing, the issuer is blocked."""
+    issuer = str(uuid.uuid4())
+    original = dict(_populate_cooldown)
+    try:
+        fresh = time.monotonic()
+        for i in range(_POPULATE_MAX_COOLDOWN_ENTRIES):
+            _populate_cooldown[f"fresh-{i}"] = fresh
+
+        result = _check_and_set_cooldown(issuer)
+
+        assert result is True  # blocked — dict still full after pruning attempt
+        assert issuer not in _populate_cooldown
     finally:
         _populate_cooldown.clear()
         _populate_cooldown.update(original)
@@ -193,6 +216,25 @@ def test_populate_normalises_uppercase_issuer(service_cluster_controller, servic
 
     assert isinstance(result, ServiceCluster)
     assert str(result.service_id) == canonical
+
+
+@pytest.mark.django_db
+def test_populate_race_condition_safe(service_cluster_controller, service_api_route_controller):
+    """When update() returns 0 but exists() returns True (concurrent write), cluster is returned."""
+    service_cluster_controller.service_id = None
+    service_cluster_controller.save()
+
+    target_id = str(uuid.uuid4())
+
+    with mock.patch(MOCK_TARGET, return_value=target_id):
+        with mock.patch.object(ServiceCluster.objects, "filter") as mock_filter:
+            mock_qs = mock.MagicMock()
+            mock_qs.update.return_value = 0  # another worker won the race
+            mock_qs.exists.return_value = True  # but the id is now there
+            mock_filter.return_value = mock_qs
+            result = populate_service_id(target_id)
+
+    assert isinstance(result, ServiceCluster)
 
 
 @pytest.mark.django_db

--- a/aap_gateway_api/tests/utils/test_service_id_sync.py
+++ b/aap_gateway_api/tests/utils/test_service_id_sync.py
@@ -1,0 +1,232 @@
+import time
+import uuid
+from unittest import mock
+
+import pytest
+
+from aap_gateway_api.models import ServiceCluster
+from aap_gateway_api.utils.service_id_sync import _check_and_set_cooldown, _fetch_service_id_for_route, _populate_cooldown, populate_service_id
+
+MOCK_TARGET = "aap_gateway_api.utils.service_id_sync._fetch_service_id_for_route"
+
+
+# ---------------------------------------------------------------------------
+# _fetch_service_id_for_route
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_returns_none_on_non_200(service_api_route_controller):
+    """Returns None when the metadata endpoint returns a non-200 status."""
+    resp = mock.Mock()
+    resp.status_code = 500
+
+    with mock.patch("aap_gateway_api.utils.service_id_sync.resources_client.GWResourceAPIClient") as mock_cls:
+        mock_cls.return_value.get_service_metadata.return_value = resp
+        result = _fetch_service_id_for_route(service_api_route_controller)
+
+    assert result is None
+
+
+def test_fetch_returns_none_on_exception(service_api_route_controller):
+    """Returns None when the HTTP call raises an exception."""
+    with mock.patch("aap_gateway_api.utils.service_id_sync.resources_client.GWResourceAPIClient") as mock_cls:
+        mock_cls.return_value.get_service_metadata.side_effect = ConnectionError("boom")
+        result = _fetch_service_id_for_route(service_api_route_controller)
+
+    assert result is None
+
+
+def test_fetch_returns_canonical_uuid(service_api_route_controller):
+    """Returns a canonical lowercase UUID string from a successful metadata response."""
+    raw = str(uuid.uuid4()).upper()
+    resp = mock.Mock()
+    resp.status_code = 200
+    resp.json.return_value = {"service_id": raw}
+
+    with mock.patch("aap_gateway_api.utils.service_id_sync.resources_client.GWResourceAPIClient") as mock_cls:
+        mock_cls.return_value.get_service_metadata.return_value = resp
+        result = _fetch_service_id_for_route(service_api_route_controller)
+
+    assert result == raw.lower()
+
+
+def test_fetch_returns_none_for_invalid_uuid(service_api_route_controller):
+    """Returns None when the metadata endpoint returns a non-UUID service_id."""
+    resp = mock.Mock()
+    resp.status_code = 200
+    resp.json.return_value = {"service_id": "not-a-uuid"}
+
+    with mock.patch("aap_gateway_api.utils.service_id_sync.resources_client.GWResourceAPIClient") as mock_cls:
+        mock_cls.return_value.get_service_metadata.return_value = resp
+        result = _fetch_service_id_for_route(service_api_route_controller)
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _check_and_set_cooldown
+# ---------------------------------------------------------------------------
+
+
+def test_cooldown_hit_returns_true():
+    """Second call with the same issuer within the window returns True (on cooldown)."""
+    issuer = str(uuid.uuid4())
+    _populate_cooldown.pop(issuer, None)
+    try:
+        assert _check_and_set_cooldown(issuer) is False
+        assert _check_and_set_cooldown(issuer) is True
+    finally:
+        _populate_cooldown.pop(issuer, None)
+
+
+def test_cooldown_pruning_removes_expired_entries():
+    """When the dict exceeds the cap, expired entries are pruned."""
+    from aap_gateway_api.utils.service_id_sync import _POPULATE_MAX_COOLDOWN_ENTRIES
+
+    issuer = str(uuid.uuid4())
+    original = dict(_populate_cooldown)
+    try:
+        far_past = time.monotonic() - 120
+        for i in range(_POPULATE_MAX_COOLDOWN_ENTRIES + 1):
+            _populate_cooldown[f"expired-{i}"] = far_past
+
+        _check_and_set_cooldown(issuer)
+
+        assert all(not k.startswith("expired-") for k in _populate_cooldown)
+    finally:
+        _populate_cooldown.clear()
+        _populate_cooldown.update(original)
+
+
+# ---------------------------------------------------------------------------
+# populate_service_id
+# ---------------------------------------------------------------------------
+
+
+def test_populate_returns_none_for_non_uuid():
+    """Returns None immediately when the iss claim is not a valid UUID."""
+    result = populate_service_id("not-a-uuid")
+    assert result is None
+
+
+@pytest.mark.django_db
+def test_populate_returns_none_when_on_cooldown(service_cluster_controller, service_api_route_controller):
+    """Returns None without probing when the issuer is on cooldown."""
+    service_cluster_controller.service_id = None
+    service_cluster_controller.save()
+
+    target_id = str(uuid.uuid4())
+    _populate_cooldown.pop(target_id, None)
+    try:
+        with mock.patch(MOCK_TARGET, return_value=str(uuid.uuid4())):
+            populate_service_id(target_id)  # sets cooldown
+
+        with mock.patch(MOCK_TARGET) as mock_fetch:
+            result = populate_service_id(target_id)
+            mock_fetch.assert_not_called()
+
+        assert result is None
+    finally:
+        _populate_cooldown.pop(target_id, None)
+
+
+@pytest.mark.django_db
+def test_populate_returns_none_when_no_null_clusters(service_cluster_controller, service_api_route_controller):
+    """Returns None when all clusters already have a service_id."""
+    service_cluster_controller.service_id = uuid.uuid4()
+    service_cluster_controller.save()
+
+    result = populate_service_id(str(uuid.uuid4()))
+    assert result is None
+
+
+@pytest.mark.django_db
+def test_populate_returns_none_when_no_route(service_cluster_controller):
+    """Returns None when the null-id cluster has no ServiceAPIRoute."""
+    service_cluster_controller.service_id = None
+    service_cluster_controller.save()
+
+    result = populate_service_id(str(uuid.uuid4()))
+    assert result is None
+
+
+@pytest.mark.django_db
+def test_populate_returns_none_when_id_does_not_match(service_cluster_controller, service_api_route_controller):
+    """Returns None when the fetched service_id does not match the JWT iss claim."""
+    service_cluster_controller.service_id = None
+    service_cluster_controller.save()
+
+    with mock.patch(MOCK_TARGET, return_value=str(uuid.uuid4())):
+        result = populate_service_id(str(uuid.uuid4()))
+
+    assert result is None
+
+
+@pytest.mark.django_db
+def test_populate_returns_cluster_and_writes_id_on_match(service_cluster_controller, service_api_route_controller):
+    """Returns the ServiceCluster and writes service_id when metadata matches the JWT iss."""
+    service_cluster_controller.service_id = None
+    service_cluster_controller.save()
+
+    target_id = str(uuid.uuid4())
+
+    with mock.patch(MOCK_TARGET, return_value=target_id):
+        result = populate_service_id(target_id)
+
+    assert isinstance(result, ServiceCluster)
+    assert str(result.service_id) == target_id
+    service_cluster_controller.refresh_from_db()
+    assert str(service_cluster_controller.service_id) == target_id
+
+
+@pytest.mark.django_db
+def test_populate_normalises_uppercase_issuer(service_cluster_controller, service_api_route_controller):
+    """An uppercase iss claim is normalised and still matches a canonical stored UUID."""
+    service_cluster_controller.service_id = None
+    service_cluster_controller.save()
+
+    canonical = str(uuid.uuid4())
+    uppercase = canonical.upper()
+
+    with mock.patch(MOCK_TARGET, return_value=canonical):
+        result = populate_service_id(uppercase)
+
+    assert isinstance(result, ServiceCluster)
+    assert str(result.service_id) == canonical
+
+
+@pytest.mark.django_db
+def test_populate_swallows_db_exception(service_cluster_controller, service_api_route_controller):
+    """Returns None when the HTTP client raises; never propagates the exception."""
+    service_cluster_controller.service_id = None
+    service_cluster_controller.save()
+
+    target_id = str(uuid.uuid4())
+
+    with mock.patch("aap_gateway_api.utils.service_id_sync.resources_client.GWResourceAPIClient") as mock_cls:
+        mock_cls.return_value.get_service_metadata.side_effect = RuntimeError("network failure")
+        result = populate_service_id(target_id)
+
+    assert result is None
+
+
+@pytest.mark.django_db
+def test_populate_skips_unknown_service_type():
+    """Does not probe clusters whose service type is not in DefaultServiceType."""
+    from aap_gateway_api.models import ServiceCluster, ServiceType
+
+    custom_type, _ = ServiceType.objects.get_or_create(name="custom-unknown-type")
+    custom_cluster = ServiceCluster.objects.create(name="custom-cluster", service_type=custom_type)
+    try:
+        target_id = str(uuid.uuid4())
+        _populate_cooldown.pop(target_id, None)
+        try:
+            with mock.patch(MOCK_TARGET) as mock_fetch:
+                result = populate_service_id(target_id)
+                mock_fetch.assert_not_called()
+            assert result is None
+        finally:
+            _populate_cooldown.pop(target_id, None)
+    finally:
+        custom_cluster.delete()
+        custom_type.delete()

--- a/aap_gateway_api/utils/service_id_sync.py
+++ b/aap_gateway_api/utils/service_id_sync.py
@@ -1,0 +1,152 @@
+import logging
+import time
+import uuid as _uuid_mod
+from typing import Optional
+
+from aap_gateway_api.models import ServiceAPIRoute, ServiceCluster
+from aap_gateway_api.models.service_type import DefaultServiceType
+from aap_gateway_api.utils import resources_client
+
+logger = logging.getLogger('aap.gateway.utils.service_id_sync')
+
+# Per-issuer cooldown for the auth fallback — prevents serial DB+HTTP calls on
+# repeated unknown tokens (e.g. a mis-configured or attacker-supplied JWT).
+_populate_cooldown: dict[str, float] = {}
+_POPULATE_COOLDOWN_SECONDS = 60
+_POPULATE_MAX_COOLDOWN_ENTRIES = 1000
+
+# Cap on how many null-id clusters are probed per unknown-issuer auth request.
+# Bounds the number of outbound HTTP calls on the first request from each issuer.
+_MAX_CLUSTERS_TO_PROBE = 5
+
+# Service types eligible for automatic service_id population on the auth path.
+# Restricting to known DefaultServiceType values (excluding GATEWAY) prevents the
+# fallback from probing custom or unknown service types during token validation.
+_SYNCABLE_TYPES = [e.value for e in DefaultServiceType if e != DefaultServiceType.GATEWAY]
+
+
+def _check_and_set_cooldown(issuer: str) -> bool:
+    """Returns True if issuer is on cooldown (caller should skip), False if ok to proceed.
+
+    Prunes expired entries when the dict exceeds the cap. If the dict is still full after
+    pruning (all entries are fresh), the new issuer is blocked without being added —
+    preventing unbounded growth under a flood of unique attacker-supplied tokens.
+
+    Note: _populate_cooldown is per-process. In a multi-worker deployment each worker
+    maintains its own dict; the DoS bound is per-worker (_MAX_CLUSTERS_TO_PROBE × N workers).
+
+    Args:
+        issuer: The JWT iss claim string used as the cooldown key.
+
+    Returns:
+        True if a recent attempt was made for this issuer (or the dict is full), False otherwise.
+    """
+    now = time.monotonic()
+    if len(_populate_cooldown) > _POPULATE_MAX_COOLDOWN_ENTRIES:
+        cutoff = now - _POPULATE_COOLDOWN_SECONDS
+        expired = [k for k, t in _populate_cooldown.items() if t < cutoff]
+        for k in expired:
+            del _populate_cooldown[k]
+        if len(_populate_cooldown) >= _POPULATE_MAX_COOLDOWN_ENTRIES:
+            # Still full after pruning — all entries are fresh. Refuse without adding
+            # so the dict cannot grow without bound under a flood of unique tokens.
+            return True
+
+    if now - _populate_cooldown.get(issuer, 0) < _POPULATE_COOLDOWN_SECONDS:
+        return True
+
+    _populate_cooldown[issuer] = now
+    return False
+
+
+def _fetch_service_id_for_route(service_api: ServiceAPIRoute, user=None) -> Optional[str]:
+    """Calls the service metadata endpoint and returns a validated service_id string.
+
+    Args:
+        service_api: The ServiceAPIRoute whose upstream to query.
+        user: Optional user for JWT signing. Falls back to the first superuser.
+
+    Returns:
+        A valid UUID string in canonical lowercase form, or None if the fetch failed,
+        returned no id, or returned an invalid value.
+    """
+    try:
+        client = resources_client.GWResourceAPIClient(service_api, user=user)
+        response = client.get_service_metadata()
+        if response.status_code != 200:
+            logger.warning("Metadata fetch for %s returned %s", service_api.api_slug, response.status_code)
+            return None
+
+        raw_id = str(response.json().get("service_id") or "").strip()
+        try:
+            # Parse and re-serialize to normalize to lowercase canonical form so that the
+            # comparison with the JWT iss claim never mismatches due to casing or formatting.
+            return str(_uuid_mod.UUID(raw_id))
+        except ValueError:
+            logger.warning("Invalid service_id value '%s' from %s metadata", raw_id, service_api.api_slug)
+            return None
+    except Exception:
+        logger.exception("Failed to fetch metadata for cluster %s", service_api.service_cluster.name)
+        return None
+
+
+def populate_service_id(unverified_service_id: str) -> Optional[ServiceCluster]:
+    """Finds and populates service_id for a cluster whose metadata matches the given UUID.
+
+    Called during token validation when a ServiceCluster.DoesNotExist is raised — a service
+    registered after migrate_service_data ran (e.g. added in a later upgrade) will have
+    service_id=null on its ServiceCluster. This function probes null-id clusters of known
+    service types to find a match, writes the id, and returns the cluster so the caller
+    can continue authentication without an extra DB round-trip.
+
+    A per-issuer cooldown prevents serial DB+HTTP calls on repeated requests from an
+    unknown or attacker-supplied issuer. At most _MAX_CLUSTERS_TO_PROBE clusters are
+    probed per request to bound outbound HTTP calls. All DB and HTTP operations are wrapped
+    in a broad except so that a transient DB error returns None rather than propagating a
+    500 through the gRPC auth handler.
+
+    Args:
+        unverified_service_id: The UUID string from the JWT's iss claim.
+
+    Returns:
+        The populated ServiceCluster if a matching cluster was found, None otherwise.
+    """
+    # Normalize to canonical lowercase so the cooldown key and comparison are consistent
+    # regardless of how the JWT iss claim was formatted (uppercase, braced, etc.).
+    # An invalid (non-UUID) issuer can never match any cluster — return None immediately.
+    try:
+        canonical_id = str(_uuid_mod.UUID(unverified_service_id))
+    except ValueError:
+        logger.debug("JWT iss claim is not a valid UUID: %s", unverified_service_id)
+        return None
+
+    if _check_and_set_cooldown(canonical_id):
+        logger.debug("Service_id populate skipped for %s (on cooldown)", canonical_id)
+        return None
+
+    try:
+        # Single query: null-id clusters of known service types only, capped to limit HTTP calls.
+        # Restricting to _SYNCABLE_TYPES means the fallback never probes custom or unknown
+        # service types during token validation.
+        api_routes = ServiceAPIRoute.objects.filter(
+            service_cluster__service_id__isnull=True,
+            service_cluster__service_type__name__in=_SYNCABLE_TYPES,
+        ).select_related('service_cluster', 'service_cluster__service_type')[:_MAX_CLUSTERS_TO_PROBE]
+
+        for service_api in api_routes:
+            cluster = service_api.service_cluster
+
+            fetched_id = _fetch_service_id_for_route(service_api)
+            if not fetched_id or fetched_id != canonical_id:
+                continue
+
+            rows = ServiceCluster.objects.filter(pk=cluster.pk, service_id__isnull=True).update(service_id=fetched_id)
+            if rows or ServiceCluster.objects.filter(pk=cluster.pk, service_id=fetched_id).exists():
+                cluster.service_id = fetched_id  # sync in-memory object to avoid extra DB round-trip
+                logger.info("Populated service_id %s for cluster %s", fetched_id, cluster.name)
+                return cluster
+
+    except Exception:
+        logger.exception("Unexpected error during service_id populate for %s", unverified_service_id)
+
+    return None

--- a/aap_gateway_api/utils/service_id_sync.py
+++ b/aap_gateway_api/utils/service_id_sync.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 import time
 import uuid as _uuid_mod
 from typing import Optional
@@ -12,6 +13,7 @@ logger = logging.getLogger('aap.gateway.utils.service_id_sync')
 # Per-issuer cooldown for the auth fallback — prevents serial DB+HTTP calls on
 # repeated unknown tokens (e.g. a mis-configured or attacker-supplied JWT).
 _populate_cooldown: dict[str, float] = {}
+_populate_cooldown_lock = threading.Lock()
 _POPULATE_COOLDOWN_SECONDS = 60
 _POPULATE_MAX_COOLDOWN_ENTRIES = 1000
 
@@ -42,21 +44,22 @@ def _check_and_set_cooldown(issuer: str) -> bool:
         True if a recent attempt was made for this issuer (or the dict is full), False otherwise.
     """
     now = time.monotonic()
-    if len(_populate_cooldown) > _POPULATE_MAX_COOLDOWN_ENTRIES:
-        cutoff = now - _POPULATE_COOLDOWN_SECONDS
-        expired = [k for k, t in _populate_cooldown.items() if t < cutoff]
-        for k in expired:
-            del _populate_cooldown[k]
+    with _populate_cooldown_lock:
         if len(_populate_cooldown) >= _POPULATE_MAX_COOLDOWN_ENTRIES:
-            # Still full after pruning — all entries are fresh. Refuse without adding
-            # so the dict cannot grow without bound under a flood of unique tokens.
+            cutoff = now - _POPULATE_COOLDOWN_SECONDS
+            expired = [k for k, t in _populate_cooldown.items() if t < cutoff]
+            for k in expired:
+                del _populate_cooldown[k]
+            if len(_populate_cooldown) >= _POPULATE_MAX_COOLDOWN_ENTRIES:
+                # Still full after pruning — all entries are fresh. Refuse without adding
+                # so the dict cannot grow without bound under a flood of unique tokens.
+                return True
+
+        if now - _populate_cooldown.get(issuer, 0) < _POPULATE_COOLDOWN_SECONDS:
             return True
 
-    if now - _populate_cooldown.get(issuer, 0) < _POPULATE_COOLDOWN_SECONDS:
-        return True
-
-    _populate_cooldown[issuer] = now
-    return False
+        _populate_cooldown[issuer] = now
+        return False
 
 
 def _fetch_service_id_for_route(service_api: ServiceAPIRoute, user=None) -> Optional[str]:
@@ -128,10 +131,14 @@ def populate_service_id(unverified_service_id: str) -> Optional[ServiceCluster]:
         # Single query: null-id clusters of known service types only, capped to limit HTTP calls.
         # Restricting to _SYNCABLE_TYPES means the fallback never probes custom or unknown
         # service types during token validation.
-        api_routes = ServiceAPIRoute.objects.filter(
-            service_cluster__service_id__isnull=True,
-            service_cluster__service_type__name__in=_SYNCABLE_TYPES,
-        ).select_related('service_cluster', 'service_cluster__service_type')[:_MAX_CLUSTERS_TO_PROBE]
+        api_routes = (
+            ServiceAPIRoute.objects.filter(
+                service_cluster__service_id__isnull=True,
+                service_cluster__service_type__name__in=_SYNCABLE_TYPES,
+            )
+            .order_by('service_cluster__pk')
+            .select_related('service_cluster', 'service_cluster__service_type')[:_MAX_CLUSTERS_TO_PROBE]
+        )
 
         for service_api in api_routes:
             cluster = service_api.service_cluster

--- a/aap_gateway_api/utils/service_id_sync.py
+++ b/aap_gateway_api/utils/service_id_sync.py
@@ -15,14 +15,14 @@ _populate_cooldown: dict[str, float] = {}
 _POPULATE_COOLDOWN_SECONDS = 60
 _POPULATE_MAX_COOLDOWN_ENTRIES = 1000
 
-# Cap on how many null-id clusters are probed per unknown-issuer auth request.
-# Bounds the number of outbound HTTP calls on the first request from each issuer.
-_MAX_CLUSTERS_TO_PROBE = 5
-
 # Service types eligible for automatic service_id population on the auth path.
 # Restricting to known DefaultServiceType values (excluding GATEWAY) prevents the
 # fallback from probing custom or unknown service types during token validation.
 _SYNCABLE_TYPES = [e.value for e in DefaultServiceType if e != DefaultServiceType.GATEWAY]
+
+# The maximum number of null-id clusters we can ever need to probe equals the number of
+# known non-gateway service types — there can be at most one cluster per type.
+_MAX_CLUSTERS_TO_PROBE = len(_SYNCABLE_TYPES)
 
 
 def _check_and_set_cooldown(issuer: str) -> bool:
@@ -33,7 +33,7 @@ def _check_and_set_cooldown(issuer: str) -> bool:
     preventing unbounded growth under a flood of unique attacker-supplied tokens.
 
     Note: _populate_cooldown is per-process. In a multi-worker deployment each worker
-    maintains its own dict; the DoS bound is per-worker (_MAX_CLUSTERS_TO_PROBE × N workers).
+    maintains its own dict; the effective DoS bound is per-worker.
 
     Args:
         issuer: The JWT iss claim string used as the cooldown key.
@@ -100,10 +100,11 @@ def populate_service_id(unverified_service_id: str) -> Optional[ServiceCluster]:
     can continue authentication without an extra DB round-trip.
 
     A per-issuer cooldown prevents serial DB+HTTP calls on repeated requests from an
-    unknown or attacker-supplied issuer. At most _MAX_CLUSTERS_TO_PROBE clusters are
-    probed per request to bound outbound HTTP calls. All DB and HTTP operations are wrapped
-    in a broad except so that a transient DB error returns None rather than propagating a
-    500 through the gRPC auth handler.
+    unknown or attacker-supplied issuer. All eligible null-id clusters are probed in
+    deterministic (pk) order, capped at _MAX_CLUSTERS_TO_PROBE (= len(_SYNCABLE_TYPES)),
+    which is provably sufficient to cover every possible matching cluster.
+    All DB and HTTP operations are wrapped in a broad except so that a transient DB error
+    returns None rather than propagating a 500 through the gRPC auth handler.
 
     Args:
         unverified_service_id: The UUID string from the JWT's iss claim.
@@ -125,9 +126,9 @@ def populate_service_id(unverified_service_id: str) -> Optional[ServiceCluster]:
         return None
 
     try:
-        # Single query: null-id clusters of known service types only, capped to limit HTTP calls.
-        # Restricting to _SYNCABLE_TYPES means the fallback never probes custom or unknown
-        # service types during token validation.
+        # Single query: null-id clusters of known service types, ordered deterministically by pk.
+        # Slicing to _MAX_CLUSTERS_TO_PROBE (= len(_SYNCABLE_TYPES)) guarantees we cover every
+        # possible eligible cluster in one pass — there can be at most one cluster per type.
         api_routes = (
             ServiceAPIRoute.objects.filter(
                 service_cluster__service_id__isnull=True,

--- a/aap_gateway_api/utils/service_id_sync.py
+++ b/aap_gateway_api/utils/service_id_sync.py
@@ -1,5 +1,4 @@
 import logging
-import threading
 import time
 import uuid as _uuid_mod
 from typing import Optional
@@ -13,7 +12,6 @@ logger = logging.getLogger('aap.gateway.utils.service_id_sync')
 # Per-issuer cooldown for the auth fallback — prevents serial DB+HTTP calls on
 # repeated unknown tokens (e.g. a mis-configured or attacker-supplied JWT).
 _populate_cooldown: dict[str, float] = {}
-_populate_cooldown_lock = threading.Lock()
 _POPULATE_COOLDOWN_SECONDS = 60
 _POPULATE_MAX_COOLDOWN_ENTRIES = 1000
 
@@ -44,22 +42,21 @@ def _check_and_set_cooldown(issuer: str) -> bool:
         True if a recent attempt was made for this issuer (or the dict is full), False otherwise.
     """
     now = time.monotonic()
-    with _populate_cooldown_lock:
+    if len(_populate_cooldown) >= _POPULATE_MAX_COOLDOWN_ENTRIES:
+        cutoff = now - _POPULATE_COOLDOWN_SECONDS
+        expired = [k for k, t in _populate_cooldown.items() if t < cutoff]
+        for k in expired:
+            del _populate_cooldown[k]
         if len(_populate_cooldown) >= _POPULATE_MAX_COOLDOWN_ENTRIES:
-            cutoff = now - _POPULATE_COOLDOWN_SECONDS
-            expired = [k for k, t in _populate_cooldown.items() if t < cutoff]
-            for k in expired:
-                del _populate_cooldown[k]
-            if len(_populate_cooldown) >= _POPULATE_MAX_COOLDOWN_ENTRIES:
-                # Still full after pruning — all entries are fresh. Refuse without adding
-                # so the dict cannot grow without bound under a flood of unique tokens.
-                return True
-
-        if now - _populate_cooldown.get(issuer, 0) < _POPULATE_COOLDOWN_SECONDS:
+            # Still full after pruning — all entries are fresh. Refuse without adding
+            # so the dict cannot grow without bound under a flood of unique tokens.
             return True
 
-        _populate_cooldown[issuer] = now
-        return False
+    if now - _populate_cooldown.get(issuer, 0) < _POPULATE_COOLDOWN_SECONDS:
+        return True
+
+    _populate_cooldown[issuer] = now
+    return False
 
 
 def _fetch_service_id_for_route(service_api: ServiceAPIRoute, user=None) -> Optional[str]:

--- a/aap_gateway_api/utils/service_token.py
+++ b/aap_gateway_api/utils/service_token.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import gettext as _
 
 from aap_gateway_api.models import ServiceCluster, ServiceKey, User
+from aap_gateway_api.utils.service_id_sync import populate_service_id
 
 
 class ValidatedToken(TypedDict):
@@ -13,6 +14,63 @@ class ValidatedToken(TypedDict):
     service_cluster: ServiceCluster
     token_data: dict
     key: ServiceKey
+
+
+def _verify_token_signature(token, service_cluster, unverified_service_id):
+    """Loops over the cluster's active keys and verifies the JWT signature.
+
+    Args:
+        token: The raw JWT string.
+        service_cluster: The ServiceCluster whose keys to try.
+        unverified_service_id: The iss claim used to cross-check after verification.
+
+    Returns:
+        Tuple of (verified_payload, full_data, valid_key).
+
+    Raises:
+        ValidationError: If no key validates the token or the iss claim mismatches.
+    """
+    verified_payload = None
+    valid_key = None
+    full_data = None
+
+    for key in service_cluster.service_keys.filter(is_active=True).order_by("-created"):
+        try:
+            full_data = jwt.api_jwt.decode_complete(token, key.secret, algorithms=key.algorithm)
+            verified_payload = full_data["payload"]
+            valid_key = key
+        except jwt.exceptions.PyJWTError:
+            continue
+        # Cross-check the signature-verified iss against the unverified value. Using an explicit
+        # conditional rather than assert so the check cannot be compiled away with -O.
+        if verified_payload["iss"] != unverified_service_id:
+            raise ValidationError(_("Verified token data does not match unverified data."))
+        break
+
+    if verified_payload is None:
+        raise ValidationError(_("Unable to validate JWT token against any keys for %(iss)s.") % {"iss": unverified_service_id})
+
+    return verified_payload, full_data, valid_key
+
+
+def _get_user_from_payload(verified_payload):
+    """Resolves the User from the verified JWT payload.
+
+    Args:
+        verified_payload: The decoded and verified JWT payload dict.
+
+    Returns:
+        The matching User instance.
+
+    Raises:
+        ValidationError: If the sub claim references a non-existent user.
+    """
+    if "sub" in verified_payload:
+        try:
+            return User.objects.get(resource__ansible_id=verified_payload["sub"])
+        except User.DoesNotExist:
+            raise ValidationError(_("Token subject %(sub)s does not exist.") % {'sub': verified_payload['sub']})
+    return User.all_objects.get(username=settings.SYSTEM_USERNAME)
 
 
 def validate_service_token(token, required_type=None) -> ValidatedToken:
@@ -37,35 +95,18 @@ def validate_service_token(token, required_type=None) -> ValidatedToken:
     except jwt.exceptions.PyJWTError as pje:
         raise ValidationError(_("Token is not a valid JWT: %(exception)s") % {"exception": pje})
 
+    # Look up the cluster by the iss claim. If not found, attempt to populate the service_id
+    # for services registered after migrate_service_data ran (e.g. added in a later upgrade).
     try:
         service_cluster = ServiceCluster.objects.get(service_id=unverified_service_id)
-        verified_payload = None
-        valid_key = None
-        full_data = None
-
-        # Loop through the service's active keys until a key is found that matches the
-        # token's signature
-        for key in service_cluster.service_keys.filter(is_active=True).order_by("-created"):
-            try:
-                full_data = jwt.api_jwt.decode_complete(token, key.secret, algorithms=key.algorithm)
-                verified_payload = full_data["payload"]
-                valid_key = key
-
-                # Double check that the signature verified payload matches the unverified
-                # service id.
-                assert verified_payload["iss"] == unverified_service_id
-                break
-
-            except jwt.exceptions.PyJWTError:
-                continue
-            except AssertionError:
-                raise ValidationError(_("Verified token data does not match unverified data."))
-
-        if verified_payload is None:
-            raise ValidationError(_("Unable to validate JWT token against any keys for %(iss)s.") % {"iss": unverified_service_id})
-
     except ServiceCluster.DoesNotExist:
-        raise ValidationError(_("Token issuer %(iss)s does not exist.") % {'iss': unverified_service_id})
+        # populate_service_id never raises — safe to call on the hot auth path.
+        # Returns the cluster directly so we avoid a second DB round-trip.
+        service_cluster = populate_service_id(str(unverified_service_id))
+        if service_cluster is None:
+            raise ValidationError(_("Token issuer %(iss)s does not exist.") % {'iss': unverified_service_id})
+
+    verified_payload, full_data, valid_key = _verify_token_signature(token, service_cluster, unverified_service_id)
 
     token_type = full_data["payload"].get("type", None)
     if required_type != token_type:
@@ -73,18 +114,9 @@ def validate_service_token(token, required_type=None) -> ValidatedToken:
             _("Expected token of type %(required_type)s, but got token of type %(token_type)s") % {"required_type": required_type, "token_type": token_type}
         )
 
-    # Check that the user requested in the "sub" claim exists.
-    if "sub" in verified_payload:
-        try:
-            user = User.objects.get(resource__ansible_id=verified_payload["sub"])
-        except User.DoesNotExist:
-            raise ValidationError(_("Token subject %(sub)s does not exist.") % {'sub': verified_payload['sub']})
-    else:
-        user = User.all_objects.get(username=settings.SYSTEM_USERNAME)
-
     return ValidatedToken(
         {
-            "user": user,
+            "user": _get_user_from_payload(verified_payload),
             "service_cluster": service_cluster,
             "token_data": full_data,
             "key": valid_key,


### PR DESCRIPTION
## Problem

`migrate_service_data` uses a global completion flag. On the first upgrade (2.5→2.6) it runs, writes `service_id` onto each `ServiceCluster`, and marks itself done. On all subsequent upgrades it exits immediately. New services introduced in later releases (e.g. metrics-service in 2.7) are left with `service_id=null`, causing every JWT auth attempt from those services to fail with a 403.

## Solution

When `validate_service_token()` raises `ServiceCluster.DoesNotExist`, a new `populate_service_id()` function is called before rejecting the token. It probes null-id clusters of known service types to find one whose metadata matches the JWT `iss` claim, writes the `service_id`, and returns the cluster — all in the same request that would otherwise have 403'd. Subsequent requests take the normal fast path.

**Key design properties:**

- Restricted to known `DefaultServiceType` values (excluding GATEWAY) — unknown or custom service types are never probed
- Per-issuer 60-second cooldown prevents repeated DB+HTTP calls from unknown or attacker-supplied tokens; dict is bounded at 1000 entries
- At most 5 clusters probed per request to cap outbound HTTP calls
- JWT `iss` normalised to canonical lowercase UUID before matching — prevents case/format mismatches
- All DB and HTTP operations wrapped in `except Exception` — never raises, returns `None` on failure, auth path continues cleanly
- One-time self-healing: once `service_id` is written, every subsequent request finds the cluster normally

## What changed

| File | Change |
|------|--------|
| `aap_gateway_api/utils/service_id_sync.py` | New module — `populate_service_id()` and supporting helpers |
| `aap_gateway_api/utils/service_token.py` | Call `populate_service_id()` on `DoesNotExist`; extract `_verify_token_signature` + `_get_user_from_payload` helpers; replace `assert` with explicit conditional |
| `aap_gateway_api/tests/utils/test_service_id_sync.py` | New utility tests |
| `aap_gateway_api/tests/authentication/test_service_token_auth.py` | Auto-populate path tests + `classify_backend`, `required_type` mismatch, iss mismatch coverage |

No changes to `migrate_service_data`, service orchestration, model migrations, or management commands.

## Verified in aap-dev (AAP 2.7)

Deployed against a live AAP 2.7 cluster with metrics-service running. Nulled metrics-service `service_id`, sent a real service JWT — gateway auto-populated the `service_id` from the metrics metadata endpoint and returned **HTTP 200** on the first request.

## AI Assistance
This change was developed with assistance from Claude Code (Claude Sonnet 4.6).
All generated code was reviewed, tested, and validated before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Service-token authentication can now automatically resolve and populate missing service IDs using issuer data and service metadata.
  - Added rate-limited, safe service-metadata lookup behavior during token validation.
- **Bug Fixes**
  - Improved validation behavior with clearer errors for invalid signatures, issuer mismatches, and required token-type mismatches.
  - Normalizes service IDs consistently, including uppercase UUID inputs.
  - Handles concurrent updates more reliably when populating service IDs.
- **Tests**
  - Added extensive coverage for authentication validation, service-ID synchronization, cooldown/race conditions, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->