### PR TITLE
[AAP-83772] Fix SonarCloud workflow for fork PRs after checkout v4 security backport

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -32,10 +32,15 @@ jobs:
       # This checks out the PR head in a workflow_run context, but no code from
       # the checkout is executed — only downloaded artifacts are processed.
       # persist-credentials: false prevents GITHUB_TOKEN from leaking via git config.
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      # allow-unsafe-pr-checkout: required since actions/checkout v4.2+
+      # (backported from v7 on 2026-07-16) refuses to check out fork PR
+      # code in workflow_run contexts by default. Safe here because only
+      # coverage artifacts are processed — no fork code is executed.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Download coverage artifacts
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21

--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -122,10 +122,19 @@ jobs:
     steps:
       # Pin to the exact commit that the Unit Tests workflow ran against,
       # since workflow_run context defaults to the repo's default branch.
-      - uses: actions/checkout@v4
+      #
+      # allow-unsafe-pr-checkout: required since actions/checkout v4.2+
+      # (backported from v7 on 2026-07-16) refuses to check out fork PR
+      # code in workflow_run contexts by default. Safe here because this
+      # workflow only reads source for static analysis — no fork code is
+      # executed.
+      # SONAR githubactions:S7631 - safe: workflow only reads source for static analysis, no fork code is executed, permissions are read-only
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha }}
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
 
       # Download all individual coverage artifacts from Unit Tests workflow
       - name: Download coverage artifacts
@@ -294,10 +303,13 @@ jobs:
     steps:
       # Pin to the exact commit that the Unit Tests workflow ran against,
       # since workflow_run context defaults to the repo's default branch.
-      - uses: actions/checkout@v4
+      #
+      # SONAR githubactions:S7631 - safe: this job only runs for push events (see the 'if' above), which come from repo collaborators, never from forks
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
 
       # Download all individual coverage artifacts from Unit Tests workflow (optional for branch pushes)
       - name: Download coverage artifacts


### PR DESCRIPTION
## Summary

- Adds `allow-unsafe-pr-checkout: true` to the `actions/checkout` step in both SonarCloud and Codecov workflows
- Pins all `actions/checkout` references to SHA `11d5960a` (current v4) to prevent future floating-tag breakage
- Fixes fork PR analysis broken since July 16 when GitHub backported v7 secure defaults to the `v4` floating tag

## Background

On [2026-07-16](https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/), GitHub backported `actions/checkout@v7` security defaults to v4/v5/v6 floating tags. This causes `workflow_run` checkouts of fork PR code to be refused by default, breaking SonarCloud analysis for all fork PRs. The workflow fails silently — SonarCloud appears permanently "Waiting for status to be reported" on the PR.

Codecov was previously SHA-pinned (v4.2.2) so it wasn't immediately affected, but is updated here to the current v4 SHA with the new flag for consistency and future-proofing.

Observed on: https://github.com/ansible/jewel/pull/168

## Test plan

- [ ] Verify SonarCloud reports status on a fork PR after this merges
- [ ] Verify Codecov continues to report on fork PRs
- [ ] Verify SonarCloud branch analysis on devel pushes is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated automated code quality and coverage workflows to improve reliability for workflow-triggered runs.
  - Pinned the checkout action to specific commit SHAs for more consistent execution.
  - Enabled unsafe checkout where required in these contexts, and documented the rationale with inline comments.
  - Adjusted checkout credential handling in the quality workflow to better match safe execution for pull request analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->