### PR TITLE
[AAP-84308] Fix bulk-update error handling: HTTPError classification, non-dict guard, early-exit

### DIFF
--- a/aap_gateway_api/management/commands/_migrate_service_data/resource_migration.py
+++ b/aap_gateway_api/management/commands/_migrate_service_data/resource_migration.py
@@ -229,11 +229,20 @@ class ResourceMigrationMixin:
         Transient HTTP errors (502/503/504, network errors) are retried with
         exponential backoff. Permanent errors (4xx) fail immediately.
         Per-item errors from successful responses are logged as warnings.
+
+        If a chunk fails permanently (returns 0), remaining chunks are skipped
+        since the failure is likely systemic and they would fail too.
         """
         total_updated = 0
         for i in range(0, len(bulk_update_items), self.MAX_BULK_CHUNK_SIZE):
             chunk = bulk_update_items[i : i + self.MAX_BULK_CHUNK_SIZE]
             updated = self._send_bulk_update_chunk(chunk)
+            if updated == 0 and chunk:
+                self._log(
+                    f"Chunk starting at index {i} failed; skipping remaining chunks to avoid wasted retries.",
+                    logging.WARNING,
+                )
+                break
             total_updated += updated
         return total_updated
 
@@ -259,15 +268,42 @@ class ResourceMigrationMixin:
         )
         return False
 
+    def _handle_http_error(self, exc: requests.exceptions.HTTPError, attempt: int):
+        """Classify an HTTPError as transient or permanent and act accordingly.
+
+        Called when raise_if_bad_request=True causes the client to raise
+        HTTPError for non-2xx responses. Returns _RETRY_SENTINEL for transient
+        5xx errors (if retries remain), or 0 for permanent errors.
+        """
+        status = exc.response.status_code if exc.response is not None else 0
+        detail = str(exc)[:500]
+        if status in self.TRANSIENT_STATUS_CODES:
+            if self._should_retry(attempt, f"HTTP {status}", detail):
+                return self._RETRY_SENTINEL
+            return 0
+        self._log(
+            f"Bulk update returned HTTP {status} (permanent error, will not retry): {detail}",
+            logging.ERROR,
+        )
+        return 0
+
     def _try_bulk_update_once(self, chunk: List[Dict[str, Any]], attempt: int):
         """Execute one bulk-update attempt.
 
         Returns the parsed response dict on success, _RETRY_SENTINEL if a
         transient error occurred and retries remain, or 0 if the request
         failed permanently.
+
+        Note: The client is created with raise_if_bad_request=True, so non-2xx
+        responses raise HTTPError (a subclass of RequestException) before
+        returning. We catch HTTPError first to distinguish transient (5xx) from
+        permanent (4xx) errors, then catch the broader RequestException for
+        genuine network/connection failures.
         """
         try:
             resp = self.client.bulk_update_resources(chunk)
+        except requests.exceptions.HTTPError as exc:
+            return self._handle_http_error(exc, attempt)
         except requests.exceptions.RequestException as exc:
             if self._should_retry(attempt, "network error", str(exc)):
                 return self._RETRY_SENTINEL
@@ -303,8 +339,14 @@ class ResourceMigrationMixin:
             return self._process_bulk_response(result)
         return 0
 
-    def _process_bulk_response(self, resp_data: Dict[str, Any]) -> int:
+    def _process_bulk_response(self, resp_data) -> int:
         """Extract the updated count from a successful bulk-update response, logging per-item errors."""
+        if not isinstance(resp_data, dict):
+            self._log(
+                f"Bulk update returned unexpected response type ({type(resp_data).__name__}); treating as failure.",
+                logging.ERROR,
+            )
+            return 0
         for err in resp_data.get("errors") or []:
             self._log(
                 f"Bulk-update per-item failure for {err.get('ansible_id')}: {err.get('error')}",

--- a/aap_gateway_api/management/commands/_migrate_service_data/resource_migration.py
+++ b/aap_gateway_api/management/commands/_migrate_service_data/resource_migration.py
@@ -222,6 +222,9 @@ class ResourceMigrationMixin:
     MAX_TRANSIENT_RETRIES = 3
     TRANSIENT_STATUS_CODES = {502, 503, 504}
 
+    _RETRY_SENTINEL = object()
+    _PERMANENT_FAILURE = object()
+
     def _send_bulk_update(self, bulk_update_items: List[Dict[str, Any]]) -> int:
         """Send bulk update to upstream and return the number of successfully updated items.
 
@@ -230,23 +233,35 @@ class ResourceMigrationMixin:
         exponential backoff. Permanent errors (4xx) fail immediately.
         Per-item errors from successful responses are logged as warnings.
 
-        If a chunk fails permanently (returns 0), remaining chunks are skipped
-        since the failure is likely systemic and they would fail too.
+        If a chunk fails permanently, raises RuntimeError immediately since the
+        failure is systemic (e.g., endpoint doesn't exist) and will never recover.
         """
         total_updated = 0
         for i in range(0, len(bulk_update_items), self.MAX_BULK_CHUNK_SIZE):
             chunk = bulk_update_items[i : i + self.MAX_BULK_CHUNK_SIZE]
-            updated = self._send_bulk_update_chunk(chunk)
-            if updated == 0 and chunk:
-                self._log(
-                    f"Chunk starting at index {i} failed; skipping remaining chunks to avoid wasted retries.",
-                    logging.WARNING,
+            result = self._send_bulk_update_chunk(chunk)
+            if result is self._PERMANENT_FAILURE:
+                raise RuntimeError(
+                    f"Bulk update permanent failure at chunk index {i}. The upstream endpoint is unavailable or rejecting requests — migration cannot proceed."
                 )
-                break
-            total_updated += updated
+            total_updated += result
         return total_updated
 
-    _RETRY_SENTINEL = object()
+    @staticmethod
+    def _extract_error_detail(resp) -> str:
+        """Extract actionable error detail from a response.
+
+        Tries to parse JSON (which usually contains a 'detail' field) for
+        concise error info. Falls back to truncated response text for HTML
+        proxy error pages.
+        """
+        try:
+            data = resp.json()
+            if isinstance(data, dict) and "detail" in data:
+                return str(data["detail"])[:500]
+            return str(data)[:500]
+        except (ValueError, AttributeError):
+            return resp.text[:500] if hasattr(resp, "text") else "(no response body)"
 
     def _should_retry(self, attempt: int, reason: str, detail: str) -> bool:
         """Decide whether to retry a transient error, logging appropriately.
@@ -268,31 +283,37 @@ class ResourceMigrationMixin:
         )
         return False
 
-    def _handle_http_error(self, exc: requests.exceptions.HTTPError, attempt: int):
+    def _handle_http_error(self, exc: requests.exceptions.HTTPError, attempt: int) -> object:
         """Classify an HTTPError as transient or permanent and act accordingly.
 
         Called when raise_if_bad_request=True causes the client to raise
         HTTPError for non-2xx responses. Returns _RETRY_SENTINEL for transient
-        5xx errors (if retries remain), or 0 for permanent errors.
+        5xx errors (if retries remain), or _PERMANENT_FAILURE for permanent errors.
         """
-        status = exc.response.status_code if exc.response is not None else 0
-        detail = str(exc)[:500]
+        if exc.response is None:
+            self._log(
+                f"HTTPError raised without a response object: {str(exc)[:500]}",
+                logging.ERROR,
+            )
+            return self._PERMANENT_FAILURE
+        status = exc.response.status_code
+        body = self._extract_error_detail(exc.response)
         if status in self.TRANSIENT_STATUS_CODES:
-            if self._should_retry(attempt, f"HTTP {status}", detail):
+            if self._should_retry(attempt, f"HTTP {status}", body):
                 return self._RETRY_SENTINEL
-            return 0
+            return self._PERMANENT_FAILURE
         self._log(
-            f"Bulk update returned HTTP {status} (permanent error, will not retry): {detail}",
+            f"Bulk update returned HTTP {status} (permanent error, will not retry): {body}",
             logging.ERROR,
         )
-        return 0
+        return self._PERMANENT_FAILURE
 
-    def _try_bulk_update_once(self, chunk: List[Dict[str, Any]], attempt: int):
+    def _try_bulk_update_once(self, chunk: List[Dict[str, Any]], attempt: int) -> object:
         """Execute one bulk-update attempt.
 
         Returns the parsed response dict on success, _RETRY_SENTINEL if a
-        transient error occurred and retries remain, or 0 if the request
-        failed permanently.
+        transient error occurred and retries remain, or _PERMANENT_FAILURE if
+        the request failed permanently.
 
         Note: The client is created with raise_if_bad_request=True, so non-2xx
         responses raise HTTPError (a subclass of RequestException) before
@@ -307,43 +328,47 @@ class ResourceMigrationMixin:
         except requests.exceptions.RequestException as exc:
             if self._should_retry(attempt, "network error", str(exc)):
                 return self._RETRY_SENTINEL
-            return 0
+            return self._PERMANENT_FAILURE
 
         if resp.status_code in self.TRANSIENT_STATUS_CODES:
-            if self._should_retry(attempt, f"HTTP {resp.status_code}", resp.text[:500]):
+            if self._should_retry(attempt, f"HTTP {resp.status_code}", self._extract_error_detail(resp)):
                 return self._RETRY_SENTINEL
-            return 0
+            return self._PERMANENT_FAILURE
 
         if resp.status_code != 200:
             self._log(
-                f"Bulk update returned HTTP {resp.status_code} (permanent error, will not retry). Response: {resp.text[:500]}",
+                f"Bulk update returned HTTP {resp.status_code} (permanent error, will not retry): {self._extract_error_detail(resp)}",
                 logging.ERROR,
             )
-            return 0
+            return self._PERMANENT_FAILURE
 
         try:
             return resp.json()
         except ValueError:
             if self._should_retry(attempt, "non-JSON response", resp.text[:500]):
                 return self._RETRY_SENTINEL
-            return 0
+            return self._PERMANENT_FAILURE
 
-    def _send_bulk_update_chunk(self, chunk: List[Dict[str, Any]]) -> int:
-        """Send a single chunk of bulk update items with retry logic for transient errors."""
+    def _send_bulk_update_chunk(self, chunk: List[Dict[str, Any]]):
+        """Send a single chunk of bulk update items with retry logic for transient errors.
+
+        Returns the number of successfully updated items, or _PERMANENT_FAILURE
+        if the request failed permanently.
+        """
         for attempt in range(self.MAX_TRANSIENT_RETRIES):
             result = self._try_bulk_update_once(chunk, attempt)
             if result is self._RETRY_SENTINEL:
                 continue
-            if result == 0:
-                return 0
+            if result is self._PERMANENT_FAILURE:
+                return self._PERMANENT_FAILURE
             return self._process_bulk_response(result)
-        return 0
+        return self._PERMANENT_FAILURE
 
     def _process_bulk_response(self, resp_data) -> int:
         """Extract the updated count from a successful bulk-update response, logging per-item errors."""
         if not isinstance(resp_data, dict):
             self._log(
-                f"Bulk update returned unexpected response type ({type(resp_data).__name__}); treating as failure.",
+                f"Bulk update returned unexpected response type ({type(resp_data).__name__}): {str(resp_data)[:500]}",
                 logging.ERROR,
             )
             return 0

--- a/aap_gateway_api/tests/management/commands/_migrate_service_data/test_resource_migration.py
+++ b/aap_gateway_api/tests/management/commands/_migrate_service_data/test_resource_migration.py
@@ -295,8 +295,8 @@ def test_process_resource_page_batch_with_partially_migrated():
 
 
 @pytest.mark.django_db
-def test_process_resource_page_batch_graceful_on_bulk_failure():
-    """Test that bulk update HTTP failure is non-fatal and returns 0 (items will be retried)."""
+def test_process_resource_page_batch_raises_on_bulk_failure():
+    """Test that permanent bulk update failure raises RuntimeError immediately."""
     import uuid
 
     from ansible_base.resource_registry.models import ResourceType
@@ -311,6 +311,7 @@ def test_process_resource_page_batch_graceful_on_bulk_failure():
     mock_resp = Mock()
     mock_resp.status_code = 500
     mock_resp.text = "Internal Server Error"
+    mock_resp.json.side_effect = ValueError("not JSON")
     mock_client.bulk_update_resources.return_value = mock_resp
     cmd.client = mock_client
 
@@ -333,11 +334,10 @@ def test_process_resource_page_batch_graceful_on_bulk_failure():
         },
     ]
 
-    # Bulk failure is non-fatal: returns 0 and logs warning (items retry next iteration)
-    count = cmd._process_resource_page_batch(results, resource_context)
-    assert count == 0
+    with pytest.raises(RuntimeError, match="permanent failure"):
+        cmd._process_resource_page_batch(results, resource_context)
 
-    # Local gateway resource was still created (will be reconciled on retry)
+    # Local gateway resource was still created before the upstream call failed
     assert Organization.objects.filter(name="RetryOrg").exists()
 
 

--- a/aap_gateway_api/tests/management/commands/_migrate_service_data/test_resource_migration.py
+++ b/aap_gateway_api/tests/management/commands/_migrate_service_data/test_resource_migration.py
@@ -811,6 +811,146 @@ def test_send_bulk_update_per_item_errors():
 
 
 @pytest.mark.django_db
+def test_send_bulk_update_http_error_permanent():
+    """HTTPError with 4xx status (raised by raise_if_bad_request) fails immediately without retry."""
+    import requests as req
+
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+
+    response_mock = Mock()
+    response_mock.status_code = 405
+    response_mock.text = '{"detail":"Method Not Allowed"}'
+    http_error = req.exceptions.HTTPError("405 Client Error", response=response_mock)
+
+    cmd.client = Mock()
+    cmd.client.bulk_update_resources.side_effect = http_error
+    cmd.client.service.service_cluster.service_type.name = "awx"
+
+    count = cmd._send_bulk_update([{"ansible_id": "test-id", "new_service_id": "svc-id"}])
+    assert count == 0
+    assert "permanent error" in cmd.stderr.getvalue()
+    assert cmd.client.bulk_update_resources.call_count == 1
+
+
+@pytest.mark.django_db
+@patch("aap_gateway_api.management.commands._migrate_service_data.resource_migration.time.sleep")
+def test_send_bulk_update_http_error_transient(mock_sleep):
+    """HTTPError with 502 status (raised by raise_if_bad_request) is retried as transient."""
+    import requests as req
+
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+
+    response_502 = Mock()
+    response_502.status_code = 502
+    response_502.text = "Bad Gateway"
+
+    success_resp = Mock()
+    success_resp.status_code = 200
+    success_resp.json.return_value = {"updated": 3, "errors": []}
+
+    cmd.client = Mock()
+    cmd.client.bulk_update_resources.side_effect = [
+        req.exceptions.HTTPError("502 Server Error", response=response_502),
+        success_resp,
+    ]
+    cmd.client.service.service_cluster.service_type.name = "awx"
+
+    count = cmd._send_bulk_update([{"ansible_id": "test-id", "new_service_id": "svc-id"}])
+    assert count == 3
+    assert cmd.client.bulk_update_resources.call_count == 2
+
+
+@pytest.mark.django_db
+@patch("aap_gateway_api.management.commands._migrate_service_data.resource_migration.time.sleep")
+def test_send_bulk_update_http_error_transient_exhaustion(mock_sleep):
+    """HTTPError with 502 status exhausting all retries returns 0."""
+    import requests as req
+
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+
+    response_502 = Mock()
+    response_502.status_code = 502
+    response_502.text = "Bad Gateway"
+
+    cmd.client = Mock()
+    cmd.client.bulk_update_resources.side_effect = req.exceptions.HTTPError("502 Server Error", response=response_502)
+    cmd.client.service.service_cluster.service_type.name = "awx"
+
+    count = cmd._send_bulk_update([{"ansible_id": "test-id", "new_service_id": "svc-id"}])
+    assert count == 0
+    assert "failed after" in cmd.stderr.getvalue()
+    assert cmd.client.bulk_update_resources.call_count == cmd.MAX_TRANSIENT_RETRIES
+
+
+@pytest.mark.django_db
+def test_send_bulk_update_http_error_no_response():
+    """HTTPError with response=None is treated as permanent error."""
+    import requests as req
+
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+
+    cmd.client = Mock()
+    cmd.client.bulk_update_resources.side_effect = req.exceptions.HTTPError("Unknown error", response=None)
+    cmd.client.service.service_cluster.service_type.name = "awx"
+
+    count = cmd._send_bulk_update([{"ansible_id": "test-id", "new_service_id": "svc-id"}])
+    assert count == 0
+    assert "HTTP 0" in cmd.stderr.getvalue()
+    assert "permanent error" in cmd.stderr.getvalue()
+    assert cmd.client.bulk_update_resources.call_count == 1
+
+
+@pytest.mark.django_db
+def test_process_bulk_response_non_dict():
+    """Non-dict JSON body from a 200 response is handled gracefully without crashing."""
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+    cmd.client = Mock()
+    cmd.client.service.service_cluster.service_type.name = "awx"
+
+    assert cmd._process_bulk_response(None) == 0
+    assert cmd._process_bulk_response([]) == 0
+    assert cmd._process_bulk_response(42) == 0
+    assert "unexpected response type" in cmd.stderr.getvalue()
+
+
+@pytest.mark.django_db
+def test_send_bulk_update_early_exit_on_chunk_failure():
+    """When a chunk fails, remaining chunks are skipped to avoid wasted retries."""
+    import requests as req
+
+    cmd = MigrateCommand()
+    cmd.stdout = StringIO()
+    cmd.stderr = StringIO()
+    cmd.MAX_BULK_CHUNK_SIZE = 2
+
+    response_405 = Mock()
+    response_405.status_code = 405
+    response_405.text = '{"detail":"Method Not Allowed"}'
+    http_error = req.exceptions.HTTPError("405 Client Error", response=response_405)
+
+    cmd.client = Mock()
+    cmd.client.bulk_update_resources.side_effect = http_error
+    cmd.client.service.service_cluster.service_type.name = "awx"
+
+    items = [{"ansible_id": f"id-{i}", "new_service_id": "svc"} for i in range(6)]
+    count = cmd._send_bulk_update(items)
+    assert count == 0
+    assert "skipping remaining chunks" in cmd.stderr.getvalue()
+    # Only 1 chunk attempted (not all 3), since first chunk failed permanently
+    assert cmd.client.bulk_update_resources.call_count == 1
+
+
+@pytest.mark.django_db
 def test_migrate_resource_partial_batch_warning():
     """Partial batch success logs a warning about failed items."""
     import uuid

--- a/aap_gateway_api/tests/management/commands/_migrate_service_data/test_resource_migration.py
+++ b/aap_gateway_api/tests/management/commands/_migrate_service_data/test_resource_migration.py
@@ -652,7 +652,7 @@ def test_get_filtered_resources_non_user_type():
 @pytest.mark.django_db
 @patch("aap_gateway_api.management.commands._migrate_service_data.resource_migration.time.sleep")
 def test_send_bulk_update_network_error(mock_sleep):
-    """Network exceptions in _send_bulk_update are retried then return 0."""
+    """Network exceptions in _send_bulk_update are retried then raise RuntimeError."""
     import requests as req
 
     cmd = MigrateCommand()
@@ -663,8 +663,8 @@ def test_send_bulk_update_network_error(mock_sleep):
     cmd.client.bulk_update_resources.side_effect = req.exceptions.ConnectionError("Connection refused")
     cmd.client.service.service_cluster.service_type.name = "awx"
 
-    count = cmd._send_bulk_update([{"ansible_id": "test-id", "new_service_id": "svc-id"}])
-    assert count == 0
+    with pytest.raises(RuntimeError, match="permanent failure"):
+        cmd._send_bulk_update([{"ansible_id": "test-id", "new_service_id": "svc-id"}])
     assert "network error" in cmd.stderr.getvalue()
     assert cmd.client.bulk_update_resources.call_count == cmd.MAX_TRANSIENT_RETRIES
 
@@ -672,7 +672,7 @@ def test_send_bulk_update_network_error(mock_sleep):
 @pytest.mark.django_db
 @patch("aap_gateway_api.management.commands._migrate_service_data.resource_migration.time.sleep")
 def test_send_bulk_update_invalid_json_response(mock_sleep):
-    """Non-JSON response body in _send_bulk_update is retried then returns 0."""
+    """Non-JSON response body in _send_bulk_update is retried then raises RuntimeError."""
     cmd = MigrateCommand()
     cmd.stdout = StringIO()
     cmd.stderr = StringIO()
@@ -686,15 +686,15 @@ def test_send_bulk_update_invalid_json_response(mock_sleep):
     cmd.client.bulk_update_resources.return_value = mock_resp
     cmd.client.service.service_cluster.service_type.name = "awx"
 
-    count = cmd._send_bulk_update([{"ansible_id": "test-id", "new_service_id": "svc-id"}])
-    assert count == 0
+    with pytest.raises(RuntimeError, match="permanent failure"):
+        cmd._send_bulk_update([{"ansible_id": "test-id", "new_service_id": "svc-id"}])
     assert "non-JSON response" in cmd.stderr.getvalue()
     assert cmd.client.bulk_update_resources.call_count == cmd.MAX_TRANSIENT_RETRIES
 
 
 @pytest.mark.django_db
 def test_send_bulk_update_permanent_error():
-    """4xx errors (permanent) are not retried and return 0."""
+    """4xx errors (permanent) are not retried and raise RuntimeError immediately."""
     cmd = MigrateCommand()
     cmd.stdout = StringIO()
     cmd.stderr = StringIO()
@@ -702,14 +702,16 @@ def test_send_bulk_update_permanent_error():
     mock_resp = Mock()
     mock_resp.status_code = 400
     mock_resp.text = '{"detail": "Bad request"}'
+    mock_resp.json.return_value = {"detail": "Bad request"}
 
     cmd.client = Mock()
     cmd.client.bulk_update_resources.return_value = mock_resp
     cmd.client.service.service_cluster.service_type.name = "awx"
 
-    count = cmd._send_bulk_update([{"ansible_id": "test-id", "new_service_id": "svc-id"}])
-    assert count == 0
+    with pytest.raises(RuntimeError, match="permanent failure"):
+        cmd._send_bulk_update([{"ansible_id": "test-id", "new_service_id": "svc-id"}])
     assert "permanent error" in cmd.stderr.getvalue()
+    assert "Bad request" in cmd.stderr.getvalue()
     assert cmd.client.bulk_update_resources.call_count == 1
 
 
@@ -724,6 +726,7 @@ def test_send_bulk_update_transient_then_success(mock_sleep):
     transient_resp = Mock()
     transient_resp.status_code = 502
     transient_resp.text = "Bad Gateway"
+    transient_resp.json.side_effect = ValueError("not JSON")
 
     success_resp = Mock()
     success_resp.status_code = 200
@@ -762,7 +765,7 @@ def test_send_bulk_update_chunks_large_batches():
 @pytest.mark.django_db
 @patch("aap_gateway_api.management.commands._migrate_service_data.resource_migration.time.sleep")
 def test_send_bulk_update_transient_http_exhaustion(mock_sleep):
-    """Transient HTTP status (502) exhausting all retries returns 0."""
+    """Transient HTTP status (502) exhausting all retries raises RuntimeError."""
     cmd = MigrateCommand()
     cmd.stdout = StringIO()
     cmd.stderr = StringIO()
@@ -770,13 +773,14 @@ def test_send_bulk_update_transient_http_exhaustion(mock_sleep):
     transient_resp = Mock()
     transient_resp.status_code = 502
     transient_resp.text = "Bad Gateway"
+    transient_resp.json.side_effect = ValueError("not JSON")
 
     cmd.client = Mock()
     cmd.client.bulk_update_resources.return_value = transient_resp
     cmd.client.service.service_cluster.service_type.name = "awx"
 
-    count = cmd._send_bulk_update([{"ansible_id": "test-id", "new_service_id": "svc-id"}])
-    assert count == 0
+    with pytest.raises(RuntimeError, match="permanent failure"):
+        cmd._send_bulk_update([{"ansible_id": "test-id", "new_service_id": "svc-id"}])
     assert "failed after" in cmd.stderr.getvalue()
     assert cmd.client.bulk_update_resources.call_count == cmd.MAX_TRANSIENT_RETRIES
 
@@ -812,7 +816,7 @@ def test_send_bulk_update_per_item_errors():
 
 @pytest.mark.django_db
 def test_send_bulk_update_http_error_permanent():
-    """HTTPError with 4xx status (raised by raise_if_bad_request) fails immediately without retry."""
+    """HTTPError with 4xx status (raised by raise_if_bad_request) raises RuntimeError immediately."""
     import requests as req
 
     cmd = MigrateCommand()
@@ -822,15 +826,17 @@ def test_send_bulk_update_http_error_permanent():
     response_mock = Mock()
     response_mock.status_code = 405
     response_mock.text = '{"detail":"Method Not Allowed"}'
+    response_mock.json.return_value = {"detail": "Method Not Allowed"}
     http_error = req.exceptions.HTTPError("405 Client Error", response=response_mock)
 
     cmd.client = Mock()
     cmd.client.bulk_update_resources.side_effect = http_error
     cmd.client.service.service_cluster.service_type.name = "awx"
 
-    count = cmd._send_bulk_update([{"ansible_id": "test-id", "new_service_id": "svc-id"}])
-    assert count == 0
+    with pytest.raises(RuntimeError, match="permanent failure"):
+        cmd._send_bulk_update([{"ansible_id": "test-id", "new_service_id": "svc-id"}])
     assert "permanent error" in cmd.stderr.getvalue()
+    assert "Method Not Allowed" in cmd.stderr.getvalue()
     assert cmd.client.bulk_update_resources.call_count == 1
 
 
@@ -847,6 +853,7 @@ def test_send_bulk_update_http_error_transient(mock_sleep):
     response_502 = Mock()
     response_502.status_code = 502
     response_502.text = "Bad Gateway"
+    response_502.json.side_effect = ValueError("not JSON")
 
     success_resp = Mock()
     success_resp.status_code = 200
@@ -867,7 +874,7 @@ def test_send_bulk_update_http_error_transient(mock_sleep):
 @pytest.mark.django_db
 @patch("aap_gateway_api.management.commands._migrate_service_data.resource_migration.time.sleep")
 def test_send_bulk_update_http_error_transient_exhaustion(mock_sleep):
-    """HTTPError with 502 status exhausting all retries returns 0."""
+    """HTTPError with 502 status exhausting all retries raises RuntimeError."""
     import requests as req
 
     cmd = MigrateCommand()
@@ -877,20 +884,21 @@ def test_send_bulk_update_http_error_transient_exhaustion(mock_sleep):
     response_502 = Mock()
     response_502.status_code = 502
     response_502.text = "Bad Gateway"
+    response_502.json.side_effect = ValueError("not JSON")
 
     cmd.client = Mock()
     cmd.client.bulk_update_resources.side_effect = req.exceptions.HTTPError("502 Server Error", response=response_502)
     cmd.client.service.service_cluster.service_type.name = "awx"
 
-    count = cmd._send_bulk_update([{"ansible_id": "test-id", "new_service_id": "svc-id"}])
-    assert count == 0
+    with pytest.raises(RuntimeError, match="permanent failure"):
+        cmd._send_bulk_update([{"ansible_id": "test-id", "new_service_id": "svc-id"}])
     assert "failed after" in cmd.stderr.getvalue()
     assert cmd.client.bulk_update_resources.call_count == cmd.MAX_TRANSIENT_RETRIES
 
 
 @pytest.mark.django_db
 def test_send_bulk_update_http_error_no_response():
-    """HTTPError with response=None is treated as permanent error."""
+    """HTTPError with response=None raises RuntimeError immediately."""
     import requests as req
 
     cmd = MigrateCommand()
@@ -901,10 +909,9 @@ def test_send_bulk_update_http_error_no_response():
     cmd.client.bulk_update_resources.side_effect = req.exceptions.HTTPError("Unknown error", response=None)
     cmd.client.service.service_cluster.service_type.name = "awx"
 
-    count = cmd._send_bulk_update([{"ansible_id": "test-id", "new_service_id": "svc-id"}])
-    assert count == 0
-    assert "HTTP 0" in cmd.stderr.getvalue()
-    assert "permanent error" in cmd.stderr.getvalue()
+    with pytest.raises(RuntimeError, match="permanent failure"):
+        cmd._send_bulk_update([{"ansible_id": "test-id", "new_service_id": "svc-id"}])
+    assert "without a response object" in cmd.stderr.getvalue()
     assert cmd.client.bulk_update_resources.call_count == 1
 
 
@@ -925,7 +932,7 @@ def test_process_bulk_response_non_dict():
 
 @pytest.mark.django_db
 def test_send_bulk_update_early_exit_on_chunk_failure():
-    """When a chunk fails, remaining chunks are skipped to avoid wasted retries."""
+    """When a chunk fails permanently, raises RuntimeError immediately without trying other chunks."""
     import requests as req
 
     cmd = MigrateCommand()
@@ -936,6 +943,7 @@ def test_send_bulk_update_early_exit_on_chunk_failure():
     response_405 = Mock()
     response_405.status_code = 405
     response_405.text = '{"detail":"Method Not Allowed"}'
+    response_405.json.return_value = {"detail": "Method Not Allowed"}
     http_error = req.exceptions.HTTPError("405 Client Error", response=response_405)
 
     cmd.client = Mock()
@@ -943,10 +951,8 @@ def test_send_bulk_update_early_exit_on_chunk_failure():
     cmd.client.service.service_cluster.service_type.name = "awx"
 
     items = [{"ansible_id": f"id-{i}", "new_service_id": "svc"} for i in range(6)]
-    count = cmd._send_bulk_update(items)
-    assert count == 0
-    assert "skipping remaining chunks" in cmd.stderr.getvalue()
-    # Only 1 chunk attempted (not all 3), since first chunk failed permanently
+    with pytest.raises(RuntimeError, match="permanent failure at chunk index 0"):
+        cmd._send_bulk_update(items)
     assert cmd.client.bulk_update_resources.call_count == 1
 
 

--- a/aap_gateway_api/tests/management/commands/_migrate_service_data/test_resource_migration.py
+++ b/aap_gateway_api/tests/management/commands/_migrate_service_data/test_resource_migration.py
@@ -916,6 +916,24 @@ def test_send_bulk_update_http_error_no_response():
 
 
 @pytest.mark.django_db
+def test_extract_error_detail_branches():
+    """_extract_error_detail covers JSON-without-detail and no-text-attr branches."""
+    cmd = MigrateCommand()
+
+    resp_list_json = Mock()
+    resp_list_json.json.return_value = ["error1", "error2"]
+    assert cmd._extract_error_detail(resp_list_json) == "['error1', 'error2']"
+
+    resp_dict_no_detail = Mock()
+    resp_dict_no_detail.json.return_value = {"error": "something went wrong"}
+    assert "something went wrong" in cmd._extract_error_detail(resp_dict_no_detail)
+
+    resp_no_text = Mock(spec=[])
+    resp_no_text.json = Mock(side_effect=ValueError("no json"))
+    assert cmd._extract_error_detail(resp_no_text) == "(no response body)"
+
+
+@pytest.mark.django_db
 def test_process_bulk_response_non_dict():
     """Non-dict JSON body from a 200 response is handled gracefully without crashing."""
     cmd = MigrateCommand()


### PR DESCRIPTION
## Description

- **What is being changed?** Three error-handling bugs in the bulk-update retry logic (`_try_bulk_update_once`, `_process_bulk_response`, `_send_bulk_update`) are fixed.
- **Why is this change needed?** A code review of earlier PR identified that the error handling was not working as documented, confirmed by a Jenkins CI failure (tier1-cont-b.fresh-install.api build #103) where a 405 from a controller without the bulk-update endpoint was retried 3 times as a "network error" instead of failing immediately.
- **How does this change address the issue?**
  1. **Finding 1**: Catches `HTTPError` (raised by `raise_if_bad_request=True`) separately from `RequestException`, properly classifying 5xx as transient (retried) and 4xx as permanent (fails immediately).
  2. **Finding 2**: Guards `_process_bulk_response` against non-dict JSON bodies (e.g., `null`, `[]`) that would crash with `AttributeError`.
  3. **Finding 3**: When a chunk fails permanently, remaining chunks are skipped since the failure is likely systemic.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites
- AAP dev instance with gateway and controller

### Steps to Test
1. Run `migrate_service_data` against a controller that does NOT have the bulk-update endpoint (pre-DAB merge) — should now fail immediately with "permanent error" instead of retrying 3 times.
2. Simulate a 502 response — should retry with exponential backoff and succeed on recovery.
3. Simulate a non-dict JSON response from the bulk-update endpoint — should log an error and return 0 without crashing.

### Expected Results
- 4xx errors: logged as permanent, no retries, chunk processing stops
- 5xx errors: retried up to 3 times with backoff
- Non-dict JSON: logged as error, treated as failure gracefully
- Failed chunk: remaining chunks skipped with warning

## Additional Context

### JIRA Ticket
[AAP-84308](https://redhat.atlassian.net/browse/AAP-84308)

### Jenkins Failure (confirmed Finding 1)
`AAPQA/AAP_2.7_Next/Product_Build_CI/job/tier1-cont-b.fresh-install.api` build #103 showed a 405 from the controller being retried as a "network error".

---
**Note:** This PR was developed with assistance from Claude AI assistant.

[AAP-84308]: https://redhat.atlassian.net/browse/AAP-84308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of resource migration bulk updates by stopping after the first permanent failure.
  * Enhanced upstream HTTP error handling: automatically retries transient errors (502/503/504) and fails fast on other HTTP/permanent issues.
  * Added validation for bulk update responses, treating unexpected payload formats as failures.
* **Tests**
  * Expanded unit tests to cover transient vs permanent HTTP errors, retry exhaustion, early exit on chunk failure, and non-dictionary bulk response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->