### PR TITLE
[AAP-83975] Scope ext_auth AUTH_TYPE_NONE to EDA routes only

### DIFF
--- a/aap_gateway_api/common/envoy.py
+++ b/aap_gateway_api/common/envoy.py
@@ -15,6 +15,7 @@ def _type_url(descriptor) -> str:
 
 # Filter name used in Envoy filter chain config — not a type URL.
 EXT_AUTH_FILTER = "envoy.filters.http.ext_authz"
+AUTH_TYPE_NONE = "NONE"
 
 # Type URLs derived from protobuf message descriptors.
 EXT_AUTH_PER_ROUTE = _type_url(ext_authz_pb2.ExtAuthzPerRoute.DESCRIPTOR)

--- a/aap_gateway_api/models/route.py
+++ b/aap_gateway_api/models/route.py
@@ -124,9 +124,9 @@ class Route(UniqueNamedCommonModel, AuditableModel):
     )
 
     @property
-    def is_gateway_service(self):
-        """True if this route targets the gateway service itself."""
-        return self.service_cluster.service_type.is_gateway_service
+    def is_eda_service(self):
+        """True if this route targets the EDA service."""
+        return self.service_cluster.service_type.is_eda_service
 
     def is_internal_route_string(self):
         return "t" if self.is_internal_route else "f"
@@ -286,12 +286,9 @@ class Route(UniqueNamedCommonModel, AuditableModel):
             }
 
         if not self.enable_gateway_auth:
-            if self.is_gateway_service:
-                cfg["typed_per_filter_config"][EXT_AUTH_FILTER] = {
-                    TYPE_KEY: EXT_AUTH_PER_ROUTE,
-                    "disabled": True,
-                }
-            else:
+            if self.is_eda_service:
+                # EDA webhooks handle their own auth but need X-Trusted-Proxy
+                # to verify requests originated from the gateway (CVE fix)
                 cfg["typed_per_filter_config"][EXT_AUTH_FILTER] = {
                     TYPE_KEY: EXT_AUTH_PER_ROUTE,
                     "check_settings": {
@@ -301,6 +298,15 @@ class Route(UniqueNamedCommonModel, AuditableModel):
                             "auth_type": AUTH_TYPE_NONE,
                         },
                     },
+                }
+            else:
+                # All other services: completely disable ext_auth to restore
+                # pre-CVE-fix behavior. This avoids X-Trusted-Proxy being added
+                # (which causes 403 on gateway config writes) and prevents
+                # unnecessary gRPC calls (which causes 401 in proxy environments).
+                cfg["typed_per_filter_config"][EXT_AUTH_FILTER] = {
+                    TYPE_KEY: EXT_AUTH_PER_ROUTE,
+                    "disabled": True,
                 }
         else:
             cfg["typed_per_filter_config"][EXT_AUTH_FILTER] = {

--- a/aap_gateway_api/models/route.py
+++ b/aap_gateway_api/models/route.py
@@ -6,7 +6,7 @@ from django.db import models
 from django.urls import reverse
 from django.utils.translation import gettext as _
 
-from aap_gateway_api.common.envoy import EXT_AUTH_FILTER, EXT_AUTH_PER_ROUTE, LUA_PER_ROUTE, UPSTREAM_TLS_CONTEXT
+from aap_gateway_api.common.envoy import AUTH_TYPE_NONE, EXT_AUTH_FILTER, EXT_AUTH_PER_ROUTE, LUA_PER_ROUTE, UPSTREAM_TLS_CONTEXT
 from aap_gateway_api.models.http_port import HTTPPort
 from aap_gateway_api.models.service_cluster import ServiceCluster
 from aap_gateway_api.models.service_type import DefaultServiceType
@@ -283,7 +283,13 @@ class Route(UniqueNamedCommonModel, AuditableModel):
         if not self.enable_gateway_auth:
             cfg["typed_per_filter_config"][EXT_AUTH_FILTER] = {
                 TYPE_KEY: EXT_AUTH_PER_ROUTE,
-                "disabled": not self.enable_gateway_auth,
+                "check_settings": {
+                    "context_extensions": {
+                        "is_internal_route": self.is_internal_route_string(),
+                        "service_type": self.service_cluster.service_type.name,
+                        "auth_type": AUTH_TYPE_NONE,
+                    },
+                },
             }
         else:
             cfg["typed_per_filter_config"][EXT_AUTH_FILTER] = {

--- a/aap_gateway_api/models/route.py
+++ b/aap_gateway_api/models/route.py
@@ -123,6 +123,11 @@ class Route(UniqueNamedCommonModel, AuditableModel):
         ),
     )
 
+    @property
+    def is_gateway_service(self):
+        """True if this route targets the gateway service itself."""
+        return self.service_cluster.service_type.is_gateway_service
+
     def is_internal_route_string(self):
         return "t" if self.is_internal_route else "f"
 
@@ -281,16 +286,22 @@ class Route(UniqueNamedCommonModel, AuditableModel):
             }
 
         if not self.enable_gateway_auth:
-            cfg["typed_per_filter_config"][EXT_AUTH_FILTER] = {
-                TYPE_KEY: EXT_AUTH_PER_ROUTE,
-                "check_settings": {
-                    "context_extensions": {
-                        "is_internal_route": self.is_internal_route_string(),
-                        "service_type": self.service_cluster.service_type.name,
-                        "auth_type": AUTH_TYPE_NONE,
+            if self.is_gateway_service:
+                cfg["typed_per_filter_config"][EXT_AUTH_FILTER] = {
+                    TYPE_KEY: EXT_AUTH_PER_ROUTE,
+                    "disabled": True,
+                }
+            else:
+                cfg["typed_per_filter_config"][EXT_AUTH_FILTER] = {
+                    TYPE_KEY: EXT_AUTH_PER_ROUTE,
+                    "check_settings": {
+                        "context_extensions": {
+                            "is_internal_route": self.is_internal_route_string(),
+                            "service_type": self.service_cluster.service_type.name,
+                            "auth_type": AUTH_TYPE_NONE,
+                        },
                     },
-                },
-            }
+                }
         else:
             cfg["typed_per_filter_config"][EXT_AUTH_FILTER] = {
                 TYPE_KEY: EXT_AUTH_PER_ROUTE,

--- a/aap_gateway_api/models/service_type.py
+++ b/aap_gateway_api/models/service_type.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from functools import cached_property
 
 from ansible_base.activitystream.models import AuditableModel
 from ansible_base.lib.abstract_models.common import UniqueNamedCommonModel
@@ -12,6 +13,11 @@ class ServiceType(UniqueNamedCommonModel, AuditableModel):
     """
 
     router_basename = 'service_type'
+
+    @cached_property
+    def is_gateway_service(self):
+        """True if this is the gateway service type."""
+        return self.name == DefaultServiceType.GATEWAY
 
     ping_url = models.CharField(max_length=255, blank=False, null=True, help_text=_("URL to the ping/status page of the service, ex. /pulp/api/v3/status/"))
 

--- a/aap_gateway_api/models/service_type.py
+++ b/aap_gateway_api/models/service_type.py
@@ -15,9 +15,9 @@ class ServiceType(UniqueNamedCommonModel, AuditableModel):
     router_basename = 'service_type'
 
     @cached_property
-    def is_gateway_service(self):
-        """True if this is the gateway service type."""
-        return self.name == DefaultServiceType.GATEWAY
+    def is_eda_service(self):
+        """True if this is the EDA service type."""
+        return self.name == DefaultServiceType.EDA
 
     ping_url = models.CharField(max_length=255, blank=False, null=True, help_text=_("URL to the ping/status page of the service, ex. /pulp/api/v3/status/"))
 

--- a/aap_gateway_api/proxy/control_plane.py
+++ b/aap_gateway_api/proxy/control_plane.py
@@ -27,6 +27,7 @@ from rest_framework.request import Request as DRFRequest
 from rest_framework.settings import api_settings
 
 from aap_gateway_api.common.authentication import SERVICE_TOKEN_AUTH_STRING
+from aap_gateway_api.common.envoy import AUTH_TYPE_NONE
 from aap_gateway_api.utils import JWTSessionCache, create_signed_jwt, get_jwt_rsa_key, get_preference_value
 
 MIDDLEWARE = [SessionMiddleware, AuthenticatorBackendMiddleware, AuthenticationMiddleware, LogRequestMiddleware]
@@ -294,6 +295,13 @@ class _ExternalAuth:
         self.request_path = request.attributes.request.http.path
         self.is_internal_route = self.is_route_internal(request)
         self.reject_failed_basic_auth = self.should_reject_failed_basic_auth(request)
+
+        # Routes with auth_type=NONE (enable_gateway_auth=false) skip authentication
+        # but still get the X-Trusted-Proxy header to verify they came through the gateway.
+        # This is useful for services like EDA that handle their own authentication.
+        if self.auth_type == AUTH_TYPE_NONE:
+            logger.debug(f"Auth type is NONE for {self.request_id} {self.request_path} - adding trusted proxy header without authentication")
+            return self._return_no_authentication_required()
 
         # OIDC/OAuth2 flow endpoints handle their own authentication via DOT.
         # This check runs before internal/external branching so it works regardless

--- a/aap_gateway_api/proxy/control_plane.py
+++ b/aap_gateway_api/proxy/control_plane.py
@@ -268,6 +268,7 @@ class _ExternalAuth:
 
         self.headers = []
         self.service_type = request.attributes.context_extensions["service_type"]
+        self.auth_type = request.attributes.context_extensions["auth_type"]
 
         # Clear the thread local request. If we log before we get the new one, we'll log the wrong request.
         logging_thread_local.request = None

--- a/aap_gateway_api/tests/models/test_route.py
+++ b/aap_gateway_api/tests/models/test_route.py
@@ -1,6 +1,7 @@
 import pytest
 from ansible_base.feature_flags.utils import create_initial_data as seed_feature_flags
 
+from aap_gateway_api.common.envoy import AUTH_TYPE_NONE
 from aap_gateway_api.models import AdditionalRoute, DefaultServiceType, HTTPPort, ServiceAPIRoute, ServiceCluster, ServiceType, UIPluginRoute
 from aap_gateway_api.models.service_node import ServiceNode
 
@@ -130,6 +131,17 @@ class TestRoute:
         routes = route.get_xds_route_config()
         assert len(routes) == 1
         assert 'envoy.filters.http.ext_authz' in routes[0]["typed_per_filter_config"]
+
+        # Verify the new structure: uses check_settings with auth_type=NONE instead of disabled=True
+        ext_authz_config = routes[0]["typed_per_filter_config"]["envoy.filters.http.ext_authz"]
+        assert 'disabled' not in ext_authz_config
+        assert 'check_settings' in ext_authz_config
+        assert 'context_extensions' in ext_authz_config["check_settings"]
+
+        context_extensions = ext_authz_config["check_settings"]["context_extensions"]
+        assert context_extensions["auth_type"] == AUTH_TYPE_NONE
+        assert context_extensions["service_type"] == service_cluster_eda.service_type.name
+        assert context_extensions["is_internal_route"] == "f"  # ServiceAPIRoute defaults to is_internal_route=False
 
     @pytest.mark.parametrize(
         "service,expected_route_len",

--- a/aap_gateway_api/tests/models/test_route.py
+++ b/aap_gateway_api/tests/models/test_route.py
@@ -124,7 +124,11 @@ class TestRoute:
         assert routes[0]["typed_per_filter_config"]["envoy.filters.http.ext_authz"]["check_settings"]["context_extensions"]["is_internal_route"] == "t"
 
     @pytest.mark.django_db
-    def test_xds_route_config_disable_gateway_auth(self, service_cluster_eda):
+    def test_xds_route_config_disable_gateway_auth_for_eda(self, service_cluster_eda):
+        """
+        Test that EDA routes with enable_gateway_auth=False use AUTH_TYPE_NONE.
+        This allows EDA webhooks to handle their own auth while still getting X-Trusted-Proxy.
+        """
         route = ServiceAPIRoute(
             gateway_path='/', service_path='/path', envoy_cluster_name='testing', enable_gateway_auth=False, service_cluster=service_cluster_eda
         )
@@ -134,7 +138,7 @@ class TestRoute:
 
         # Verify the new structure: uses check_settings with auth_type=NONE instead of disabled=True
         ext_authz_config = routes[0]["typed_per_filter_config"]["envoy.filters.http.ext_authz"]
-        assert 'disabled' not in ext_authz_config
+        assert 'disabled' not in ext_authz_config, "EDA routes should NOT disable ext_auth completely"
         assert 'check_settings' in ext_authz_config
         assert 'context_extensions' in ext_authz_config["check_settings"]
 
@@ -142,6 +146,40 @@ class TestRoute:
         assert context_extensions["auth_type"] == AUTH_TYPE_NONE
         assert context_extensions["service_type"] == service_cluster_eda.service_type.name
         assert context_extensions["is_internal_route"] == "f"  # ServiceAPIRoute defaults to is_internal_route=False
+
+    @pytest.mark.django_db
+    def test_service_type_is_gateway_service(self, service_cluster_gateway, service_cluster_eda):
+        """Verify ServiceType.is_gateway_service cached_property identifies gateway vs non-gateway."""
+        assert service_cluster_gateway.service_type.is_gateway_service is True
+        assert service_cluster_eda.service_type.is_gateway_service is False
+
+    @pytest.mark.django_db
+    def test_is_gateway_service_property(self, service_cluster_gateway, service_cluster_eda):
+        """Verify the Route.is_gateway_service property delegates correctly to ServiceType."""
+        gw_route = ServiceAPIRoute(gateway_path='/', service_path='/path', envoy_cluster_name='testing', service_cluster=service_cluster_gateway)
+        eda_route = ServiceAPIRoute(gateway_path='/', service_path='/path', envoy_cluster_name='testing', service_cluster=service_cluster_eda)
+        assert gw_route.is_gateway_service is True
+        assert eda_route.is_gateway_service is False
+
+    @pytest.mark.django_db
+    def test_xds_route_config_disable_gateway_auth_for_gateway(self, service_cluster_gateway):
+        """
+        Test that GATEWAY routes with enable_gateway_auth=False completely disable ext_auth.
+        This is necessary to prevent X-Trusted-Proxy from being added, which would cause
+        DisallowWriteFromProxy to block configuration changes.
+        """
+        route = ServiceAPIRoute(
+            gateway_path='/', service_path='/path', envoy_cluster_name='testing', enable_gateway_auth=False, service_cluster=service_cluster_gateway
+        )
+        routes = route.get_xds_route_config()
+        assert len(routes) == 1
+        assert 'envoy.filters.http.ext_authz' in routes[0]["typed_per_filter_config"]
+
+        # Verify the gateway special case: ext_auth is completely disabled
+        ext_authz_config = routes[0]["typed_per_filter_config"]["envoy.filters.http.ext_authz"]
+        assert 'disabled' in ext_authz_config, "Gateway routes MUST disable ext_auth completely"
+        assert ext_authz_config['disabled'] is True
+        assert 'check_settings' not in ext_authz_config, "Gateway routes should not have check_settings"
 
     @pytest.mark.parametrize(
         "service,expected_route_len",

--- a/aap_gateway_api/tests/models/test_route.py
+++ b/aap_gateway_api/tests/models/test_route.py
@@ -148,25 +148,71 @@ class TestRoute:
         assert context_extensions["is_internal_route"] == "f"  # ServiceAPIRoute defaults to is_internal_route=False
 
     @pytest.mark.django_db
-    def test_service_type_is_gateway_service(self, service_cluster_gateway, service_cluster_eda):
-        """Verify ServiceType.is_gateway_service cached_property identifies gateway vs non-gateway."""
-        assert service_cluster_gateway.service_type.is_gateway_service is True
-        assert service_cluster_eda.service_type.is_gateway_service is False
+    def test_eda_event_stream_route_gets_trusted_proxy_config(self, service_cluster_eda):
+        """
+        Simulate an EDA event stream webhook route (enable_gateway_auth=False).
+        Verify the xDS config enables ext_auth with AUTH_TYPE_NONE so the control
+        plane adds X-Trusted-Proxy, allowing EDA to verify the request came through
+        the gateway. This is the core CVE fix behavior (AAP-79215/79216).
+        """
+        route = ServiceAPIRoute(
+            gateway_path='/api/eda/v1/external-event-stream/',
+            service_path='/api/eda/v1/external-event-stream/',
+            envoy_cluster_name='eda-cluster',
+            enable_gateway_auth=False,
+            service_cluster=service_cluster_eda,
+        )
+        routes = route.get_xds_route_config()
+        assert len(routes) == 1
+
+        ext_authz_config = routes[0]["typed_per_filter_config"]["envoy.filters.http.ext_authz"]
+        assert 'disabled' not in ext_authz_config, "EDA event stream routes must NOT disable ext_auth"
+        assert ext_authz_config["check_settings"]["context_extensions"]["auth_type"] == AUTH_TYPE_NONE
+        assert ext_authz_config["check_settings"]["context_extensions"]["service_type"] == "eda"
 
     @pytest.mark.django_db
-    def test_is_gateway_service_property(self, service_cluster_gateway, service_cluster_eda):
-        """Verify the Route.is_gateway_service property delegates correctly to ServiceType."""
+    @pytest.mark.parametrize("service_type_fixture", ["service_cluster_hub", "service_cluster_controller"])
+    def test_non_eda_services_disable_ext_auth(self, service_type_fixture, request):
+        """
+        Verify that non-EDA services (hub, controller) with enable_gateway_auth=False
+        completely disable ext_auth, preventing gRPC calls that could be misrouted
+        through corporate proxies in restricted network environments (AAP-83727).
+        """
+        service_cluster = request.getfixturevalue(service_type_fixture)
+        route = ServiceAPIRoute(
+            gateway_path='/',
+            service_path='/path',
+            envoy_cluster_name='testing',
+            enable_gateway_auth=False,
+            service_cluster=service_cluster,
+        )
+        routes = route.get_xds_route_config()
+        assert len(routes) == 1
+
+        ext_authz_config = routes[0]["typed_per_filter_config"]["envoy.filters.http.ext_authz"]
+        assert ext_authz_config.get('disabled') is True, f"{service_cluster.service_type.name} routes must disable ext_auth"
+        assert 'check_settings' not in ext_authz_config
+
+    @pytest.mark.django_db
+    def test_service_type_is_eda_service(self, service_cluster_gateway, service_cluster_eda):
+        """Verify ServiceType.is_eda_service cached_property identifies EDA vs non-EDA."""
+        assert service_cluster_eda.service_type.is_eda_service is True
+        assert service_cluster_gateway.service_type.is_eda_service is False
+
+    @pytest.mark.django_db
+    def test_is_eda_service_property(self, service_cluster_gateway, service_cluster_eda):
+        """Verify the Route.is_eda_service property delegates correctly to ServiceType."""
         gw_route = ServiceAPIRoute(gateway_path='/', service_path='/path', envoy_cluster_name='testing', service_cluster=service_cluster_gateway)
         eda_route = ServiceAPIRoute(gateway_path='/', service_path='/path', envoy_cluster_name='testing', service_cluster=service_cluster_eda)
-        assert gw_route.is_gateway_service is True
-        assert eda_route.is_gateway_service is False
+        assert gw_route.is_eda_service is False
+        assert eda_route.is_eda_service is True
 
     @pytest.mark.django_db
-    def test_xds_route_config_disable_gateway_auth_for_gateway(self, service_cluster_gateway):
+    def test_xds_route_config_disable_gateway_auth_for_non_eda(self, service_cluster_gateway):
         """
-        Test that GATEWAY routes with enable_gateway_auth=False completely disable ext_auth.
-        This is necessary to prevent X-Trusted-Proxy from being added, which would cause
-        DisallowWriteFromProxy to block configuration changes.
+        Test that non-EDA routes with enable_gateway_auth=False completely disable ext_auth.
+        Only EDA needs AUTH_TYPE_NONE for X-Trusted-Proxy; all other services restore
+        pre-CVE-fix behavior to avoid 403s and gRPC misrouting in proxy environments.
         """
         route = ServiceAPIRoute(
             gateway_path='/', service_path='/path', envoy_cluster_name='testing', enable_gateway_auth=False, service_cluster=service_cluster_gateway
@@ -175,11 +221,10 @@ class TestRoute:
         assert len(routes) == 1
         assert 'envoy.filters.http.ext_authz' in routes[0]["typed_per_filter_config"]
 
-        # Verify the gateway special case: ext_auth is completely disabled
         ext_authz_config = routes[0]["typed_per_filter_config"]["envoy.filters.http.ext_authz"]
-        assert 'disabled' in ext_authz_config, "Gateway routes MUST disable ext_auth completely"
+        assert 'disabled' in ext_authz_config, "Non-EDA routes MUST disable ext_auth completely"
         assert ext_authz_config['disabled'] is True
-        assert 'check_settings' not in ext_authz_config, "Gateway routes should not have check_settings"
+        assert 'check_settings' not in ext_authz_config, "Non-EDA routes should not have check_settings"
 
     @pytest.mark.parametrize(
         "service,expected_route_len",

--- a/aap_gateway_api/tests/proxy/test_proxy.py
+++ b/aap_gateway_api/tests/proxy/test_proxy.py
@@ -335,6 +335,17 @@ class TestContainerRegistryAuth:
 
         assert response.status.code == 0
 
+    def test_jwt_without_credentials_passes_through_without_token(self, ext_auth, admin_user):
+        """Verify that auth_type=JWT requests without credentials pass through but don't get a JWT token."""
+        request = Request(method="GET", path="/api/eda/v1/activations/", auth_type="JWT")
+
+        response = ext_auth.Check(request, None)
+
+        assert response.status.code == 0
+        header_keys = [h.header.key for h in response.ok_response.headers]
+        assert "x-trusted-proxy" in header_keys
+        assert "X-DAB-JW-TOKEN" not in header_keys
+
 
 class MockOAuth2Token:
     """Mock OAuth2 access token for testing scope validation."""
@@ -768,6 +779,66 @@ class TestOAuth2ScopeValidation:
                         assert path in log_message, f"Path {path} should be in log message"
 
             assert response.status.code == 7, f"Should deny DELETE on {path} with read scope"
+
+
+@pytest.mark.django_db
+class TestAuthTypeNone:
+    """Tests for auth_type=NONE (enable_gateway_auth=false) which adds X-Trusted-Proxy without authentication."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def mock_close_old_connections(self):
+        with mock.patch("aap_gateway_api.proxy.control_plane.close_old_connections"):
+            yield
+
+    def test_auth_type_none_adds_trusted_proxy_without_auth(self, ext_auth):
+        """Verify that auth_type=NONE adds X-Trusted-Proxy header without attempting authentication."""
+        request = Request(method="POST", path="/api/eda/v1/external-event-stream/a1b2c3d4-5678-9012-3456-789012345678/", auth_type="NONE")
+        response = ext_auth.Check(request, None)
+
+        assert response.status.code == 0
+        header_keys = [h.header.key for h in response.ok_response.headers]
+        assert "x-trusted-proxy" in header_keys
+        assert "X-DAB-JW-TOKEN" not in header_keys
+
+    def test_auth_type_none_works_for_get_requests(self, ext_auth):
+        """Verify that auth_type=NONE works for GET requests on event streams."""
+        request = Request(method="GET", path="/api/eda/v1/external-event-stream/12345678-1234-5678-1234-567812345678/", auth_type="NONE")
+        response = ext_auth.Check(request, None)
+
+        assert response.status.code == 0
+        header_keys = [h.header.key for h in response.ok_response.headers]
+        assert "x-trusted-proxy" in header_keys
+
+    def test_auth_type_none_with_webhook_payload(self, ext_auth):
+        """Verify that auth_type=NONE works for POST requests with webhook payloads."""
+        webhook_payload = '{"source": "github", "event": "push", "data": {"ref": "refs/heads/main"}}'
+        request = Request(
+            method="POST",
+            path="/api/eda/v1/external-event-stream/abcdef12-3456-7890-abcd-ef1234567890/",
+            auth_type="NONE",
+            body=webhook_payload,
+            header_diff={"CONTENT_TYPE": "application/json"},
+        )
+        response = ext_auth.Check(request, None)
+
+        assert response.status.code == 0
+        header_keys = [h.header.key for h in response.ok_response.headers]
+        assert "x-trusted-proxy" in header_keys
+
+    def test_auth_type_none_with_internal_route(self, ext_auth):
+        """Verify that auth_type=NONE combined with is_internal_route=True still skips auth and adds header."""
+        request = Request(
+            method="POST",
+            path="/api/eda/v1/external-event-stream/a1b2c3d4-5678-9012-3456-789012345678/",
+            auth_type="NONE",
+            is_internal_route="t",
+        )
+        response = ext_auth.Check(request, None)
+
+        assert response.status.code == 0
+        header_keys = [h.header.key for h in response.ok_response.headers]
+        assert "x-trusted-proxy" in header_keys
+        assert "X-DAB-JW-TOKEN" not in header_keys
 
 
 @pytest.mark.django_db

--- a/aap_gateway_api/tests/views/api/v1/service_cluster/test_service_cluster.py
+++ b/aap_gateway_api/tests/views/api/v1/service_cluster/test_service_cluster.py
@@ -133,7 +133,7 @@ def test_service_model_write_from_proxy_non_default(admin_api_client):
         url = get_relative_url("service_cluster-detail", kwargs={"pk": ServiceCluster.objects.filter(name="testsc").first().id})
         response = admin_api_client.patch(url, {"name": "changed"})
         assert response.status_code == 200
-        assert "changed" == ServiceCluster.objects.filter(name="changed").first().name, "Expected cluster to have name changed"
+        assert ServiceCluster.objects.filter(name="changed").first().name == "changed", "Expected cluster to have name changed"
 
 
 @pytest.mark.parametrize(
@@ -164,3 +164,40 @@ def test_service_outlier_detection_max_ejection_percent_min_max(value, message, 
     response = admin_api_client.patch(url, {"outlier_detection_max_ejection_percent": value})
     assert response.status_code == 400
     assert response.data["outlier_detection_max_ejection_percent"][0] == message
+
+
+@pytest.mark.django_db
+def test_service_cluster_gateway_modification_allowed_without_proxy_header(admin_api_client, service_cluster_gateway):
+    """
+    Test that the gateway service cluster CAN be modified when there's no X-Trusted-Proxy header.
+
+    With ext_auth disabled on gateway routes, Envoy does not add X-Trusted-Proxy, so
+    DisallowWriteFromProxy does not block admin configuration changes.
+    """
+    url = get_relative_url("service_cluster-detail", kwargs={"pk": service_cluster_gateway.pk})
+
+    response = admin_api_client.patch(url, {"outlier_detection_enabled": False})
+    assert response.status_code == 200
+    assert response.data["outlier_detection_enabled"] is False
+
+
+@pytest.mark.django_db
+def test_service_cluster_gateway_blocked_with_proxy_header(admin_api_client, service_cluster_gateway):
+    """
+    Document DisallowWriteFromProxy: writes to default service clusters are blocked
+    when X-Trusted-Proxy is present.
+
+    This does not validate Envoy/xDS route config (see
+    test_xds_route_config_disable_gateway_auth_for_gateway). It asserts the permission
+    check itself still rejects unsafe proxied writes.
+    """
+    url = get_relative_url("service_cluster-detail", kwargs={"pk": service_cluster_gateway.pk})
+
+    extras = {"HTTP_X_TRUSTED_PROXY": "simulated-jwt-signature"}
+
+    # from_proxy() is True, method is unsafe, and gateway is a default service type
+    # → DisallowWriteFromProxy raises ProxyDenied
+    response = admin_api_client.patch(url, {"outlier_detection_enabled": True}, **extras)
+
+    assert response.status_code == 403, "Default service clusters should be blocked when X-Trusted-Proxy header is present"
+    assert "proxy" in str(response.content).lower()


### PR DESCRIPTION
## Summary

When `enable_gateway_auth=False`, the ext_auth filter now uses `AUTH_TYPE_NONE` only for EDA routes (to add `X-Trusted-Proxy` for webhook verification). All other services completely disable ext_auth (`disabled: True`), restoring the original behavior.

Requires ansible/ansible.platform#219

## Changes

- `aap_gateway_api/common/envoy.py` — Added `AUTH_TYPE_NONE` constant
- `aap_gateway_api/models/route.py` — Added `is_eda_service` property; EDA routes get `AUTH_TYPE_NONE`, all others get `disabled: True`
- `aap_gateway_api/models/service_type.py` — Added `is_eda_service` cached property
- `aap_gateway_api/proxy/control_plane.py` — Handle `AUTH_TYPE_NONE` by adding `X-Trusted-Proxy` without authentication
- Tests updated across `test_route.py`, `test_proxy.py`, and `test_service_cluster.py`

## Why

The original CVE fix applied `AUTH_TYPE_NONE` to all `enable_gateway_auth=False` routes, which caused two issues:
1. The `X-Trusted-Proxy` header triggered `DisallowWriteFromProxy` on gateway config endpoints (403 on PATCH)
2. Unnecessary gRPC calls to the control plane were misrouted through corporate proxies in restricted network environments (401 JWT errors)

Scoping `AUTH_TYPE_NONE` to EDA only eliminates both issues while preserving the CVE fix for the one service that needs it.

## Test plan
- [ ] CI pipeline green
- [ ] Unit tests pass (ruff-check, ruff-format clean)

---
**Note:** This PR was developed with assistance from Claude AI assistant.