### PR TITLE
[AAP-79732] Add performance scaling tests for claims processing

### DIFF
--- a/aap_gateway_api/tests/authentication/test_claims_perf.py
+++ b/aap_gateway_api/tests/authentication/test_claims_perf.py
@@ -1,0 +1,211 @@
+"""Performance scaling tests for claims processing (AAP-79732).
+
+Background
+----------
+AAP-79732 fixed a critical bug where SAML/OIDC login took 60-120+ seconds
+with 300+ authenticator maps. The root cause was _process_user_value()
+evaluating every user attribute value against every map trigger in a nested
+loop, producing O(n×m) iterations — each with a DEBUG log line costing ~5ms
+of I/O in production.
+
+The fix has two parts:
+  1. "in" operator: replaced the per-value loop with a set intersection.
+     Complexity went from O(n×m) to O(n+m), and logging from O(n) per map
+     to O(1) per map (one summary line).
+  2. Scalar operators (equals, contains, ends_with, matches): added early
+     exit on first match (or join) / first mismatch (and join), so the loop
+     stops as soon as the result is determined.
+
+What these tests catch
+----------------------
+- A regression that reintroduces per-value iteration in the "in" operator.
+- A regression that removes early exit from scalar operators.
+- Any future change that adds hidden O(n) or O(n²) work (e.g. expensive
+  per-value computation that doesn't emit log lines).
+
+Why two metrics
+---------------
+Each test class uses two complementary metrics:
+
+  Log line count (deterministic):
+    Proves structural O(1) logging — the number of log lines emitted must
+    not grow with input size. This is the primary signal: fully deterministic,
+    never flaky, and directly tests the optimization's core invariant.
+
+  Elapsed time ratio (empirical):
+    Catches performance regressions that don't manifest as extra log lines —
+    for example, an expensive computation added inside the loop that doesn't
+    log. TESTING.md (§274-295) discourages absolute wall-clock thresholds
+    because they are hardware-dependent and flaky on loaded CI runners.
+    These tests use RELATIVE time ratios instead: run the same function at
+    two scales and compare the ratio. A slow CI runner is slow for both
+    measurements, so the ratio stays stable. This technique is consistent
+    with the ratio approach described in TESTING.md and used in
+    test_role_assignments_perf.py.
+"""
+
+import hashlib
+import logging
+import time
+
+from ansible_base.authentication.utils import claims
+
+_CLAIMS_LOGGER = 'ansible_base.authentication.utils.claims'
+
+# Deterministic group names at two scales.
+# 33 groups matches the scale observed in the production SAML responses that
+# triggered AAP-79732. 330 groups is the 10x scale used for ratio comparison.
+_GROUPS_33 = [f"group-{hashlib.sha256(f'seed-{i}'.encode()).hexdigest()[:16]}" for i in range(33)]
+_GROUPS_330 = [f"group-{hashlib.sha256(f'seed-{i}'.encode()).hexdigest()[:16]}" for i in range(330)]
+
+# Number of iterations per timing measurement to smooth out noise.
+_TIMING_ITERATIONS = 500
+
+
+def _count_log_records(caplog, func, *args, **kwargs):
+    """Run func and return (result, log_record_count) for the claims logger."""
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger=_CLAIMS_LOGGER):
+        result = func(*args, **kwargs)
+    count = len([r for r in caplog.records if r.name == _CLAIMS_LOGGER])
+    return result, count
+
+
+def _measure_time(func, *args, iterations=_TIMING_ITERATIONS, **kwargs):
+    """Run func `iterations` times and return total elapsed seconds."""
+    start = time.perf_counter()
+    for _ in range(iterations):
+        func(*args, **kwargs)
+    return time.perf_counter() - start
+
+
+class TestInOperatorScaling:
+    """Verify the "in" operator evaluates in O(n+m) time with O(1) logging.
+
+    The set-based implementation builds two sets (user values and trigger values)
+    and intersects them. This is O(n+m) in the number of values — some linear
+    scaling with input size is expected and acceptable. What we are guarding
+    against is a regression to the OLD O(n×m) behavior where each user value
+    was checked individually against the trigger list in a nested loop, with a
+    per-iteration log line.
+
+    Concretely, for 33 vs 330 user groups (10x increase):
+      - O(n+m) (current): time scales ~7-8x, log count stays at 1
+      - O(n×m) (regression): time scales ~100x, log count scales 10x
+    """
+
+    def _run_in(self, user_groups):
+        tc = {'groups': {'in': ['nonexistent_trigger']}}
+        return claims._process_user_value(None, tc, user_groups, 'or', 'groups', 1, 'perf')
+
+    def test_log_count_constant_as_user_values_grow(self, caplog):
+        """The "in" operator must emit exactly 1 summary log line per map
+        evaluation, regardless of how many user values are checked.
+
+        Before the fix, 33 groups produced 33 log lines per map, and 330
+        groups produced 330 log lines — each costing ~5ms of I/O in
+        production. The fix replaces this with a single summary line.
+        """
+        _, logs_33 = _count_log_records(caplog, self._run_in, _GROUPS_33)
+        _, logs_330 = _count_log_records(caplog, self._run_in, _GROUPS_330)
+
+        assert logs_33 == 1, f"Expected 1 log line for 33 groups, got {logs_33}"
+        assert logs_330 == 1, f"Expected 1 log line for 330 groups, got {logs_330}"
+
+    def test_elapsed_time_linear_as_user_values_grow(self):
+        """Elapsed time must scale at most linearly (O(n+m)), not quadratically.
+
+        The set-based "in" operator constructs two sets and intersects them,
+        which is O(n+m). For a 10x increase in user values (33 → 330), we
+        expect roughly linear time growth (~7-8x observed in practice due to
+        set construction overhead, which is acceptable).
+
+        What would FAIL this test: a regression to the old per-value loop
+        where each of n user values was compared individually against m
+        trigger values, producing O(n×m) iterations. With 10x more user
+        values, the old code would scale 10x in iterations PLUS 10x in log
+        I/O, easily exceeding the 10x threshold.
+
+        The threshold of < 10.0x is deliberately generous to avoid CI flakiness
+        while still catching quadratic regressions. Observed ratios are ~7-8x.
+        """
+        time_33 = _measure_time(self._run_in, _GROUPS_33)
+        time_330 = _measure_time(self._run_in, _GROUPS_330)
+
+        ratio = time_330 / max(time_33, 1e-9)
+        assert ratio < 10.0, (
+            f"Time scaled {ratio:.1f}x for 10x user values — expected <10.0x (at most linear). "
+            f"Super-linear scaling suggests a regression to per-value iteration. "
+            f"33 groups: {time_33:.4f}s, 330 groups: {time_330:.4f}s "
+            f"({_TIMING_ITERATIONS} iterations each)"
+        )
+
+
+class TestScalarOperatorEarlyExitScaling:
+    """Verify scalar operators exit early and don't scan values past the match.
+
+    For operators like equals, contains, ends_with, and matches with an "or"
+    join condition, the loop should break on the first matching value. This
+    means the number of values AFTER the match point is irrelevant — a list
+    of 10 values and a list of 100 values with the match at the same position
+    should produce identical work.
+
+    Concretely, with a match at position 3:
+      - With early exit (current): evaluates exactly 4 values (0, 1, 2, 3)
+      - Without early exit (regression): evaluates all 10 or all 100 values
+    """
+
+    def _make_values_with_match_at(self, match_position, total):
+        """Build a value list where 'target' appears at match_position (0-indexed), rest are misses."""
+        values = [f"miss-{i}" for i in range(total)]
+        values[match_position] = "target"
+        return values
+
+    def _run_equals(self, values):
+        tc = {'attr': {'equals': 'target'}}
+        return claims._process_user_value(None, tc, values, 'or', 'attr', 1, 'perf')
+
+    def test_log_count_constant_with_early_exit(self, caplog):
+        """Log count must depend on match position, not total list length.
+
+        With the match at position 3, exactly 4 values are evaluated (indices
+        0, 1, 2, 3) producing 4 log lines — regardless of whether the list
+        has 10 or 100 elements. The remaining elements are never touched.
+
+        A regression that removes the early exit break would produce 10 log
+        lines for the short list and 100 for the long list.
+        """
+        values_10 = self._make_values_with_match_at(3, 10)
+        values_100 = self._make_values_with_match_at(3, 100)
+
+        _, logs_10 = _count_log_records(caplog, self._run_equals, values_10)
+        _, logs_100 = _count_log_records(caplog, self._run_equals, values_100)
+
+        assert logs_10 == 4, f"Expected 4 log lines (match at pos 3) for 10 values, got {logs_10}"
+        assert logs_100 == 4, f"Expected 4 log lines (match at pos 3) for 100 values, got {logs_100}"
+        assert logs_10 == logs_100, f"Early exit should make log count independent of list size: 10 values={logs_10}, 100 values={logs_100}"
+
+    def test_elapsed_time_constant_with_early_exit(self):
+        """Elapsed time must not grow when values are added after the match point.
+
+        With the match at position 3, the loop breaks after evaluating 4 values.
+        Adding 90 more values after the match point (10 → 100 total) should
+        have zero effect on execution time because those values are never reached.
+
+        The threshold of < 2.0x is tight because this truly IS O(1) — the work
+        done is identical regardless of list length. Any ratio above 2.0x would
+        indicate the loop is not actually breaking on match.
+        """
+        values_10 = self._make_values_with_match_at(3, 10)
+        values_100 = self._make_values_with_match_at(3, 100)
+
+        time_10 = _measure_time(self._run_equals, values_10)
+        time_100 = _measure_time(self._run_equals, values_100)
+
+        ratio = time_100 / max(time_10, 1e-9)
+        assert ratio < 2.0, (
+            f"Time scaled {ratio:.1f}x for 10x list size — expected <2.0x with early exit at position 3. "
+            f"The extra 90 values after the match should never be evaluated. "
+            f"10 values: {time_10:.4f}s, 100 values: {time_100:.4f}s "
+            f"({_TIMING_ITERATIONS} iterations each)"
+        )

--- a/aap_gateway_api/tests/authentication/test_claims_perf.py
+++ b/aap_gateway_api/tests/authentication/test_claims_perf.py
@@ -47,6 +47,7 @@ import hashlib
 import logging
 import time
 
+import pytest
 from ansible_base.authentication.utils import claims
 
 _CLAIMS_LOGGER = 'ansible_base.authentication.utils.claims'
@@ -133,6 +134,18 @@ class TestInOperatorScaling:
         )
 
 
+# Parametrized data for scalar operator early-exit tests.
+# Each tuple: (operator_key, trigger_value, matching_user_value)
+# The matching value is placed at position 3 in the value list; all other
+# values are non-matching "miss-N" strings that don't satisfy any operator.
+_SCALAR_OPERATOR_CASES = [
+    ("equals", "target", "target"),
+    ("contains", "target", "has-target-inside"),
+    ("ends_with", "@target.com", "user@target.com"),
+    ("matches", r"^admin-.*", "admin-group-1"),
+]
+
+
 class TestScalarOperatorEarlyExitScaling:
     """Verify scalar operators exit early and don't scan values past the decision point.
 
@@ -143,63 +156,61 @@ class TestScalarOperatorEarlyExitScaling:
     See module docstring for background on the early-exit optimization.
     """
 
-    def _make_values_with_match_at(self, match_position, total):
-        """Build a value list where 'target' appears at match_position (0-indexed), rest are misses."""
-        values = [f"miss-{i}" for i in range(total)]
-        values[match_position] = "target"
-        return values
+    @pytest.mark.parametrize(
+        "operator,trigger_value,matching_value",
+        _SCALAR_OPERATOR_CASES,
+        ids=[c[0] for c in _SCALAR_OPERATOR_CASES],
+    )
+    def test_log_count_constant_or_join(self, caplog, operator, trigger_value, matching_value):
+        """With or join, log count depends on match position, not list length.
 
-    def _make_values_with_mismatch_at(self, mismatch_position, total):
-        """Build a value list where all values match except at mismatch_position."""
-        values = ["target"] * total
-        values[mismatch_position] = "miss"
-        return values
+        The match is placed at position 3. With early exit, exactly 4 values
+        are evaluated (indices 0, 1, 2, 3) regardless of total list size.
+        """
+        for total in (10, 100):
+            values = [f"miss-{i}" for i in range(total)]
+            values[3] = matching_value
+            tc = {'attr': {operator: trigger_value}}
 
-    # --- equals operator ---
+            result, logs = _count_log_records(caplog, claims._process_user_value, None, tc, values, 'or', 'attr', 1, 'perf')
 
-    def _run_equals(self, values, join_condition='or'):
-        tc = {'attr': {'equals': 'target'}}
-        return claims._process_user_value(None, tc, values, join_condition, 'attr', 1, 'perf')
+            assert result is True, f"{operator}: expected True for {total} values"
+            assert logs == 4, f"{operator}: expected 4 log lines (match at pos 3) for {total} values, got {logs}"
 
-    def test_equals_log_count_constant_or_join(self, caplog):
-        """With or join, log count depends on match position, not list length."""
-        values_10 = self._make_values_with_match_at(3, 10)
-        values_100 = self._make_values_with_match_at(3, 100)
+    def test_log_count_constant_and_join(self, caplog):
+        """With and join, log count depends on mismatch position, not list length.
 
-        result_10, logs_10 = _count_log_records(caplog, self._run_equals, values_10)
-        result_100, logs_100 = _count_log_records(caplog, self._run_equals, values_100)
+        All values are "target" except at position 3. With early exit on first
+        mismatch, exactly 4 values are evaluated regardless of total list size.
+        """
+        for total in (10, 100):
+            values = ["target"] * total
+            values[3] = "miss"
+            tc = {'attr': {'equals': 'target'}}
 
-        assert result_10 is True
-        assert result_100 is True
-        assert logs_10 == 4, f"Expected 4 log lines (match at pos 3) for 10 values, got {logs_10}"
-        assert logs_100 == 4, f"Expected 4 log lines (match at pos 3) for 100 values, got {logs_100}"
-        assert logs_10 == logs_100, f"Early exit should make log count independent of list size: 10 values={logs_10}, 100 values={logs_100}"
+            result, logs = _count_log_records(caplog, claims._process_user_value, None, tc, values, 'and', 'attr', 1, 'perf')
 
-    def test_equals_log_count_constant_and_join(self, caplog):
-        """With and join, log count depends on mismatch position, not list length."""
-        values_10 = self._make_values_with_mismatch_at(3, 10)
-        values_100 = self._make_values_with_mismatch_at(3, 100)
+            assert result is False, f"Expected False for {total} values"
+            assert logs == 4, f"Expected 4 log lines (mismatch at pos 3) for {total} values, got {logs}"
 
-        result_10, logs_10 = _count_log_records(caplog, self._run_equals, values_10, join_condition='and')
-        result_100, logs_100 = _count_log_records(caplog, self._run_equals, values_100, join_condition='and')
-
-        assert result_10 is False
-        assert result_100 is False
-        assert logs_10 == 4, f"Expected 4 log lines (mismatch at pos 3) for 10 values, got {logs_10}"
-        assert logs_100 == 4, f"Expected 4 log lines (mismatch at pos 3) for 100 values, got {logs_100}"
-        assert logs_10 == logs_100, f"Early exit should make log count independent of list size: 10 values={logs_10}, 100 values={logs_100}"
-
-    def test_equals_elapsed_time_constant_or_join(self):
+    def test_elapsed_time_constant_or_join(self):
         """With or join and early exit, trailing values should not affect time.
 
-        The threshold of < 2.0x is tight because with early exit the work
-        is identical regardless of list length.
+        Uses the equals operator as a representative case. The threshold of
+        < 2.0x is tight because with early exit the work is identical
+        regardless of list length.
         """
-        values_10 = self._make_values_with_match_at(3, 10)
-        values_100 = self._make_values_with_match_at(3, 100)
+        values_10 = [f"miss-{i}" for i in range(10)]
+        values_10[3] = "target"
+        values_100 = [f"miss-{i}" for i in range(100)]
+        values_100[3] = "target"
 
-        time_10 = _measure_time(self._run_equals, values_10)
-        time_100 = _measure_time(self._run_equals, values_100)
+        def run(values):
+            tc = {'attr': {'equals': 'target'}}
+            return claims._process_user_value(None, tc, values, 'or', 'attr', 1, 'perf')
+
+        time_10 = _measure_time(run, values_10)
+        time_100 = _measure_time(run, values_100)
 
         ratio = time_100 / max(time_10, 1e-9)
         assert ratio < 2.0, (
@@ -207,64 +218,3 @@ class TestScalarOperatorEarlyExitScaling:
             f"10 values: {time_10:.4f}s, 100 values: {time_100:.4f}s "
             f"({_TIMING_ITERATIONS} iterations each)"
         )
-
-    # --- contains operator ---
-
-    def test_contains_log_count_constant_or_join(self, caplog):
-        """Contains operator must also exit early on first match."""
-        values_10 = [f"miss-{i}" for i in range(10)]
-        values_10[3] = "has-target-inside"
-        values_100 = [f"miss-{i}" for i in range(100)]
-        values_100[3] = "has-target-inside"
-
-        tc = {'attr': {'contains': 'target'}}
-
-        result_10, logs_10 = _count_log_records(caplog, claims._process_user_value, None, tc, values_10, 'or', 'attr', 1, 'perf')
-        result_100, logs_100 = _count_log_records(caplog, claims._process_user_value, None, tc, values_100, 'or', 'attr', 1, 'perf')
-
-        assert result_10 is True
-        assert result_100 is True
-        assert logs_10 == 4, f"Expected 4 log lines for contains, got {logs_10}"
-        assert logs_100 == 4, f"Expected 4 log lines for contains, got {logs_100}"
-
-    # --- ends_with operator ---
-
-    def test_ends_with_log_count_constant_or_join(self, caplog):
-        """ends_with operator must also exit early on first match."""
-        values_10 = [f"miss-{i}" for i in range(10)]
-        values_10[3] = "user@target.com"
-        values_100 = [f"miss-{i}" for i in range(100)]
-        values_100[3] = "user@target.com"
-
-        tc = {'attr': {'ends_with': '@target.com'}}
-
-        result_10, logs_10 = _count_log_records(caplog, claims._process_user_value, None, tc, values_10, 'or', 'attr', 1, 'perf')
-        result_100, logs_100 = _count_log_records(caplog, claims._process_user_value, None, tc, values_100, 'or', 'attr', 1, 'perf')
-
-        assert result_10 is True
-        assert result_100 is True
-        assert logs_10 == 4, f"Expected 4 log lines for ends_with, got {logs_10}"
-        assert logs_100 == 4, f"Expected 4 log lines for ends_with, got {logs_100}"
-
-    # --- matches (regex) operator ---
-
-    def test_matches_log_count_constant_or_join(self, caplog):
-        """matches (regex) operator must also exit early on first match.
-
-        Regex has different performance characteristics than string comparison
-        (re.match() compilation per call), so it gets its own test.
-        """
-        values_10 = [f"miss-{i}" for i in range(10)]
-        values_10[3] = "admin-group-1"
-        values_100 = [f"miss-{i}" for i in range(100)]
-        values_100[3] = "admin-group-1"
-
-        tc = {'attr': {'matches': r'^admin-.*'}}
-
-        result_10, logs_10 = _count_log_records(caplog, claims._process_user_value, None, tc, values_10, 'or', 'attr', 1, 'perf')
-        result_100, logs_100 = _count_log_records(caplog, claims._process_user_value, None, tc, values_100, 'or', 'attr', 1, 'perf')
-
-        assert result_10 is True
-        assert result_100 is True
-        assert logs_10 == 4, f"Expected 4 log lines for matches, got {logs_10}"
-        assert logs_100 == 4, f"Expected 4 log lines for matches, got {logs_100}"

--- a/aap_gateway_api/tests/authentication/test_claims_perf.py
+++ b/aap_gateway_api/tests/authentication/test_claims_perf.py
@@ -5,8 +5,8 @@ Background
 AAP-79732 fixed a critical bug where SAML/OIDC login took 60-120+ seconds
 with 300+ authenticator maps. The root cause was _process_user_value()
 evaluating every user attribute value against every map trigger in a nested
-loop, producing O(n×m) iterations — each with a DEBUG log line costing ~5ms
-of I/O in production.
+loop, producing O(n×m) iterations — each with a DEBUG log line that added
+significant I/O overhead in production.
 
 The fix has two parts:
   1. "in" operator: replaced the per-value loop with a set intersection.
@@ -18,10 +18,11 @@ The fix has two parts:
 
 What these tests catch
 ----------------------
-- A regression that reintroduces per-value iteration in the "in" operator.
-- A regression that removes early exit from scalar operators.
-- Any future change that adds hidden O(n) or O(n²) work (e.g. expensive
-  per-value computation that doesn't emit log lines).
+- A regression that reintroduces per-value logging in the "in" operator.
+- A regression that removes early exit from scalar operators (both or/and
+  join conditions).
+- Any future change that adds hidden expensive work (e.g. per-value
+  computation that doesn't emit log lines).
 
 Why two metrics
 ---------------
@@ -35,13 +36,11 @@ Each test class uses two complementary metrics:
   Elapsed time ratio (empirical):
     Catches performance regressions that don't manifest as extra log lines —
     for example, an expensive computation added inside the loop that doesn't
-    log. TESTING.md (§274-295) discourages absolute wall-clock thresholds
-    because they are hardware-dependent and flaky on loaded CI runners.
-    These tests use RELATIVE time ratios instead: run the same function at
-    two scales and compare the ratio. A slow CI runner is slow for both
-    measurements, so the ratio stays stable. This technique is consistent
-    with the ratio approach described in TESTING.md and used in
-    test_role_assignments_perf.py.
+    log. TESTING.md's "Performance Tests (Perf)" section recommends relative
+    comparison at two scales for query counts and memory; these tests extend
+    that same ratio technique to elapsed time. By comparing ratios rather
+    than absolute thresholds, the measurements stay hardware-independent —
+    a slow CI runner is slow for both scales, so the ratio is stable.
 """
 
 import hashlib
@@ -55,6 +54,8 @@ _CLAIMS_LOGGER = 'ansible_base.authentication.utils.claims'
 # Deterministic group names at two scales.
 # 33 groups matches the scale observed in the production SAML responses that
 # triggered AAP-79732. 330 groups is the 10x scale used for ratio comparison.
+# In production, each authenticator map typically has a single trigger value
+# (one SAML group name), so the trigger list uses m=1 to mirror that scenario.
 _GROUPS_33 = [f"group-{hashlib.sha256(f'seed-{i}'.encode()).hexdigest()[:16]}" for i in range(33)]
 _GROUPS_330 = [f"group-{hashlib.sha256(f'seed-{i}'.encode()).hexdigest()[:16]}" for i in range(330)]
 
@@ -80,18 +81,18 @@ def _measure_time(func, *args, iterations=_TIMING_ITERATIONS, **kwargs):
 
 
 class TestInOperatorScaling:
-    """Verify the "in" operator evaluates in O(n+m) time with O(1) logging.
+    """Verify the "in" operator evaluates with O(1) logging per map.
 
-    The set-based implementation builds two sets (user values and trigger values)
-    and intersects them. This is O(n+m) in the number of values — some linear
-    scaling with input size is expected and acceptable. What we are guarding
-    against is a regression to the OLD O(n×m) behavior where each user value
-    was checked individually against the trigger list in a nested loop, with a
-    per-iteration log line.
+    The set-based implementation builds two sets and intersects them. The
+    computation is O(n+m), so some linear time scaling with input size is
+    expected. The critical invariant is that logging is O(1) per evaluation
+    (one summary line), not O(n) per user value as in the old code.
 
-    Concretely, for 33 vs 330 user groups (10x increase):
-      - O(n+m) (current): time scales ~7-8x, log count stays at 1
-      - O(n×m) (regression): time scales ~100x, log count scales 10x
+    The trigger list uses m=1 to match the production scenario where each
+    authenticator map checks membership in a single SAML/OIDC group. With
+    m=1, the timing test catches regressions worse than O(n) (e.g. accidental
+    O(n²) sorting or per-value overhead) but cannot distinguish O(n×m) from
+    O(n+m) — the log-count test is the primary guard for that.
     """
 
     def _run_in(self, user_groups):
@@ -99,35 +100,26 @@ class TestInOperatorScaling:
         return claims._process_user_value(None, tc, user_groups, 'or', 'groups', 1, 'perf')
 
     def test_log_count_constant_as_user_values_grow(self, caplog):
-        """The "in" operator must emit exactly 1 summary log line per map
-        evaluation, regardless of how many user values are checked.
+        """O(1) logging: exactly 1 summary log line regardless of user value count.
 
-        Before the fix, 33 groups produced 33 log lines per map, and 330
-        groups produced 330 log lines — each costing ~5ms of I/O in
-        production. The fix replaces this with a single summary line.
+        See module docstring for background on the per-value logging regression
+        this test guards against.
         """
-        _, logs_33 = _count_log_records(caplog, self._run_in, _GROUPS_33)
-        _, logs_330 = _count_log_records(caplog, self._run_in, _GROUPS_330)
+        result_33, logs_33 = _count_log_records(caplog, self._run_in, _GROUPS_33)
+        result_330, logs_330 = _count_log_records(caplog, self._run_in, _GROUPS_330)
 
+        assert result_33 is False
+        assert result_330 is False
         assert logs_33 == 1, f"Expected 1 log line for 33 groups, got {logs_33}"
         assert logs_330 == 1, f"Expected 1 log line for 330 groups, got {logs_330}"
 
     def test_elapsed_time_linear_as_user_values_grow(self):
-        """Elapsed time must scale at most linearly (O(n+m)), not quadratically.
+        """Time must scale at most linearly with user value count.
 
-        The set-based "in" operator constructs two sets and intersects them,
-        which is O(n+m). For a 10x increase in user values (33 → 330), we
-        expect roughly linear time growth (~7-8x observed in practice due to
-        set construction overhead, which is acceptable).
-
-        What would FAIL this test: a regression to the old per-value loop
-        where each of n user values was compared individually against m
-        trigger values, producing O(n×m) iterations. With 10x more user
-        values, the old code would scale 10x in iterations PLUS 10x in log
-        I/O, easily exceeding the 10x threshold.
-
-        The threshold of < 10.0x is deliberately generous to avoid CI flakiness
-        while still catching quadratic regressions. Observed ratios are ~7-8x.
+        The set construction is O(n), so linear growth is expected. The
+        threshold of < 10.0x for a 10x input increase is deliberately generous
+        to avoid CI flakiness while catching super-linear regressions (e.g.
+        per-value overhead reintroduced inside the loop).
         """
         time_33 = _measure_time(self._run_in, _GROUPS_33)
         time_330 = _measure_time(self._run_in, _GROUPS_330)
@@ -135,24 +127,20 @@ class TestInOperatorScaling:
         ratio = time_330 / max(time_33, 1e-9)
         assert ratio < 10.0, (
             f"Time scaled {ratio:.1f}x for 10x user values — expected <10.0x (at most linear). "
-            f"Super-linear scaling suggests a regression to per-value iteration. "
+            f"Super-linear scaling suggests per-value overhead was reintroduced. "
             f"33 groups: {time_33:.4f}s, 330 groups: {time_330:.4f}s "
             f"({_TIMING_ITERATIONS} iterations each)"
         )
 
 
 class TestScalarOperatorEarlyExitScaling:
-    """Verify scalar operators exit early and don't scan values past the match.
+    """Verify scalar operators exit early and don't scan values past the decision point.
 
-    For operators like equals, contains, ends_with, and matches with an "or"
-    join condition, the loop should break on the first matching value. This
-    means the number of values AFTER the match point is irrelevant — a list
-    of 10 values and a list of 100 values with the match at the same position
-    should produce identical work.
+    With an "or" join, the loop should break on the first matching value.
+    With an "and" join, the loop should break on the first mismatching value.
+    In both cases, the number of values after the decision point is irrelevant.
 
-    Concretely, with a match at position 3:
-      - With early exit (current): evaluates exactly 4 values (0, 1, 2, 3)
-      - Without early exit (regression): evaluates all 10 or all 100 values
+    See module docstring for background on the early-exit optimization.
     """
 
     def _make_values_with_match_at(self, match_position, total):
@@ -161,40 +149,51 @@ class TestScalarOperatorEarlyExitScaling:
         values[match_position] = "target"
         return values
 
-    def _run_equals(self, values):
+    def _make_values_with_mismatch_at(self, mismatch_position, total):
+        """Build a value list where all values match except at mismatch_position."""
+        values = ["target"] * total
+        values[mismatch_position] = "miss"
+        return values
+
+    # --- equals operator ---
+
+    def _run_equals(self, values, join_condition='or'):
         tc = {'attr': {'equals': 'target'}}
-        return claims._process_user_value(None, tc, values, 'or', 'attr', 1, 'perf')
+        return claims._process_user_value(None, tc, values, join_condition, 'attr', 1, 'perf')
 
-    def test_log_count_constant_with_early_exit(self, caplog):
-        """Log count must depend on match position, not total list length.
-
-        With the match at position 3, exactly 4 values are evaluated (indices
-        0, 1, 2, 3) producing 4 log lines — regardless of whether the list
-        has 10 or 100 elements. The remaining elements are never touched.
-
-        A regression that removes the early exit break would produce 10 log
-        lines for the short list and 100 for the long list.
-        """
+    def test_equals_log_count_constant_or_join(self, caplog):
+        """With or join, log count depends on match position, not list length."""
         values_10 = self._make_values_with_match_at(3, 10)
         values_100 = self._make_values_with_match_at(3, 100)
 
-        _, logs_10 = _count_log_records(caplog, self._run_equals, values_10)
-        _, logs_100 = _count_log_records(caplog, self._run_equals, values_100)
+        result_10, logs_10 = _count_log_records(caplog, self._run_equals, values_10)
+        result_100, logs_100 = _count_log_records(caplog, self._run_equals, values_100)
 
+        assert result_10 is True
+        assert result_100 is True
         assert logs_10 == 4, f"Expected 4 log lines (match at pos 3) for 10 values, got {logs_10}"
         assert logs_100 == 4, f"Expected 4 log lines (match at pos 3) for 100 values, got {logs_100}"
         assert logs_10 == logs_100, f"Early exit should make log count independent of list size: 10 values={logs_10}, 100 values={logs_100}"
 
-    def test_elapsed_time_constant_with_early_exit(self):
-        """Elapsed time must not grow when values are added after the match point.
+    def test_equals_log_count_constant_and_join(self, caplog):
+        """With and join, log count depends on mismatch position, not list length."""
+        values_10 = self._make_values_with_mismatch_at(3, 10)
+        values_100 = self._make_values_with_mismatch_at(3, 100)
 
-        With the match at position 3, the loop breaks after evaluating 4 values.
-        Adding 90 more values after the match point (10 → 100 total) should
-        have zero effect on execution time because those values are never reached.
+        result_10, logs_10 = _count_log_records(caplog, self._run_equals, values_10, join_condition='and')
+        result_100, logs_100 = _count_log_records(caplog, self._run_equals, values_100, join_condition='and')
 
-        The threshold of < 2.0x is tight because this truly IS O(1) — the work
-        done is identical regardless of list length. Any ratio above 2.0x would
-        indicate the loop is not actually breaking on match.
+        assert result_10 is False
+        assert result_100 is False
+        assert logs_10 == 4, f"Expected 4 log lines (mismatch at pos 3) for 10 values, got {logs_10}"
+        assert logs_100 == 4, f"Expected 4 log lines (mismatch at pos 3) for 100 values, got {logs_100}"
+        assert logs_10 == logs_100, f"Early exit should make log count independent of list size: 10 values={logs_10}, 100 values={logs_100}"
+
+    def test_equals_elapsed_time_constant_or_join(self):
+        """With or join and early exit, trailing values should not affect time.
+
+        The threshold of < 2.0x is tight because with early exit the work
+        is identical regardless of list length.
         """
         values_10 = self._make_values_with_match_at(3, 10)
         values_100 = self._make_values_with_match_at(3, 100)
@@ -205,7 +204,67 @@ class TestScalarOperatorEarlyExitScaling:
         ratio = time_100 / max(time_10, 1e-9)
         assert ratio < 2.0, (
             f"Time scaled {ratio:.1f}x for 10x list size — expected <2.0x with early exit at position 3. "
-            f"The extra 90 values after the match should never be evaluated. "
             f"10 values: {time_10:.4f}s, 100 values: {time_100:.4f}s "
             f"({_TIMING_ITERATIONS} iterations each)"
         )
+
+    # --- contains operator ---
+
+    def test_contains_log_count_constant_or_join(self, caplog):
+        """Contains operator must also exit early on first match."""
+        values_10 = [f"miss-{i}" for i in range(10)]
+        values_10[3] = "has-target-inside"
+        values_100 = [f"miss-{i}" for i in range(100)]
+        values_100[3] = "has-target-inside"
+
+        tc = {'attr': {'contains': 'target'}}
+
+        result_10, logs_10 = _count_log_records(caplog, claims._process_user_value, None, tc, values_10, 'or', 'attr', 1, 'perf')
+        result_100, logs_100 = _count_log_records(caplog, claims._process_user_value, None, tc, values_100, 'or', 'attr', 1, 'perf')
+
+        assert result_10 is True
+        assert result_100 is True
+        assert logs_10 == 4, f"Expected 4 log lines for contains, got {logs_10}"
+        assert logs_100 == 4, f"Expected 4 log lines for contains, got {logs_100}"
+
+    # --- ends_with operator ---
+
+    def test_ends_with_log_count_constant_or_join(self, caplog):
+        """ends_with operator must also exit early on first match."""
+        values_10 = [f"miss-{i}" for i in range(10)]
+        values_10[3] = "user@target.com"
+        values_100 = [f"miss-{i}" for i in range(100)]
+        values_100[3] = "user@target.com"
+
+        tc = {'attr': {'ends_with': '@target.com'}}
+
+        result_10, logs_10 = _count_log_records(caplog, claims._process_user_value, None, tc, values_10, 'or', 'attr', 1, 'perf')
+        result_100, logs_100 = _count_log_records(caplog, claims._process_user_value, None, tc, values_100, 'or', 'attr', 1, 'perf')
+
+        assert result_10 is True
+        assert result_100 is True
+        assert logs_10 == 4, f"Expected 4 log lines for ends_with, got {logs_10}"
+        assert logs_100 == 4, f"Expected 4 log lines for ends_with, got {logs_100}"
+
+    # --- matches (regex) operator ---
+
+    def test_matches_log_count_constant_or_join(self, caplog):
+        """matches (regex) operator must also exit early on first match.
+
+        Regex has different performance characteristics than string comparison
+        (re.match() compilation per call), so it gets its own test.
+        """
+        values_10 = [f"miss-{i}" for i in range(10)]
+        values_10[3] = "admin-group-1"
+        values_100 = [f"miss-{i}" for i in range(100)]
+        values_100[3] = "admin-group-1"
+
+        tc = {'attr': {'matches': r'^admin-.*'}}
+
+        result_10, logs_10 = _count_log_records(caplog, claims._process_user_value, None, tc, values_10, 'or', 'attr', 1, 'perf')
+        result_100, logs_100 = _count_log_records(caplog, claims._process_user_value, None, tc, values_100, 'or', 'attr', 1, 'perf')
+
+        assert result_10 is True
+        assert result_100 is True
+        assert logs_10 == 4, f"Expected 4 log lines for matches, got {logs_10}"
+        assert logs_100 == 4, f"Expected 4 log lines for matches, got {logs_100}"

--- a/aap_gateway_api/tests/authentication/test_claims_perf.py
+++ b/aap_gateway_api/tests/authentication/test_claims_perf.py
@@ -114,6 +114,20 @@ class TestInOperatorScaling:
         assert logs_33 == 1, f"Expected 1 log line for 33 groups, got {logs_33}"
         assert logs_330 == 1, f"Expected 1 log line for 330 groups, got {logs_330}"
 
+    @pytest.mark.parametrize("user_groups", [_GROUPS_33, _GROUPS_330], ids=["33_groups", "330_groups"])
+    def test_log_count_constant_with_matching_trigger(self, caplog, user_groups):
+        """O(1) logging holds on the match path, not just the miss path.
+
+        The base test uses a nonexistent trigger (no intersection). This test
+        places a trigger that IS present in the user groups, exercising the
+        set-intersection hit-path which may have different logging behavior.
+        """
+        tc = {'groups': {'in': [user_groups[0]]}}
+        result, logs = _count_log_records(caplog, claims._process_user_value, None, tc, user_groups, 'or', 'groups', 1, 'perf')
+
+        assert result is True, "Expected True when trigger matches a user group"
+        assert logs == 1, f"Expected 1 log line on match path for {len(user_groups)} groups, got {logs}"
+
     def test_elapsed_time_linear_as_user_values_grow(self):
         """Time must scale at most linearly with user value count.
 
@@ -193,6 +207,72 @@ class TestScalarOperatorEarlyExitScaling:
             assert result is False, f"Expected False for {total} values"
             assert logs == 4, f"Expected 4 log lines (mismatch at pos 3) for {total} values, got {logs}"
 
+    @pytest.mark.parametrize(
+        "operator,trigger_value,matching_value",
+        _SCALAR_OPERATOR_CASES,
+        ids=[c[0] for c in _SCALAR_OPERATOR_CASES],
+    )
+    def test_log_count_full_scan_or_join_no_match(self, caplog, operator, trigger_value, matching_value):
+        """With or join and NO match, all values are scanned — log count = total.
+
+        Contrasts with test_log_count_constant_or_join: without this test,
+        the assertion `logs == 4` could be right for the wrong reason (e.g.
+        the function always logs exactly 4 lines). This test proves the
+        early-exit test is actually testing early exit.
+        """
+        for total in (10, 100):
+            values = [f"miss-{i}" for i in range(total)]
+            tc = {'attr': {operator: trigger_value}}
+
+            result, logs = _count_log_records(caplog, claims._process_user_value, None, tc, values, 'or', 'attr', 1, 'perf')
+
+            assert result is False, f"{operator}: expected False with no matching values for {total} values"
+            assert logs == total, f"{operator}: expected {total} log lines (full scan, no match), got {logs}"
+
+    @pytest.mark.parametrize(
+        "operator,trigger_value,matching_value",
+        _SCALAR_OPERATOR_CASES,
+        ids=[c[0] for c in _SCALAR_OPERATOR_CASES],
+    )
+    def test_log_count_early_exit_at_position_0(self, caplog, operator, trigger_value, matching_value):
+        """With or join and match at position 0, exactly 1 log line.
+
+        Verifies the break happens on the very first iteration — the earliest
+        possible early exit.
+        """
+        values = [matching_value] + [f"miss-{i}" for i in range(99)]
+        tc = {'attr': {operator: trigger_value}}
+
+        result, logs = _count_log_records(caplog, claims._process_user_value, None, tc, values, 'or', 'attr', 1, 'perf')
+
+        assert result is True, f"{operator}: expected True with match at position 0"
+        assert logs == 1, f"{operator}: expected 1 log line (match at pos 0), got {logs}"
+
+    def test_log_count_full_scan_and_join_all_match(self, caplog):
+        """With and join where ALL values match, every value is scanned.
+
+        Contrasts with test_log_count_constant_and_join: that test verifies
+        early exit on mismatch. This test verifies the full-scan path when
+        no early exit is possible (all values satisfy the condition).
+        """
+        for total in (10, 100):
+            values = ["target"] * total
+            tc = {'attr': {'equals': 'target'}}
+
+            result, logs = _count_log_records(caplog, claims._process_user_value, None, tc, values, 'and', 'attr', 1, 'perf')
+
+            assert result is True, f"Expected True when all {total} values match"
+            assert logs == total, f"Expected {total} log lines (all match, full scan), got {logs}"
+
+    def test_empty_user_values(self, caplog):
+        """Empty user values list: no crash, no log lines, has_access unchanged."""
+        tc = {'attr': {'equals': 'target'}}
+
+        result, logs = _count_log_records(caplog, claims._process_user_value, None, tc, [], 'or', 'attr', 1, 'perf')
+
+        assert result is None, "Expected None (has_access unchanged) for empty values"
+        assert logs == 0, f"Expected 0 log lines for empty values, got {logs}"
+
     def test_elapsed_time_constant_or_join(self):
         """With or join and early exit, trailing values should not affect time.
 
@@ -208,6 +288,32 @@ class TestScalarOperatorEarlyExitScaling:
         def run(values):
             tc = {'attr': {'equals': 'target'}}
             return claims._process_user_value(None, tc, values, 'or', 'attr', 1, 'perf')
+
+        time_10 = _measure_time(run, values_10)
+        time_100 = _measure_time(run, values_100)
+
+        ratio = time_100 / max(time_10, 1e-9)
+        assert ratio < 2.0, (
+            f"Time scaled {ratio:.1f}x for 10x list size — expected <2.0x with early exit at position 3. "
+            f"10 values: {time_10:.4f}s, 100 values: {time_100:.4f}s "
+            f"({_TIMING_ITERATIONS} iterations each)"
+        )
+
+    def test_elapsed_time_constant_and_join(self):
+        """With and join and early exit on mismatch, trailing values should not affect time.
+
+        Complements test_elapsed_time_constant_or_join: the log count tests
+        cover the and join structurally, but a timing test catches non-logging
+        regressions (expensive computation that doesn't emit log lines).
+        """
+        values_10 = ["target"] * 10
+        values_10[3] = "miss"
+        values_100 = ["target"] * 100
+        values_100[3] = "miss"
+
+        def run(values):
+            tc = {'attr': {'equals': 'target'}}
+            return claims._process_user_value(None, tc, values, 'and', 'attr', 1, 'perf')
 
         time_10 = _measure_time(run, values_10)
         time_100 = _measure_time(run, values_100)


### PR DESCRIPTION
## Description

- **What is being changed?** Adds performance scaling regression tests for the claims processing optimizations introduced in DAB PR #1033 (AAP-79732). Tests cover the set-based `"in"` operator and early-exit behavior for scalar operators (equals, contains, ends_with, matches).

- **Why is this change needed?** AAP-79732 fixed a critical bug where SAML/OIDC login took 60-120+ seconds with 300+ authenticator maps. The DAB PR has correctness tests, but no regression test that proves the functions maintain their expected complexity at scale. Without these tests, a future refactor could silently reintroduce O(n×m) behavior.

- **How does this change address the issue?** Four tests using two complementary metrics:
  - **Log line count at two scales** — deterministic proof that logging is O(1) per map, not O(n) per user value
  - **Elapsed time ratio at two scales** — catches hidden O(n²) work that doesn't emit logs, using relative ratios (not absolute thresholds) for CI stability

## Type of Change
- [x] Test update

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites
- tox with tox-docker plugin installed
- Docker running (tox starts its own Postgres container)

### Steps to Test
1. `TOX_DOCKER_GATEWAY=0.0.0.0 tox -e py312 -- -m perf -k test_claims_perf -v`
2. All 4 tests should pass

### Expected Results
```
4 passed in ~25s
```
- `test_log_count_constant_as_user_values_grow` — 1 log line at both 33 and 330 groups
- `test_elapsed_time_linear_as_user_values_grow` — time ratio < 10.0x for 10x input
- `test_log_count_constant_with_early_exit` — 4 log lines at both 10 and 100 values
- `test_elapsed_time_constant_with_early_exit` — time ratio < 2.0x for 10x list size

## Additional Context

### Required Actions
- [ ] Requires downstream repository changes
  - DAB PR #1033 must be merged first (contains the optimized functions being tested)

---

**Note:** This file uses the `_perf.py` suffix, so it is automatically marked with `@pytest.mark.perf` via the conftest hook and runs in the dedicated perf CI job, separate from the main test pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new deterministic performance-regression test suite for claims value processing as group and input sizes grow.
  * Added scaling assertions covering both linear-time behavior and effectively constant runtime when early-exit conditions apply.
  * Expanded early-exit and debug-log consistency checks for scalar operators across “match/mismatch” scenarios.
  * Added coverage for empty user values to ensure safe handling without unexpected logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->