### PR TITLE
[AAP-79673] Sync managed role permissions and add org member team visibility

### DIFF
--- a/aap_gateway_api/signals/preloaded_data.py
+++ b/aap_gateway_api/signals/preloaded_data.py
@@ -91,8 +91,11 @@ def create_default_organization() -> bool:
 def create_managed_roles() -> None:
     # Permissions and types must be created before creating managed roles
     create_dab_permissions(global_apps.get_app_config('dab_rbac'))
-    # Create the managed=True entries of RoleDefinition model
-    permission_registry.create_managed_roles(global_apps)
+    # Create the managed=True entries of RoleDefinition model.
+    # update_perms=True ensures existing managed roles stay in sync with
+    # their code-defined permissions (e.g. when DAB adds view_team to
+    # OrganizationMember).
+    permission_registry.create_managed_roles(global_apps, update_perms=True)
 
 
 def set_system_user_password() -> bool:

--- a/aap_gateway_api/tests/views/api/v1/related_views/test_related_views.py
+++ b/aap_gateway_api/tests/views/api/v1/related_views/test_related_views.py
@@ -112,8 +112,7 @@ class TestTeamRelatedUserViews(TestRelatedViewsBase):
         url = get_relative_url('team-users-list', kwargs={'pk': team.id})
         response = self.api_client.get(url)
 
-        if user_type in ['user', 'org_member']:
-            # Org Member doesn't see Team Members
+        if user_type in ['user']:
             assert response.status_code == 404
         else:
             assert response.status_code == 200
@@ -122,8 +121,11 @@ class TestTeamRelatedUserViews(TestRelatedViewsBase):
                 # Team Member doesn't see other Team members
                 assert response.data['count'] == 1, response.data['results']
                 assert response.data['results'][0]['id'] == user.id
+            elif user_type == 'org_member':
+                # Org Member can view the team but can't see other team members
+                assert response.data['count'] == 0, response.data['results']
             else:
-                # Team Admin, Auditor and Superuser see Team members
+                # Team Admin, Org Admin, Auditor and Superuser see Team members
                 assert response.data['count'] == 2, response.data['results']
                 assert set(self._get_ids(response.data['results'])) == set([member.id for member in members])
 
@@ -133,20 +135,20 @@ class TestTeamRelatedUserViews(TestRelatedViewsBase):
         url = get_relative_url('team-admins-list', kwargs={'pk': team.id})
         response = self.api_client.get(url)
 
-        if user_type in ['user', 'org_member']:
+        if user_type in ['user']:
             assert response.status_code == 404
         else:
             assert response.status_code == 200
 
-            if user_type == 'team_member':
-                # Team Member doesn't see Team Admins
+            if user_type in ['team_member', 'org_member']:
+                # Team Member and Org Member can't see Team Admins
                 assert response.data['count'] == 0, response.data['results']
             elif user_type == 'team_admin':
                 # Team Admin does see all Team Admins (including self)
                 assert response.data['count'] == 3, response.data['results']
                 assert set(self._get_ids(response.data['results'])) == set([admin.id for admin in admins] + [user.id])
             else:
-                # Auditor + Superuser see all Team Admins
+                # Org Admin, Auditor + Superuser see all Team Admins
                 assert response.data['count'] == 2, response.data['results']
                 assert set(self._get_ids(response.data['results'])) == set([admin.id for admin in admins])
 
@@ -185,7 +187,10 @@ class TestTeamRelatedUserViews(TestRelatedViewsBase):
                 if user_type == 'user':
                     assert response.status_code == (404 if api_type == 'old_api' else 400), response.data
                 elif user_type == 'org_member':
-                    assert response.status_code == (404 if api_type == 'old_api' else 400), response.data
+                    # Org member can view the team (view_team) but lacks modify permission.
+                    # old_api checks view/change perm on the team first (403).
+                    # rbac_api validates the user field first - rando isn't visible (400).
+                    assert response.status_code == (403 if api_type == 'old_api' else 400), response.data
                 elif user_type == 'org_admin':
                     # With security-first approach (False), org admins can't associate users they can't see
                     assert response.status_code == 400, response.data
@@ -213,8 +218,7 @@ class TestTeamRelatedUserViews(TestRelatedViewsBase):
             # Org member cannot add other org member although (s)he sees him/her
             elif user_type == 'org_member':
                 organization.add_member(rando)
-                # user now see rando, but is not a team admin so criteria for adding team member isn't met
+                # user now sees rando, but is not a team admin so criteria for adding team member isn't met
                 response = self.api_client.post(url, data=data)
                 assert not team.users.filter(id=rando.id).exists()
-                # Note: the old API might return also 400
-                assert response.status_code == (404 if api_type == 'old_api' else 400), response.data
+                assert response.status_code == 403, response.data

--- a/aap_gateway_api/tests/views/api/v1/team/test_team_rbac.py
+++ b/aap_gateway_api/tests/views/api/v1/team/test_team_rbac.py
@@ -3,7 +3,7 @@ from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac.models import DABContentType, RoleDefinition, RoleUserAssignment
 from django.urls import reverse
 
-from aap_gateway_api.models import Organization, User
+from aap_gateway_api.models import Organization, Team, User
 from aap_gateway_api.tests.views.api.v1.conftest import api_get_and_assert
 
 
@@ -30,24 +30,25 @@ def _visible_teams(teams, organizations, org_admins_can_see_all=True):
     """
     Based on associate_logged_user()
     When ORG_ADMINS_CAN_SEE_ALL_USERS=True (default): Org Admins can see ALL teams
-    When ORG_ADMINS_CAN_SEE_ALL_USERS=False: Org Admins can only see teams from their own organization
-    Team Members and Team Admins can always see their teams
+    When ORG_ADMINS_CAN_SEE_ALL_USERS=False: falls through to DAB access_qs, so
+      visibility comes from RBAC permissions - team member/admin see their teams,
+      org member sees all teams in their org, org admin sees all teams in their org.
     """
     if org_admins_can_see_all:
-        # User is org admin, so they can see ALL teams when ORG_ADMINS_CAN_SEE_ALL_USERS=True (default)
         all_teams = []
         for org in organizations:
             all_teams.extend(teams[org])
         return sorted(all_teams, key=lambda t: t.id)
     else:
-        # When False: org admin can only see teams from their own org (organizations[4])
-        # Plus teams where they're team member/admin (orgs 0, 1, 2)
-        return [
+        visible = [
             teams[organizations[0]][0],  # Team member
             teams[organizations[1]][0],  # Team admin
             teams[organizations[2]][0],  # Team member
             teams[organizations[2]][1],  # Team admin
-        ] + teams[organizations[4]]  # All teams from org where user is org admin
+        ]
+        visible += teams[organizations[3]]  # All teams from org where user is org member
+        visible += teams[organizations[4]]  # All teams from org where user is org admin
+        return visible
 
 
 def _editable_teams(teams, organizations):
@@ -396,6 +397,43 @@ class TestTeamOptions:
         response = admin_api_client.options(url)
         assert response.status_code == 200
         assert response.data.get('actions', {}).get('PUT', None) is not None, "PUT action should be available for superuser"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('org_admins_can_see_all', [True, False], ids=['see_all=True', 'see_all=False'])
+def test_pure_org_member_can_see_teams_in_org(user_api_client, user, org_member_rd, preference_manager, org_admins_can_see_all):
+    """Regression test for AAP-79673.
+
+    A user who is ONLY an org member (no org admin role anywhere) should see
+    teams in their organization via the team list API.  Before the fix,
+    can_view_all_users() returned False for such users, so the view fell
+    through to access_qs which did not grant view_team to org members.
+
+    Parametrized on ORG_ADMINS_CAN_SEE_ALL_USERS because a pure org member
+    (no org admin role) should behave identically regardless of this setting.
+    """
+    org = Organization.objects.create(name='OrgMember-Only Org')
+    other_org = Organization.objects.create(name='Other Org')
+    team_in_org = Team.objects.create(name='Visible Team', organization=org)
+    hidden_team = Team.objects.create(name='Hidden Team', organization=other_org)
+
+    org_member_rd.give_permission(user, org)
+
+    with preference_manager.set('configuration', 'ORG_ADMINS_CAN_SEE_ALL_USERS', org_admins_can_see_all):
+        url = get_relative_url("team-list")
+        response = user_api_client.get(url)
+        assert response.status_code == 200
+        team_ids = {t['id'] for t in response.data['results']}
+        assert team_in_org.pk in team_ids, "Org member should see teams in their org"
+        assert response.data['count'] == 1, "Org member should only see teams from their own org"
+
+        detail_url = get_relative_url("team-detail", kwargs={'pk': team_in_org.pk})
+        response = user_api_client.get(detail_url)
+        assert response.status_code == 200, "Org member should access team detail in their org"
+
+        hidden_detail_url = get_relative_url("team-detail", kwargs={'pk': hidden_team.pk})
+        response = user_api_client.get(hidden_detail_url)
+        assert response.status_code == 404, "Org member should NOT access teams in other orgs"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Description

- **What:** Pass `update_perms=True` to `permission_registry.create_managed_roles()` in the post-migrate signal, and update team RBAC test expectations so org members see teams in their organization.
- **Why:** AAP-79673 reports that organization members cannot view teams within their organization. The root cause is that the `OrganizationMember` managed role lacks `view_team`. The DAB fix (ansible/django-ansible-base#1070) adds `view_team` to the `OrganizationMember` constructor, but existing deployments need `update_perms=True` during migration to sync the new permission into existing role definitions.
- **How:** The `create_managed_roles()` signal function now calls `create_managed_roles(apps, update_perms=True)`, which reconciles permissions on every migration. Test expectations in `_visible_teams()` are updated to reflect that org members now see teams in their org via `access_qs`. A new regression test (`test_pure_org_member_can_see_teams_in_org`) verifies that a user with only an org member role can list and access teams in their organization.

```yaml
release: "devel"
```

Requires: https://github.com/ansible/django-ansible-base/pull/1070

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases

## Testing Instructions

### Prerequisites
- DAB PR ansible/django-ansible-base#1070 must be merged (or installed from branch) for the new `view_team` permission to exist on `OrganizationMember`.

### Steps to Test
1. Run team RBAC tests: `tox -e py312 -- aap_gateway_api/tests/views/api/v1/team/test_team_rbac.py -v`
2. Run visible_teams util tests: `tox -e py312 -- aap_gateway_api/tests/utils/test_visible_teams.py -v`
3. Manually verify: create an org member user, confirm they can list teams in their org via `/api/v1/teams/`

### Expected Results
- `test_pure_org_member_can_see_teams_in_org` passes — pure org members see teams in their org
- `test_team_org_admin_permissions_with_setting(False)` passes — org members' teams now included in expected visibility
- All other existing team RBAC tests continue to pass

## Additional Context

### Required Actions

- [x] Requires downstream repository changes
  - DAB: ansible/django-ansible-base#1070 (add `view_team` to `OrganizationMember`)
- [x] Blocked by PR/MR: ansible/django-ansible-base#1070

---
**Note:** This PR was developed with assistance from Claude AI assistant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated managed role permissions to stay synchronized when code-defined permissions change.
  - Fixed team visibility so organization members can view and access teams within their own organization, even when organization administrators are restricted from seeing all users.
  - Confirmed that teams belonging to other organizations remain hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->