### PR TITLE
[AAP-82668] Clear system user cache between tests to prevent FK violations

### DIFF
--- a/aap_gateway_api/tests/conftest.py
+++ b/aap_gateway_api/tests/conftest.py
@@ -100,6 +100,23 @@ def ensure_settings_bound_preferences():
         setattr(settings, 'RUNTIME_FEATURE_FLAGS', True)
 
 
+@pytest.fixture(autouse=True)
+def _clear_system_user_cache():
+    """Clear the cached system user between tests.
+
+    DAB's get_system_user() caches the result in Redis (via django.core.cache).
+    Tests run inside transactions that are rolled back after each test. Without
+    clearing the cache, a stale User reference from a previous test survives the
+    rollback, causing ForeignKey violations when the next test's fixtures
+    reference a user pk that no longer exists in the DB.
+    """
+    from ansible_base.lib.utils.models import clear_system_user_cache
+
+    clear_system_user_cache()
+    yield
+    clear_system_user_cache()
+
+
 def pytest_configure():
     """
     macOS uses 'spawn' by default (unlike Linux, which uses 'fork'). This causes issues with Django's app registry in subprocesses,


### PR DESCRIPTION
## Summary

- Adds an `autouse` fixture `_clear_system_user_cache` to jewel's test conftest that clears DAB's cached system user before and after each test.

## Context

DAB PR [#1056](https://github.com/ansible/django-ansible-base/pull/1056) introduced module-level caching for `get_system_user()` via Django's cache framework (Redis/fakeredis in CI). When tests roll back transactions, the cached User object (pk=1) survives the rollback. Subsequent test fixtures then try to create records with `created_by_id=1`, but that user no longer exists in the DB — causing `IntegrityError: insert or update on table ... violates foreign key constraint ... created_by_id`.

DAB's own `test_app/tests/conftest.py` already has this fixture, but jewel's tests don't inherit it. This PR adds the matching fixture to prevent the FK violations.

## Test plan

- [x] Verify the failing tests (`test_rotate_secret_key`, `test_httpport_api_port_unique`, etc.) pass with this fix
- [x] No functional changes — only test infrastructure

---
**Note:** This PR was developed with assistance from Claude AI assistant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test isolation by clearing cached system-user references before and after each test session.
  * Prevented stale references from causing database relationship errors in subsequent tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->