### PR TITLE
[AAP-83110] fix(ci): extract base branch from merge queue branch name

### DIFF
--- a/tools/scripts/get_pr_checkout.py
+++ b/tools/scripts/get_pr_checkout.py
@@ -284,6 +284,14 @@ def get_env_config():
     target_branch = os.environ.get('GITHUB_BASE_REF') or os.environ.get('GITHUB_REF_NAME')
     token = os.environ.get('GH_TOKEN') or os.environ.get('ANSIBLE_TOKEN')
 
+    # Handle GitHub merge queue branch names (gh-readonly-queue/<base-branch>/pr-<number>-<sha>)
+    if target_branch:
+        merge_queue_match = re.match(r'^gh-readonly-queue/(.+)/pr-\d+-', target_branch)
+        if merge_queue_match:
+            base_branch = merge_queue_match.group(1)
+            print(f"ℹ️  Detected merge queue branch '{target_branch}', using base branch: '{base_branch}'")
+            target_branch = base_branch
+
     print(f"Target branch: {target_branch or 'unknown'}")
     print(f"Token available: {'yes' if token else 'no'}")
 

--- a/tools/scripts/tests/test_get_pr_checkout.py
+++ b/tools/scripts/tests/test_get_pr_checkout.py
@@ -535,6 +535,7 @@ class TestMergeQueueBranchParsing:
             ("gh-readonly-queue/main/pr-42-cafebabe9876", "main"),
             ("gh-readonly-queue/test-release-0.0/pr-999-deadbeef1234", "test-release-0.0"),
             ("gh-readonly-queue/test-release-0.1/pr-1503-190debac0f96", "test-release-0.1"),
+            ("gh-readonly-queue/feature/my-feature/pr-42-abc123def456", "feature/my-feature"),
         ],
     )
     def test_merge_queue_extracts_base_branch(self, monkeypatch, merge_queue_ref, expected_base):

--- a/tools/scripts/tests/test_get_pr_checkout.py
+++ b/tools/scripts/tests/test_get_pr_checkout.py
@@ -523,3 +523,89 @@ class TestMainScenarios:
             get_pr_checkout.main()
 
         assert exc_info.value.code == 1
+
+
+class TestMergeQueueBranchParsing:
+    """Test merge queue branch name parsing in get_env_config()"""
+
+    @pytest.mark.parametrize(
+        "merge_queue_ref, expected_base",
+        [
+            ("gh-readonly-queue/devel/pr-158-abc123def456", "devel"),
+            ("gh-readonly-queue/main/pr-42-cafebabe9876", "main"),
+            ("gh-readonly-queue/test-release-0.0/pr-999-deadbeef1234", "test-release-0.0"),
+            ("gh-readonly-queue/test-release-0.1/pr-1503-190debac0f96", "test-release-0.1"),
+        ],
+    )
+    def test_merge_queue_extracts_base_branch(self, monkeypatch, merge_queue_ref, expected_base):
+        """Test that merge queue branch names are resolved to their base branch"""
+        monkeypatch.setenv("PR_BODY", "")
+        monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
+        monkeypatch.setenv("GITHUB_REF_NAME", merge_queue_ref)
+        monkeypatch.setenv("GH_TOKEN", "test_token")
+
+        _, target_branch, _ = get_pr_checkout.get_env_config()
+
+        assert target_branch == expected_base
+
+    @pytest.mark.parametrize(
+        "env_var, env_value, expected",
+        [
+            ("GITHUB_BASE_REF", "devel", "devel"),
+            ("GITHUB_REF_NAME", "test-release-0.0", "test-release-0.0"),
+            ("GITHUB_BASE_REF", "feature/my-work", "feature/my-work"),
+        ],
+    )
+    def test_regular_branch_unchanged(self, monkeypatch, env_var, env_value, expected):
+        """Test that non-merge-queue branch names pass through unchanged"""
+        monkeypatch.setenv("PR_BODY", "")
+        monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
+        monkeypatch.delenv("GITHUB_REF_NAME", raising=False)
+        monkeypatch.setenv(env_var, env_value)
+        monkeypatch.setenv("GH_TOKEN", "test_token")
+
+        _, target_branch, _ = get_pr_checkout.get_env_config()
+
+        assert target_branch == expected
+
+    @patch("get_pr_checkout.execute_git_clone")
+    @patch("get_pr_checkout.branch_exists")
+    def test_merge_queue_end_to_end_release(self, mock_branch_exists, mock_clone, monkeypatch):
+        """End-to-end: merge queue resolves base branch for dependency lookup"""
+        monkeypatch.setenv("PR_BODY", "")
+        monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
+        monkeypatch.setenv("GITHUB_REF_NAME", "gh-readonly-queue/test-release-0.0/pr-1503-190debac0f96")
+        monkeypatch.setenv("GH_TOKEN", "test_token")
+        _set_cli_args("ansible/django-ansible-base")
+
+        mock_branch_exists.return_value = True
+        mock_clone.return_value = True
+
+        with pytest.raises(SystemExit) as exc_info:
+            get_pr_checkout.main()
+
+        assert exc_info.value.code == 0
+        mock_branch_exists.assert_called_once_with("ansible/django-ansible-base", "test-release-0.0", "test_token")
+        mock_clone.assert_called_once()
+        assert mock_clone.call_args[0][1] == "test-release-0.0"
+
+    @patch("get_pr_checkout.execute_git_clone")
+    @patch("get_pr_checkout.branch_exists")
+    def test_merge_queue_end_to_end_devel(self, mock_branch_exists, mock_clone, monkeypatch):
+        """End-to-end: merge queue for devel clones dependency from devel"""
+        monkeypatch.setenv("PR_BODY", "")
+        monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
+        monkeypatch.setenv("GITHUB_REF_NAME", "gh-readonly-queue/devel/pr-158-abc123def456")
+        monkeypatch.setenv("GH_TOKEN", "test_token")
+        _set_cli_args("ansible/django-ansible-base")
+
+        mock_branch_exists.return_value = True
+        mock_clone.return_value = True
+
+        with pytest.raises(SystemExit) as exc_info:
+            get_pr_checkout.main()
+
+        assert exc_info.value.code == 0
+        mock_branch_exists.assert_called_once_with("ansible/django-ansible-base", "devel", "test_token")
+        mock_clone.assert_called_once()
+        assert mock_clone.call_args[0][1] == "devel"


### PR DESCRIPTION
## What
Parse merge queue branch names in get_pr_checkout.py to extract the actual base branch for dependency lookup.
  
## Why
When a PR enters the GitHub merge queue, GITHUB_REF_NAME becomes the merge queue branch name which never exists in dependency repos. Without this fix, the script falls back to devel regardless of the actual target branch.
  
## Test plan
- [x] Unit tests cover merge queue branch parsing
- [x] Non-regression tests verify regular branches unchanged
- [x] End-to-end tests confirm correct dependency branch used
- [x] Validated in merge queue via ansible/jewel-debug#6 

Assisted-by: Claude Code / Opus 4.6 (Anthropic)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request checkout handling for GitHub merge queue branch names.
  * Correctly derives the underlying base branch for dependency lookup and repository checkout.
  * Preserves existing behavior for standard (non-merge-queue) branch names.
* **Tests**
  * Added coverage for merge-queue “release” and “devel” ref patterns and ensured regular branches remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->