### PR TITLE
[AAP-62944] Ensure health check interval >= effective timeout

### DIFF
--- a/aap_gateway_api/migrations/0025_servicecluster_health_check_interval_default.py
+++ b/aap_gateway_api/migrations/0025_servicecluster_health_check_interval_default.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('aap_gateway_api', '0024_route_reject_failed_basic_auth'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='servicecluster',
+            name='health_check_interval_seconds',
+            field=models.PositiveIntegerField(default=30, help_text='The time between health check requests.'),
+        ),
+    ]

--- a/aap_gateway_api/models/route.py
+++ b/aap_gateway_api/models/route.py
@@ -205,10 +205,11 @@ class Route(UniqueNamedCommonModel, AuditableModel):
 
         if self.service_cluster.health_checks_enabled:
             effective_health_check_timeout = self.service_cluster.get_effective_health_check_timeout_seconds()
+            effective_health_check_interval = self.service_cluster.get_effective_health_check_interval_seconds()
             cfg["health_checks"] = [
                 {
                     "timeout": f"{effective_health_check_timeout}s",
-                    "interval": f"{self.service_cluster.health_check_interval_seconds}s",
+                    "interval": f"{effective_health_check_interval}s",
                     "unhealthy_threshold": self.service_cluster.health_check_unhealthy_threshold,
                     "healthy_threshold": self.service_cluster.health_check_healthy_threshold,
                     "http_health_check": {

--- a/aap_gateway_api/models/route.py
+++ b/aap_gateway_api/models/route.py
@@ -205,7 +205,7 @@ class Route(UniqueNamedCommonModel, AuditableModel):
 
         if self.service_cluster.health_checks_enabled:
             effective_health_check_timeout = self.service_cluster.get_effective_health_check_timeout_seconds()
-            effective_health_check_interval = self.service_cluster.get_effective_health_check_interval_seconds()
+            effective_health_check_interval = self.service_cluster.get_effective_health_check_interval_seconds(effective_health_check_timeout)
             cfg["health_checks"] = [
                 {
                     "timeout": f"{effective_health_check_timeout}s",

--- a/aap_gateway_api/models/service_cluster.py
+++ b/aap_gateway_api/models/service_cluster.py
@@ -66,7 +66,7 @@ class ServiceCluster(UniqueNamedCommonModel, AuditableModel):
     )
 
     health_check_interval_seconds = models.PositiveIntegerField(
-        default=10,
+        default=30,
         help_text=_("The time between health check requests."),
     )
 
@@ -203,6 +203,10 @@ class ServiceCluster(UniqueNamedCommonModel, AuditableModel):
             max_route_timeout,
             get_preference_value('proxy', 'request_timeout'),
         )
+
+    def get_effective_health_check_interval_seconds(self):
+        effective_timeout = self.get_effective_health_check_timeout_seconds()
+        return max(self.health_check_interval_seconds, effective_timeout)
 
     @staticmethod
     def get_cluster_by_type(service_type: ServiceType | str):

--- a/aap_gateway_api/models/service_cluster.py
+++ b/aap_gateway_api/models/service_cluster.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime
 from typing import Optional
 
@@ -11,6 +12,8 @@ from django.utils.translation import gettext as _
 
 from aap_gateway_api.models.service_type import DefaultServiceType, ServiceType
 from aap_gateway_api.utils.preferences import get_preference_value
+
+logger = logging.getLogger(__name__)
 
 
 class ServiceCluster(UniqueNamedCommonModel, AuditableModel):
@@ -207,7 +210,15 @@ class ServiceCluster(UniqueNamedCommonModel, AuditableModel):
     def get_effective_health_check_interval_seconds(self, effective_timeout=None):
         if effective_timeout is None:
             effective_timeout = self.get_effective_health_check_timeout_seconds()
-        return max(self.health_check_interval_seconds, effective_timeout)
+        effective_interval = max(self.health_check_interval_seconds, effective_timeout)
+        if effective_interval != self.health_check_interval_seconds:
+            logger.debug(
+                "Health check interval for cluster %s floored from %ds to %ds (effective timeout)",
+                self.name,
+                self.health_check_interval_seconds,
+                effective_interval,
+            )
+        return effective_interval
 
     @staticmethod
     def get_cluster_by_type(service_type: ServiceType | str):

--- a/aap_gateway_api/models/service_cluster.py
+++ b/aap_gateway_api/models/service_cluster.py
@@ -204,8 +204,9 @@ class ServiceCluster(UniqueNamedCommonModel, AuditableModel):
             get_preference_value('proxy', 'request_timeout'),
         )
 
-    def get_effective_health_check_interval_seconds(self):
-        effective_timeout = self.get_effective_health_check_timeout_seconds()
+    def get_effective_health_check_interval_seconds(self, effective_timeout=None):
+        if effective_timeout is None:
+            effective_timeout = self.get_effective_health_check_timeout_seconds()
         return max(self.health_check_interval_seconds, effective_timeout)
 
     @staticmethod

--- a/aap_gateway_api/serializers/service_cluster.py
+++ b/aap_gateway_api/serializers/service_cluster.py
@@ -9,6 +9,10 @@ class ServiceClusterSerializer(NamedCommonModelSerializer):
         help_text="The effective health check timeout Envoy will use, computed as the maximum of the cluster's "
         "health_check_timeout_seconds, the highest route request_timeout_seconds, and the global request_timeout preference."
     )
+    effective_health_check_interval_seconds = serializers.SerializerMethodField(
+        help_text="The effective health check interval Envoy will use, computed as the maximum of the cluster's "
+        "health_check_interval_seconds and the effective health check timeout."
+    )
 
     class Meta:
         model = ServiceCluster
@@ -31,7 +35,11 @@ class ServiceClusterSerializer(NamedCommonModelSerializer):
             'health_check_healthy_threshold',
             'healthy_panic_threshold',
             'effective_health_check_timeout_seconds',
+            'effective_health_check_interval_seconds',
         ]
 
     def get_effective_health_check_timeout_seconds(self, obj):
         return obj.get_effective_health_check_timeout_seconds()
+
+    def get_effective_health_check_interval_seconds(self, obj):
+        return obj.get_effective_health_check_interval_seconds()

--- a/aap_gateway_api/serializers/service_cluster.py
+++ b/aap_gateway_api/serializers/service_cluster.py
@@ -42,4 +42,5 @@ class ServiceClusterSerializer(NamedCommonModelSerializer):
         return obj.get_effective_health_check_timeout_seconds()
 
     def get_effective_health_check_interval_seconds(self, obj):
-        return obj.get_effective_health_check_interval_seconds()
+        effective_timeout = self.get_effective_health_check_timeout_seconds(obj)
+        return obj.get_effective_health_check_interval_seconds(effective_timeout)

--- a/aap_gateway_api/tests/models/test_route.py
+++ b/aap_gateway_api/tests/models/test_route.py
@@ -787,13 +787,17 @@ class TestRouteRequestTimeout:
     @pytest.mark.parametrize(
         "health_check_interval,health_check_timeout,route_timeout,preference_timeout,expected_interval",
         [
+            (0, 5, None, 30, 30),
             (10, 5, None, 30, 30),
+            (30, 5, None, 30, 30),
             (60, 5, None, 30, 60),
             (10, 5, 600, 30, 600),
             (700, 5, 600, 30, 700),
         ],
         ids=[
+            "zero_interval_uses_effective_timeout",
             "interval_below_effective_timeout_uses_effective_timeout",
+            "interval_equals_effective_timeout",
             "interval_above_effective_timeout_preserved",
             "interval_below_route_timeout_uses_route_timeout",
             "interval_above_route_timeout_preserved",

--- a/aap_gateway_api/tests/models/test_route.py
+++ b/aap_gateway_api/tests/models/test_route.py
@@ -783,3 +783,82 @@ class TestRouteRequestTimeout:
             route.node_tags = "eda"
             cluster_cfg = route.get_xds_cluster_config()
             assert cluster_cfg["health_checks"][0]["timeout"] == "600s"
+
+    @pytest.mark.parametrize(
+        "health_check_interval,health_check_timeout,route_timeout,preference_timeout,expected_interval",
+        [
+            (10, 5, None, 30, 30),
+            (60, 5, None, 30, 60),
+            (10, 5, 600, 30, 600),
+            (700, 5, 600, 30, 700),
+        ],
+        ids=[
+            "interval_below_effective_timeout_uses_effective_timeout",
+            "interval_above_effective_timeout_preserved",
+            "interval_below_route_timeout_uses_route_timeout",
+            "interval_above_route_timeout_preserved",
+        ],
+    )
+    @pytest.mark.django_db
+    def test_effective_health_check_interval(
+        self,
+        health_check_interval,
+        health_check_timeout,
+        route_timeout,
+        preference_timeout,
+        expected_interval,
+        service_cluster_eda,
+        http_port,
+        preference_manager,
+    ):
+        service_cluster_eda.health_check_timeout_seconds = health_check_timeout
+        service_cluster_eda.health_check_interval_seconds = health_check_interval
+        service_cluster_eda.save()
+
+        with preference_manager.set("proxy", "request_timeout", preference_timeout):
+            AdditionalRoute.objects.create(
+                name="test-interval-route",
+                http_port=http_port,
+                is_service_https=False,
+                service_cluster=service_cluster_eda,
+                service_port=8080,
+                service_path="/path",
+                gateway_path="/test-interval/",
+                request_timeout_seconds=route_timeout,
+            )
+            assert service_cluster_eda.get_effective_health_check_interval_seconds() == expected_interval
+
+    @pytest.mark.django_db
+    def test_xds_cluster_config_uses_effective_health_check_interval(self, service_cluster_eda, http_port, preference_manager):
+        service_cluster_eda.health_checks_enabled = True
+        service_cluster_eda.health_check_timeout_seconds = 5
+        service_cluster_eda.health_check_interval_seconds = 10
+        service_cluster_eda.save()
+        service_cluster_eda.nodes.set(
+            [
+                ServiceNode.objects.create(
+                    name="node-for-interval-test",
+                    service_cluster=service_cluster_eda,
+                    address="10.0.0.1",
+                    tags="eda",
+                )
+            ]
+        )
+
+        seed_feature_flags()
+
+        with preference_manager.set("proxy", "request_timeout", 30):
+            route = AdditionalRoute.objects.create(
+                name="interval-xds-test-route",
+                http_port=http_port,
+                is_service_https=False,
+                service_cluster=service_cluster_eda,
+                service_port=8080,
+                service_path="/path",
+                gateway_path="/xds-interval-test/",
+                request_timeout_seconds=600,
+            )
+            route.node_tags = "eda"
+            cluster_cfg = route.get_xds_cluster_config()
+            assert cluster_cfg["health_checks"][0]["timeout"] == "600s"
+            assert cluster_cfg["health_checks"][0]["interval"] == "600s"

--- a/aap_gateway_api/tests/models/test_route.py
+++ b/aap_gateway_api/tests/models/test_route.py
@@ -7,7 +7,7 @@ from aap_gateway_api.models.service_node import ServiceNode
 
 
 class TestRoute:
-    @pytest.mark.django_db()
+    @pytest.mark.django_db
     def test_xds_login_logout_missing_models(self):
         route = ServiceAPIRoute()
         # First fail because of the missing service cluster

--- a/aap_gateway_api/tests/serializers/test_service_cluster.py
+++ b/aap_gateway_api/tests/serializers/test_service_cluster.py
@@ -39,6 +39,7 @@ class TestServiceClusterSerializer:
             'health_check_healthy_threshold',
             'healthy_panic_threshold',
             'effective_health_check_timeout_seconds',
+            'effective_health_check_interval_seconds',
         ]
         for field in expected_fields:
             assert field in ServiceClusterSerializer.Meta.fields, f"Field {field} missing from Meta.fields"
@@ -258,3 +259,41 @@ class TestServiceClusterSerializer:
             # queries; if this fires, the code regressed to the fallback.
             aggregate_queries = [q for q in ctx.captured_queries if 'MAX' in q['sql'].upper()]
             assert aggregate_queries == [], f"Annotation should prevent aggregate queries, but got: {aggregate_queries}"
+
+    def test_effective_health_check_interval_in_serializer_fields(self):
+        assert 'effective_health_check_interval_seconds' in ServiceClusterSerializer.Meta.fields
+
+    @pytest.mark.parametrize(
+        "health_check_interval,health_check_timeout,route_timeout,preference_timeout,expected",
+        [
+            (10, 5, None, 30, 30),
+            (60, 5, None, 30, 60),
+            (10, 5, 600, 30, 600),
+        ],
+        ids=["interval_below_effective_timeout", "interval_above_effective_timeout", "route_timeout_raises_floor"],
+    )
+    def test_effective_health_check_interval_seconds(
+        self, service_type, health_check_interval, health_check_timeout, route_timeout, preference_timeout, expected, preference_manager
+    ):
+        cluster = ServiceCluster.objects.create(
+            name='Effective Interval Cluster',
+            service_type=service_type,
+            health_check_timeout_seconds=health_check_timeout,
+            health_check_interval_seconds=health_check_interval,
+        )
+        http_port = HTTPPort.objects.create(name="effective-interval-port", number=9995)
+
+        with preference_manager.set("proxy", "request_timeout", preference_timeout):
+            if route_timeout is not None:
+                AdditionalRoute.objects.create(
+                    name="effective-interval-route",
+                    http_port=http_port,
+                    is_service_https=False,
+                    service_cluster=cluster,
+                    service_port=8080,
+                    service_path="/path",
+                    gateway_path="/effective-interval-test/",
+                    request_timeout_seconds=route_timeout,
+                )
+            serializer = ServiceClusterSerializer(instance=cluster, context={'request': Mock(query_params={})})
+            assert serializer.data['effective_health_check_interval_seconds'] == expected

--- a/aap_gateway_api/tests/views/api/envoy/test_xds.py
+++ b/aap_gateway_api/tests/views/api/envoy/test_xds.py
@@ -148,6 +148,27 @@ def test_xds_health_check_params(admin_api_client, full_service_hierarchy_contro
         assert health_checks['healthyThreshold'] == 98
 
 
+def test_xds_health_check_interval_floor(admin_api_client, full_service_hierarchy_controller, preference_manager):
+    with preference_manager.set("proxy", "request_timeout", 30):
+        url = reverse("service_cluster-detail", kwargs={"pk": full_service_hierarchy_controller.service_cluster.pk})
+        response = admin_api_client.patch(
+            url,
+            {
+                "health_check_timeout_seconds": 5,
+                "health_check_interval_seconds": 10,
+            },
+        )
+        assert response.status_code == 200
+
+        url = reverse("cds")
+        response = admin_api_client.post(url, data={})
+        assert response.status_code == 200
+
+        health_checks = response.data['resources'][0]['healthChecks'][0]
+        assert health_checks['interval'] == '30s'
+        assert health_checks['timeout'] == '30s'
+
+
 def test_xds_cluster_discover_service_route_tags(admin_api_client, full_service_hierarchy_controller, http_port_factory, randname):
     def cds_nodes():
         url = reverse("cds")


### PR DESCRIPTION
## Summary

Under peak API load, Envoy health checks can time out and falsely eject healthy upstream nodes, causing 503 errors. The health check interval (default 10s) could be shorter than the effective health check timeout (at least 30s), causing overlapping health checks and potentially invalid Envoy configuration.

This PR adds `get_effective_health_check_interval_seconds()` to `ServiceCluster` which floors the interval at the effective timeout, mirroring the existing `get_effective_health_check_timeout_seconds()` pattern. It uses the effective interval in xDS cluster config generation, exposes it as a read-only `effective_health_check_interval_seconds` field on the API, and raises the model default from 10s to 30s for new clusters. No data migration — existing clusters keep their stored values and the effective-interval logic handles correctness at runtime.

## Acceptance Criteria

From the [Jira ticket](https://redhat.atlassian.net/browse/AAP-62944) Expected Behavior:

| # | Criterion | Status | Where |
|---|-----------|--------|-------|
| 1 | **Health check timeouts should align with `request_timeout`** — nodes should only be ejected if truly unresponsive, not just busy. The default should align with whatever `request_timeout` the operator/installer configured. | Already done | Addressed by [AAP-66486](https://redhat.atlassian.net/browse/AAP-66486) (commit `e2729e30`), which added `get_effective_health_check_timeout_seconds()` = `max(cluster_hc_timeout, max_route_timeout, global_request_timeout)`. Effective timeout is at least 30s by default. |
| 2 | **Health check frequency must decrease to match raised timeouts** — e.g., if timeout is 15s, interval should be no less than the timeout to avoid overlapping checks. | This PR | Adds `get_effective_health_check_interval_seconds()` = `max(stored_interval, effective_timeout)`. Uses it in `get_xds_cluster_config()` so Envoy always receives `interval >= timeout`. Raises model default from 10s to 30s for new clusters. |
| 3 | **Values must remain configurable via the API** — admins can tune health check parameters for their specific workload profiles. | Already done + this PR | All health check fields (`health_check_timeout_seconds`, `health_check_interval_seconds`, `health_check_unhealthy_threshold`, `health_check_healthy_threshold`) remain writable on the ServiceCluster API. This PR adds a read-only `effective_health_check_interval_seconds` computed field (matching the existing `effective_health_check_timeout_seconds`) so admins can see the actual value Envoy will use. |
| 4 | **Gateway should allow increased latency during peak loads without cutting off service access** — no false-negative outages from busy-but-healthy nodes. | Combination | Criteria 1-3 together ensure that under peak load, health checks have sufficient timeout to complete and sufficient interval to avoid overlapping, while still allowing Envoy to detect truly unresponsive nodes. |

## Test plan
- [x] Parametrized model tests for `get_effective_health_check_interval_seconds()` (interval below/above effective timeout, with route timeouts)
- [x] Integration test verifying `get_xds_cluster_config()` uses the effective interval
- [x] Serializer tests for the new `effective_health_check_interval_seconds` computed field
- [x] CDS view integration test verifying Envoy receives the correct interval
- [x] All 33 existing `health_check` tests pass
- [x] Migration check passes (`tox -e check-migrations`)
- [x] Cross-checked live Gateway API `effective_*` fields against Envoy admin config dump — values match

Closes: https://redhat.atlassian.net/browse/AAP-62944

[AAP-66486]: https://redhat.atlassian.net/browse/AAP-66486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service cluster API responses now include the computed *effective health-check interval*.
* **Improvements**
  * Default service cluster health-check interval is now **30 seconds**.
  * Generated xDS health-check configuration now uses the effective interval, derived from effective timeout and request-timeout preferences (including proxy settings).
* **Bug Fixes**
  * Health-check `interval` and `timeout` are now consistently aligned, ensuring the interval is never shorter than the effective timeout.
* **Tests**
  * Added coverage for interval “flooring” behavior and serializer/xDS propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->