### PR TITLE
[AAP-82119] Batch resource migration using bulk-update endpoint

### DIFF
--- a/aap_gateway_api/management/commands/_migrate_service_data/resource_migration.py
+++ b/aap_gateway_api/management/commands/_migrate_service_data/resource_migration.py
@@ -1,9 +1,10 @@
 import logging
+import time
 from typing import Any, Dict, List, Optional, Tuple
 
+import requests
 from ansible_base.resource_registry.constants import SHARED_USER_RESOURCE_TYPE
 from ansible_base.resource_registry.models import Resource, service_id
-from ansible_base.resource_registry.rest_client import ResourceRequestBody
 from django.conf import settings
 from django.db import transaction
 
@@ -95,7 +96,7 @@ class ResourceMigrationMixin:
     def _initialize_resource_sync_payloads(self, upstream_resource: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         """Prepare payloads for creating Gateway resources and updating upstream resources."""
         resource_creation_kwargs = {"ansible_id": upstream_resource["ansible_id"]}
-        updated_service_resource = {"service_id": str(service_id())}
+        updated_service_resource = {"new_service_id": str(service_id())}
         return resource_creation_kwargs, updated_service_resource
 
     def _reconcile_existing_resource(
@@ -149,7 +150,7 @@ class ResourceMigrationMixin:
         # so this will correct the service_id and possibly update the stale resource_data
         if str(existing_resource.ansible_id) == resource_ansible_id:
             create_gateway_resource = False
-            updated_service_resource["service_id"] = existing_resource.service_id
+            updated_service_resource["new_service_id"] = str(existing_resource.service_id)
 
             if incoming_data == local_data:
                 self._log(f"Correcting service_id of {resource_type.name} with name {upstream_resource['name']}.", logging.INFO)
@@ -203,55 +204,179 @@ class ResourceMigrationMixin:
             results = [res for res in results if res['name'] != settings.SYSTEM_USERNAME]
         return results, data['count']
 
-    def _process_and_migrate_resource_item(self, upstream_resource_item: Dict[str, Any], resource_context: Dict[str, Any]) -> None:
-        """
-        Process and migrate a single resource item from upstream to Gateway.
+    @staticmethod
+    def _build_bulk_update_item(resource_ansible_id: str, updated_service_resource: Dict[str, Any]) -> Dict[str, Any]:
+        """Build a single bulk-update payload item from the reconciled service resource fields."""
+        bulk_item: Dict[str, Any] = {"ansible_id": resource_ansible_id}
+        if "new_service_id" in updated_service_resource:
+            bulk_item["new_service_id"] = updated_service_resource["new_service_id"]
+        if "is_partially_migrated" in updated_service_resource:
+            bulk_item["is_partially_migrated"] = updated_service_resource["is_partially_migrated"]
+        if "ansible_id" in updated_service_resource:
+            bulk_item["new_ansible_id"] = str(updated_service_resource["ansible_id"])
+        if "resource_data" in updated_service_resource:
+            bulk_item["resource_data"] = updated_service_resource["resource_data"]
+        return bulk_item
 
-        This method handles the complete migration workflow for a single resource:
-        1. Fetch detailed resource data from upstream
-        2. Validate and prepare resource data
-        3. Handle conflicts with existing resources
-        4. Create/update Gateway resource and upstream resource atomically
+    MAX_BULK_CHUNK_SIZE = 1000
+    MAX_TRANSIENT_RETRIES = 3
+    TRANSIENT_STATUS_CODES = {502, 503, 504}
+
+    def _send_bulk_update(self, bulk_update_items: List[Dict[str, Any]]) -> int:
+        """Send bulk update to upstream and return the number of successfully updated items.
+
+        Items are chunked to respect the upstream MAX_BULK_SIZE limit (1000).
+        Transient HTTP errors (502/503/504, network errors) are retried with
+        exponential backoff. Permanent errors (4xx) fail immediately.
+        Per-item errors from successful responses are logged as warnings.
+        """
+        total_updated = 0
+        for i in range(0, len(bulk_update_items), self.MAX_BULK_CHUNK_SIZE):
+            chunk = bulk_update_items[i : i + self.MAX_BULK_CHUNK_SIZE]
+            updated = self._send_bulk_update_chunk(chunk)
+            total_updated += updated
+        return total_updated
+
+    _RETRY_SENTINEL = object()
+
+    def _should_retry(self, attempt: int, reason: str, detail: str) -> bool:
+        """Decide whether to retry a transient error, logging appropriately.
+
+        Returns True if the caller should retry (sleep already performed),
+        False if retries are exhausted (error already logged).
+        """
+        if attempt < self.MAX_TRANSIENT_RETRIES - 1:
+            wait = 2**attempt
+            self._log(
+                f"Bulk update {reason} (attempt {attempt + 1}/{self.MAX_TRANSIENT_RETRIES}): {detail}. Retrying in {wait}s.",
+                logging.WARNING,
+            )
+            time.sleep(wait)
+            return True
+        self._log(
+            f"Bulk update failed after {self.MAX_TRANSIENT_RETRIES} attempts — {reason}: {detail}",
+            logging.ERROR,
+        )
+        return False
+
+    def _try_bulk_update_once(self, chunk: List[Dict[str, Any]], attempt: int):
+        """Execute one bulk-update attempt.
+
+        Returns the parsed response dict on success, _RETRY_SENTINEL if a
+        transient error occurred and retries remain, or 0 if the request
+        failed permanently.
+        """
+        try:
+            resp = self.client.bulk_update_resources(chunk)
+        except requests.exceptions.RequestException as exc:
+            if self._should_retry(attempt, "network error", str(exc)):
+                return self._RETRY_SENTINEL
+            return 0
+
+        if resp.status_code in self.TRANSIENT_STATUS_CODES:
+            if self._should_retry(attempt, f"HTTP {resp.status_code}", resp.text[:500]):
+                return self._RETRY_SENTINEL
+            return 0
+
+        if resp.status_code != 200:
+            self._log(
+                f"Bulk update returned HTTP {resp.status_code} (permanent error, will not retry). Response: {resp.text[:500]}",
+                logging.ERROR,
+            )
+            return 0
+
+        try:
+            return resp.json()
+        except ValueError:
+            if self._should_retry(attempt, "non-JSON response", resp.text[:500]):
+                return self._RETRY_SENTINEL
+            return 0
+
+    def _send_bulk_update_chunk(self, chunk: List[Dict[str, Any]]) -> int:
+        """Send a single chunk of bulk update items with retry logic for transient errors."""
+        for attempt in range(self.MAX_TRANSIENT_RETRIES):
+            result = self._try_bulk_update_once(chunk, attempt)
+            if result is self._RETRY_SENTINEL:
+                continue
+            if result == 0:
+                return 0
+            return self._process_bulk_response(result)
+        return 0
+
+    def _process_bulk_response(self, resp_data: Dict[str, Any]) -> int:
+        """Extract the updated count from a successful bulk-update response, logging per-item errors."""
+        for err in resp_data.get("errors") or []:
+            self._log(
+                f"Bulk-update per-item failure for {err.get('ansible_id')}: {err.get('error')}",
+                logging.WARNING,
+            )
+        return resp_data.get("updated", 0)
+
+    def _process_resource_page_batch(self, results: List[Dict[str, Any]], resource_context: Dict[str, Any]) -> int:
+        """
+        Process and migrate a batch of resource items from a single API page.
+
+        Follows the same pattern as role assignments: validates all items,
+        performs bulk local writes, then sends a single bulk HTTP call to
+        update upstream. Per-item failures are logged as warnings rather than
+        aborting the entire page — failed items will reappear on the next
+        iteration since their service_id/is_partially_migrated was not updated.
 
         Args:
-            upstream_resource_item: Basic resource data from upstream service list
-            resource_context: Static data about the resource type and migration settings
+            results: List of resource items from the upstream service API page
+            resource_context: Static data about the resource type
 
-        Note:
-            All operations are wrapped in a database transaction to ensure
-            consistency between Gateway and upstream service updates.
+        Returns:
+            Number of items successfully processed in this batch
         """
-        resource_ansible_id = upstream_resource_item["ansible_id"]
         resource_type = resource_context["type"]
+        bulk_update_items = []
+        create_operations = []
 
-        if "resource_data" not in upstream_resource_item:
-            raise RuntimeError(
-                f"Resource {resource_ansible_id} is missing 'resource_data'. Ensure all services are running a version of DAB that supports extra_fields."
-            )
+        # NOTE: If any item fails validation, the entire page is aborted via exception.
+        # Validation failures indicate systemic issues (incompatible DAB version, corrupt
+        # data) rather than per-item corruption, so halting is the correct behavior.
+        for upstream_resource_item in results:
+            resource_ansible_id = upstream_resource_item["ansible_id"]
 
-        upstream_resource = upstream_resource_item
+            if "resource_data" not in upstream_resource_item:
+                raise RuntimeError(
+                    f"Resource {resource_ansible_id} is missing 'resource_data'. Ensure all services are running a version of DAB that supports extra_fields."
+                )
 
-        validated_resource_data = self._deserialize_and_validate_resource_data(upstream_resource, resource_context["type_serializer"])
-
-        # Sync superuser flags for user resources
-        if resource_context["type_name"] == SHARED_USER_RESOURCE_TYPE:
-            upstream_resource = self._sync_user_superuser_flag(upstream_resource, validated_resource_data)
-            # Re-validate after potential superuser flag changes
+            upstream_resource = upstream_resource_item
             validated_resource_data = self._deserialize_and_validate_resource_data(upstream_resource, resource_context["type_serializer"])
 
-        resource_creation_kwargs, updated_service_resource = self._initialize_resource_sync_payloads(upstream_resource)
+            if resource_context["type_name"] == SHARED_USER_RESOURCE_TYPE:
+                upstream_resource = self._sync_user_superuser_flag(upstream_resource, validated_resource_data)
+                validated_resource_data = self._deserialize_and_validate_resource_data(upstream_resource, resource_context["type_serializer"])
 
-        # handles case with existing resource and figure out if we should create a new resource in gateway or not
-        create_gateway_resource = self._reconcile_existing_resource(upstream_resource, resource_context, validated_resource_data, updated_service_resource)
+            resource_creation_kwargs, updated_service_resource = self._initialize_resource_sync_payloads(upstream_resource)
+            create_gateway_resource = self._reconcile_existing_resource(upstream_resource, resource_context, validated_resource_data, updated_service_resource)
 
-        # Run this as a transaction so that if the REST call to update the resource on the service fails
-        # we also rollback any database changes that were made on the gateway.
-        with transaction.atomic():
-            # determine the resource to use in Gateway
             if create_gateway_resource:
-                Resource.create_resource(resource_type, upstream_resource["resource_data"], **resource_creation_kwargs)
+                create_operations.append((resource_type, upstream_resource["resource_data"], resource_creation_kwargs))
 
-            self.client.update_resource(resource_ansible_id, ResourceRequestBody(**updated_service_resource), partial=True)
+            bulk_update_items.append(self._build_bulk_update_item(resource_ansible_id, updated_service_resource))
+
+        # Create gateway resources locally. If a resource already exists (e.g. from a
+        # previous interrupted run), the reconcile logic above will have set
+        # create_gateway_resource=False, so duplicates are safe.
+        # NOTE: Local creates are committed BEFORE the bulk update is sent.
+        # If the bulk update fails, local resources persist but upstream is not
+        # updated. This is safe because _reconcile_existing_resource detects
+        # existing resources on retry, and the upstream filter naturally retries
+        # unmigrated items.
+        with transaction.atomic():
+            for rt, resource_data, creation_kwargs in create_operations:
+                Resource.create_resource(rt, resource_data, **creation_kwargs)
+
+        # Send bulk update to upstream service.
+        if bulk_update_items:
+            return self._send_bulk_update(bulk_update_items)
+
+        # No items to update upstream (results was empty or all filtered out).
+        return 0
 
     def migrate_resource(self, resource_type_name: str) -> None:
         """
@@ -313,6 +438,8 @@ class ResourceMigrationMixin:
 
         resource_total = None
         resource_processed = 0
+        consecutive_zero_progress = 0
+        max_zero_progress_pages = 3
         progress_label = f"{self.client.service.api_slug} {resource_type_name} resources"
 
         # Following 'while True' loop is used because we are modifying the list as we go through it.
@@ -328,7 +455,20 @@ class ResourceMigrationMixin:
                 self._log("No more items remaining to migrate.", logging.INFO)
                 break
 
-            for upstream_resource_item in results:
-                resource_processed += 1
-                self._log_progress(progress_label, resource_processed, resource_total)
-                self._process_and_migrate_resource_item(upstream_resource_item, resource_context)
+            batch_size = self._process_resource_page_batch(results, resource_context)
+            if batch_size == 0:
+                consecutive_zero_progress += 1
+                if consecutive_zero_progress >= max_zero_progress_pages:
+                    raise RuntimeError(
+                        f"Migration stalled: {max_zero_progress_pages} consecutive pages made no forward progress. Check upstream service availability."
+                    )
+            else:
+                consecutive_zero_progress = 0
+
+            resource_processed += batch_size
+            if batch_size < len(results):
+                self._log(
+                    f"Only {batch_size}/{len(results)} items updated upstream. Failed items remain unmigrated and will reappear on the next page fetch.",
+                    logging.WARNING,
+                )
+            self._log_progress(progress_label, resource_processed, resource_total)

--- a/aap_gateway_api/tests/management/commands/_migrate_service_data/test_resource_migration.py
+++ b/aap_gateway_api/tests/management/commands/_migrate_service_data/test_resource_migration.py
@@ -1,7 +1,7 @@
 """Tests for ResourceMigrationMixin: migrate_conflicting_user, merge_users,
 correcting_user_service_id, migrating_user_with_invalid_email,
 updating_resource_data_for_invalid_resource,
-process_migrate_resource_item_*, reconcile_existing_resource_*.
+process_resource_page_batch_*, reconcile_existing_resource_*.
 """
 
 from io import StringIO
@@ -165,14 +165,267 @@ def test_updating_resource_data_for_invalid_resource(migration_service_invalid_u
 
 
 @pytest.mark.django_db
-def test_process_migrate_resource_item_raises_on_missing_resource_data():
-    """Test that _process_and_migrate_resource_item raises when resource_data is missing."""
+def test_process_resource_page_batch_raises_on_missing_resource_data():
+    """Test that _process_resource_page_batch raises when resource_data is missing."""
     cmd = MigrateCommand()
-    resource_item = {"ansible_id": "test-id-123", "name": "test"}
+    results = [{"ansible_id": "test-id-456", "name": "test"}]
     resource_context = {"type": Mock()}
 
     with pytest.raises(RuntimeError, match="missing 'resource_data'"):
-        cmd._process_and_migrate_resource_item(resource_item, resource_context)
+        cmd._process_resource_page_batch(results, resource_context)
+
+
+@pytest.mark.django_db
+def test_process_resource_page_batch_bulk_update():
+    """Test that _process_resource_page_batch calls bulk_update_resources with correct payloads."""
+    import uuid
+
+    from ansible_base.resource_registry.models import ResourceType
+
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+    cmd.upstream_service_id = str(uuid.uuid4())
+
+    mock_client = Mock()
+    mock_client.service.service_cluster.service_type.name = "awx"
+    mock_resp = Mock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"updated": 2, "errors": []}
+    mock_client.bulk_update_resources.return_value = mock_resp
+    cmd.client = mock_client
+
+    Organization.objects.create(name="BatchOrg1")
+
+    org_resource_type = ResourceType.objects.get(name="shared.organization")
+    resource_context = {
+        "type": org_resource_type,
+        "type_name": "shared.organization",
+        "type_serializer": org_resource_type.serializer_class,
+        "type_name_field": org_resource_type.get_resource_config().name_field,
+        "unique_fields": ["name"],
+        "LocalResourceModel": Organization,
+    }
+
+    batch_org_id = str(uuid.uuid4())
+    new_org_id = str(uuid.uuid4())
+    results = [
+        {
+            "ansible_id": batch_org_id,
+            "name": "BatchOrg1",
+            "resource_type": "shared.organization",
+            "resource_data": {"name": "BatchOrg1"},
+        },
+        {
+            "ansible_id": new_org_id,
+            "name": "NewOrg",
+            "resource_type": "shared.organization",
+            "resource_data": {"name": "NewOrg"},
+        },
+    ]
+
+    count = cmd._process_resource_page_batch(results, resource_context)
+    # Returns the "updated" count from the bulk response
+    assert count == 2
+
+    mock_client.bulk_update_resources.assert_called_once()
+    bulk_items = mock_client.bulk_update_resources.call_args[0][0]
+    assert len(bulk_items) == 2
+    assert all("ansible_id" in item for item in bulk_items)
+    # The first item (BatchOrg1 exists) triggers reconcile which sets ansible_id and resource_data
+    merged_item = bulk_items[0]
+    assert "new_ansible_id" in merged_item
+    assert "resource_data" in merged_item
+    # The second item (NewOrg is new) only gets new_service_id
+    new_item = bulk_items[1]
+    assert "new_service_id" in new_item
+
+
+@pytest.mark.django_db
+def test_process_resource_page_batch_with_partially_migrated():
+    """Test that is_partially_migrated is included in bulk payload when set."""
+    import uuid
+    from unittest.mock import patch as mock_patch
+
+    from ansible_base.resource_registry.models import ResourceType
+
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+    cmd.upstream_service_id = str(uuid.uuid4())
+
+    mock_client = Mock()
+    mock_client.service.service_cluster.service_type.name = "awx"
+    mock_resp = Mock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"updated": 1, "errors": []}
+    mock_client.bulk_update_resources.return_value = mock_resp
+    cmd.client = mock_client
+
+    org_resource_type = ResourceType.objects.get(name="shared.organization")
+    resource_context = {
+        "type": org_resource_type,
+        "type_name": "shared.organization",
+        "type_serializer": org_resource_type.serializer_class,
+        "type_name_field": org_resource_type.get_resource_config().name_field,
+        "unique_fields": ["name"],
+        "LocalResourceModel": Organization,
+    }
+
+    results = [
+        {
+            "ansible_id": str(uuid.uuid4()),
+            "name": "PartialOrg",
+            "resource_type": "shared.organization",
+            "resource_data": {"name": "PartialOrg"},
+        },
+    ]
+
+    # Mock _reconcile_existing_resource to inject is_partially_migrated
+    def mock_reconcile(upstream_resource, ctx, validated_data, updated_service_resource):
+        updated_service_resource["is_partially_migrated"] = True
+        return True
+
+    with mock_patch.object(cmd, "_reconcile_existing_resource", side_effect=mock_reconcile):
+        count = cmd._process_resource_page_batch(results, resource_context)
+
+    assert count == 1
+    bulk_items = mock_client.bulk_update_resources.call_args[0][0]
+    assert bulk_items[0]["is_partially_migrated"] is True
+
+
+@pytest.mark.django_db
+def test_process_resource_page_batch_graceful_on_bulk_failure():
+    """Test that bulk update HTTP failure is non-fatal and returns 0 (items will be retried)."""
+    import uuid
+
+    from ansible_base.resource_registry.models import ResourceType
+
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+    cmd.upstream_service_id = str(uuid.uuid4())
+
+    mock_client = Mock()
+    mock_client.service.service_cluster.service_type.name = "awx"
+    mock_resp = Mock()
+    mock_resp.status_code = 500
+    mock_resp.text = "Internal Server Error"
+    mock_client.bulk_update_resources.return_value = mock_resp
+    cmd.client = mock_client
+
+    org_resource_type = ResourceType.objects.get(name="shared.organization")
+    resource_context = {
+        "type": org_resource_type,
+        "type_name": "shared.organization",
+        "type_serializer": org_resource_type.serializer_class,
+        "type_name_field": org_resource_type.get_resource_config().name_field,
+        "unique_fields": ["name"],
+        "LocalResourceModel": Organization,
+    }
+
+    results = [
+        {
+            "ansible_id": str(uuid.uuid4()),
+            "name": "RetryOrg",
+            "resource_type": "shared.organization",
+            "resource_data": {"name": "RetryOrg"},
+        },
+    ]
+
+    # Bulk failure is non-fatal: returns 0 and logs warning (items retry next iteration)
+    count = cmd._process_resource_page_batch(results, resource_context)
+    assert count == 0
+
+    # Local gateway resource was still created (will be reconciled on retry)
+    assert Organization.objects.filter(name="RetryOrg").exists()
+
+
+@pytest.mark.django_db
+def test_process_resource_page_batch_partial_errors():
+    """Test that per-item errors from bulk update are logged as warnings."""
+    import uuid
+
+    from ansible_base.resource_registry.models import ResourceType
+
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+    cmd.upstream_service_id = str(uuid.uuid4())
+
+    mock_client = Mock()
+    mock_client.service.service_cluster.service_type.name = "awx"
+    mock_resp = Mock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "updated": 1,
+        "errors": [{"ansible_id": "some-id", "error": "Resource not found."}],
+    }
+    mock_client.bulk_update_resources.return_value = mock_resp
+    cmd.client = mock_client
+
+    Organization.objects.create(name="PartialErrOrg")
+
+    org_resource_type = ResourceType.objects.get(name="shared.organization")
+    resource_context = {
+        "type": org_resource_type,
+        "type_name": "shared.organization",
+        "type_serializer": org_resource_type.serializer_class,
+        "type_name_field": org_resource_type.get_resource_config().name_field,
+        "unique_fields": ["name"],
+        "LocalResourceModel": Organization,
+    }
+
+    results = [
+        {
+            "ansible_id": str(uuid.uuid4()),
+            "name": "PartialErrOrg",
+            "resource_type": "shared.organization",
+            "resource_data": {"name": "PartialErrOrg"},
+        },
+        {
+            "ansible_id": str(uuid.uuid4()),
+            "name": "NewPartialOrg",
+            "resource_type": "shared.organization",
+            "resource_data": {"name": "NewPartialOrg"},
+        },
+    ]
+
+    count = cmd._process_resource_page_batch(results, resource_context)
+    # Only 1 updated (the other had an error on upstream side)
+    assert count == 1
+    # Warning was logged for the failed item
+    output = cmd.stderr.getvalue()
+    assert "per-item failure" in output
+
+
+def test_build_bulk_update_item_all_fields():
+    """Test that _build_bulk_update_item includes all present fields."""
+    import uuid
+
+    cmd = MigrateCommand()
+    ansible_id = str(uuid.uuid4())
+    new_ansible_id = uuid.uuid4()
+    updated_service_resource = {
+        "new_service_id": "svc-123",
+        "is_partially_migrated": True,
+        "ansible_id": new_ansible_id,
+        "resource_data": {"username": "test"},
+    }
+
+    result = cmd._build_bulk_update_item(ansible_id, updated_service_resource)
+    assert result["ansible_id"] == ansible_id
+    assert result["new_service_id"] == "svc-123"
+    assert result["is_partially_migrated"] is True
+    assert result["new_ansible_id"] == str(new_ansible_id)
+    assert result["resource_data"] == {"username": "test"}
+
+
+def test_build_bulk_update_item_minimal():
+    """Test that _build_bulk_update_item only includes ansible_id when no updates."""
+    cmd = MigrateCommand()
+    result = cmd._build_bulk_update_item("some-id", {})
+    assert result == {"ansible_id": "some-id"}
 
 
 @pytest.mark.django_db
@@ -333,7 +586,7 @@ def test_initialize_resource_sync_payloads():
         creation_kwargs, service_resource = cmd._initialize_resource_sync_payloads(upstream_resource)
 
     assert creation_kwargs == {"ansible_id": "test-aid-100"}
-    assert service_resource == {"service_id": "gw-service-id-42"}
+    assert service_resource == {"new_service_id": "gw-service-id-42"}
 
 
 def test_get_filtered_resources_excludes_system_user():
@@ -394,3 +647,243 @@ def test_get_filtered_resources_non_user_type():
     assert len(results) == 2
     assert results[0]["name"] == "Org1"
     assert results[1]["name"] == "Org2"
+
+
+@pytest.mark.django_db
+@patch("aap_gateway_api.management.commands._migrate_service_data.resource_migration.time.sleep")
+def test_send_bulk_update_network_error(mock_sleep):
+    """Network exceptions in _send_bulk_update are retried then return 0."""
+    import requests as req
+
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+
+    cmd.client = Mock()
+    cmd.client.bulk_update_resources.side_effect = req.exceptions.ConnectionError("Connection refused")
+    cmd.client.service.service_cluster.service_type.name = "awx"
+
+    count = cmd._send_bulk_update([{"ansible_id": "test-id", "new_service_id": "svc-id"}])
+    assert count == 0
+    assert "network error" in cmd.stderr.getvalue()
+    assert cmd.client.bulk_update_resources.call_count == cmd.MAX_TRANSIENT_RETRIES
+
+
+@pytest.mark.django_db
+@patch("aap_gateway_api.management.commands._migrate_service_data.resource_migration.time.sleep")
+def test_send_bulk_update_invalid_json_response(mock_sleep):
+    """Non-JSON response body in _send_bulk_update is retried then returns 0."""
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+
+    mock_resp = Mock()
+    mock_resp.status_code = 200
+    mock_resp.json.side_effect = ValueError("No JSON object could be decoded")
+    mock_resp.text = "<html>Bad Gateway</html>"
+
+    cmd.client = Mock()
+    cmd.client.bulk_update_resources.return_value = mock_resp
+    cmd.client.service.service_cluster.service_type.name = "awx"
+
+    count = cmd._send_bulk_update([{"ansible_id": "test-id", "new_service_id": "svc-id"}])
+    assert count == 0
+    assert "non-JSON response" in cmd.stderr.getvalue()
+    assert cmd.client.bulk_update_resources.call_count == cmd.MAX_TRANSIENT_RETRIES
+
+
+@pytest.mark.django_db
+def test_send_bulk_update_permanent_error():
+    """4xx errors (permanent) are not retried and return 0."""
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+
+    mock_resp = Mock()
+    mock_resp.status_code = 400
+    mock_resp.text = '{"detail": "Bad request"}'
+
+    cmd.client = Mock()
+    cmd.client.bulk_update_resources.return_value = mock_resp
+    cmd.client.service.service_cluster.service_type.name = "awx"
+
+    count = cmd._send_bulk_update([{"ansible_id": "test-id", "new_service_id": "svc-id"}])
+    assert count == 0
+    assert "permanent error" in cmd.stderr.getvalue()
+    assert cmd.client.bulk_update_resources.call_count == 1
+
+
+@pytest.mark.django_db
+@patch("aap_gateway_api.management.commands._migrate_service_data.resource_migration.time.sleep")
+def test_send_bulk_update_transient_then_success(mock_sleep):
+    """Transient 502 followed by success returns the updated count."""
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+
+    transient_resp = Mock()
+    transient_resp.status_code = 502
+    transient_resp.text = "Bad Gateway"
+
+    success_resp = Mock()
+    success_resp.status_code = 200
+    success_resp.json.return_value = {"updated": 5, "errors": []}
+
+    cmd.client = Mock()
+    cmd.client.bulk_update_resources.side_effect = [transient_resp, success_resp]
+    cmd.client.service.service_cluster.service_type.name = "awx"
+
+    count = cmd._send_bulk_update([{"ansible_id": "test-id", "new_service_id": "svc-id"}])
+    assert count == 5
+    assert cmd.client.bulk_update_resources.call_count == 2
+
+
+@pytest.mark.django_db
+def test_send_bulk_update_chunks_large_batches():
+    """Items exceeding MAX_BULK_CHUNK_SIZE are sent in multiple chunks."""
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+
+    success_resp = Mock()
+    success_resp.status_code = 200
+    success_resp.json.return_value = {"updated": 1000, "errors": []}
+
+    cmd.client = Mock()
+    cmd.client.bulk_update_resources.return_value = success_resp
+    cmd.client.service.service_cluster.service_type.name = "awx"
+
+    items = [{"ansible_id": f"id-{i}", "new_service_id": "svc"} for i in range(2500)]
+    count = cmd._send_bulk_update(items)
+    assert count == 3000  # 1000 * 3 chunks
+    assert cmd.client.bulk_update_resources.call_count == 3
+
+
+@pytest.mark.django_db
+@patch("aap_gateway_api.management.commands._migrate_service_data.resource_migration.time.sleep")
+def test_send_bulk_update_transient_http_exhaustion(mock_sleep):
+    """Transient HTTP status (502) exhausting all retries returns 0."""
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+
+    transient_resp = Mock()
+    transient_resp.status_code = 502
+    transient_resp.text = "Bad Gateway"
+
+    cmd.client = Mock()
+    cmd.client.bulk_update_resources.return_value = transient_resp
+    cmd.client.service.service_cluster.service_type.name = "awx"
+
+    count = cmd._send_bulk_update([{"ansible_id": "test-id", "new_service_id": "svc-id"}])
+    assert count == 0
+    assert "failed after" in cmd.stderr.getvalue()
+    assert cmd.client.bulk_update_resources.call_count == cmd.MAX_TRANSIENT_RETRIES
+
+
+@pytest.mark.django_db
+def test_send_bulk_update_per_item_errors():
+    """Per-item errors in the bulk update response are logged as warnings."""
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+
+    mock_resp = Mock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "updated": 2,
+        "errors": [
+            {"ansible_id": "bad-id-1", "error": "Resource not found"},
+            {"ansible_id": "bad-id-2", "error": "Invalid service_id"},
+        ],
+    }
+
+    cmd.client = Mock()
+    cmd.client.bulk_update_resources.return_value = mock_resp
+    cmd.client.service.service_cluster.service_type.name = "awx"
+
+    count = cmd._send_bulk_update([{"ansible_id": "test-id", "new_service_id": "svc-id"}])
+    assert count == 2
+    stderr_output = cmd.stderr.getvalue()
+    assert "per-item failure" in stderr_output
+    assert "bad-id-1" in stderr_output
+    assert "bad-id-2" in stderr_output
+
+
+@pytest.mark.django_db
+def test_migrate_resource_partial_batch_warning():
+    """Partial batch success logs a warning about failed items."""
+    import uuid
+
+    from ansible_base.resource_registry.models import ResourceType
+
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+    cmd.upstream_service_id = str(uuid.uuid4())
+    cmd.RESOURCE_DATA_FILTERS = {"extra_fields": "resource_data"}
+    cmd._progress_thresholds = {}
+
+    org_resource_type = ResourceType.objects.get(name="shared.organization")
+    cmd.resource_types_to_migrate = {
+        "shared.organization": {
+            "type": org_resource_type,
+            "unique_fields": ["name"],
+        }
+    }
+
+    mock_client = Mock()
+    mock_client.service.api_slug = "controller"
+    cmd.client = mock_client
+
+    call_count = [0]
+
+    def mock_batch(results, resource_context):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return 3  # partial: only 3 of 5 succeeded
+        return 0  # subsequent: trigger circuit breaker exit
+
+    with patch.object(cmd, "_get_filtered_resources") as mock_get, patch.object(cmd, "_process_resource_page_batch", side_effect=mock_batch):
+        mock_get.return_value = ([{"ansible_id": f"a{i}"} for i in range(5)], 5)
+
+        with pytest.raises(RuntimeError, match="Migration stalled"):
+            cmd.migrate_resource("shared.organization")
+
+    stderr_output = cmd.stderr.getvalue()
+    assert "Only 3/5 items updated upstream" in stderr_output
+
+
+@pytest.mark.django_db
+def test_migrate_resource_circuit_breaker():
+    """Migration raises RuntimeError after consecutive zero-progress pages."""
+    import uuid
+
+    from ansible_base.resource_registry.models import ResourceType
+
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+    cmd.upstream_service_id = str(uuid.uuid4())
+    cmd.RESOURCE_DATA_FILTERS = {"extra_fields": "resource_data"}
+    cmd._progress_thresholds = {}
+
+    org_resource_type = ResourceType.objects.get(name="shared.organization")
+    cmd.resource_types_to_migrate = {
+        "shared.organization": {
+            "type": org_resource_type,
+            "unique_fields": ["name"],
+        }
+    }
+
+    mock_client = Mock()
+    mock_client.service.api_slug = "controller"
+    cmd.client = mock_client
+
+    # Simulate a page that always returns items but bulk update always fails
+    with patch.object(cmd, "_get_filtered_resources") as mock_get, patch.object(cmd, "_process_resource_page_batch") as mock_batch:
+        mock_get.return_value = ([{"ansible_id": "a1"}], 1)
+        mock_batch.return_value = 0
+
+        with pytest.raises(RuntimeError, match="Migration stalled"):
+            cmd.migrate_resource("shared.organization")

--- a/aap_gateway_api/utils/resources_client.py
+++ b/aap_gateway_api/utils/resources_client.py
@@ -35,6 +35,15 @@ class GWResourceAPIClient(DABResourceAPIClient):
             return get_user_model().objects.first()
         return user
 
+    def bulk_update_resources(self, items: list[dict]):
+        """
+        Bulk-update multiple resources in a single HTTP request.
+
+        Each item must contain 'ansible_id' and one or more fields to update:
+        service_id, new_ansible_id, is_partially_migrated, resource_data.
+        """
+        return self._make_request("post", "resources/bulk-update/", data={"items": items})
+
     def get_url_for_service(self, service):
         http_port = service.http_port
         protocol = "https" if http_port.use_https else "http"


### PR DESCRIPTION
Requires: https://github.com/ansible/django-ansible-base/pull/1054

## Description

- **What:** Refactor `migrate_resource()` to process entire API pages as batches instead of one item at a time, using the new DAB bulk-update endpoint.
- **Why:** Each resource triggers an individual HTTP PATCH to the upstream controller. For 3,962 users this means 3,962 sequential round-trips taking 203s (3.4 min). Role assignments (119,721 items) already use bulk optimization and take only 51s.
- **How:** New `_process_resource_page_batch()` method validates all items on the page, reconciles conflicts, bulk-creates gateway resources in a single transaction, then sends one `bulk_update_resources()` HTTP call per page.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites

- Full AAP environment with controller service running
- DAB must include the bulk-update endpoint (PR: https://github.com/ansible/django-ansible-base/pull/1054)

### Steps to Test

1. Deploy with both PRs merged
2. Run `manage.py migrate_service_data --username admin`
3. Verify resource migration (users, orgs, teams) completes successfully
4. At Kyndryl scale (~4k users, ~2k teams, ~130 orgs): total resource migration should complete under 2 minutes

### Expected Results

- Resources migrate correctly (same behavior as before)
- HTTP round-trips reduced from N (one per resource) to N/page_size (one per page)
- Transaction rollback on bulk-update failure (no partial state)
- Progress logging still reports per-page progress

## Additional Context

### Required Actions

- [x] Blocked by PR/MR: https://github.com/ansible/django-ansible-base/pull/1054
  - DAB bulk-update endpoint must be merged first

### Performance Impact

| Metric | Before | After |
|--------|--------|-------|
| HTTP calls (3,962 users) | 3,962 | ~80 (page_size=50) |
| HTTP calls (2,288 teams) | 2,288 | ~46 |
| Projected user migration time | 203s | <10s |
| Projected total resource migration | ~7 min | <2 min |

---
**Note:** This PR was developed with assistance from Claude AI assistant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bulk upstream resource updates during migration to reduce per-item API calls.
  * Improved migration flow with page/batch processing, configurable chunking, transient-error retries, and reconciliation-aware payloads.
  * Added stall detection to abort runs after repeated zero progress.
  * Added warnings when some upstream items fail to update while still progressing.

* **Bug Fixes**
  * Updated upstream migration payloads to use the `new_service_id` field name.

* **Tests**
  * Expanded unit coverage for batch processing, bulk update retries/error handling, payload generation, and stalled-migration circuit breakers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->