### PR TITLE
[AAP-82668] Wrap org delete with deferral context managers

### DIFF
--- a/aap_gateway_api/views/api/v1/organization.py
+++ b/aap_gateway_api/views/api/v1/organization.py
@@ -1,5 +1,8 @@
 import logging
 
+from ansible_base.activitystream import deferred_activity_stream
+from ansible_base.rbac.triggers import defer_rbac_computations
+from ansible_base.resource_registry.signals.handlers import defer_resource_cleanup
 from django.utils.translation import gettext_lazy as _
 from rest_framework import status
 from rest_framework.response import Response
@@ -26,5 +29,7 @@ class OrganizationViewSet(ResourceAPIUpdateMixin, RoleModelViewSet):
         if instance.managed:
             logger.info("Managed organizations cannot be deleted.")
             return Response(status=status.HTTP_400_BAD_REQUEST, data={"details": _("Managed organizations cannot be deleted.")})
-        else:
-            return super().destroy(request, *args, **kwargs)
+        with deferred_activity_stream():
+            with defer_resource_cleanup():
+                with defer_rbac_computations():
+                    return super().destroy(request, *args, **kwargs)


### PR DESCRIPTION
## Summary

- Wraps `OrganizationViewSet.destroy` with `defer_rbac_computations`, `deferred_activity_stream`, and `defer_resource_cleanup` context managers so cascade deletes of large organizations batch all signal-driven work instead of firing per-object.
- Addresses organization deletion timeout at scale (AAP-82668).

Requires ansible/django-ansible-base#1059

## Test plan

- [ ] Delete an organization with many teams/users/inventories — should complete without timeout
- [ ] Delete a managed organization — should still return 400
- [ ] Delete a small organization — should behave identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)