### PR TITLE
[AAP-82668] Fix resource sync blocking on org delete

### DIFF
--- a/aap_gateway_api/tests/utils/test_crud_resource_in_services.py
+++ b/aap_gateway_api/tests/utils/test_crud_resource_in_services.py
@@ -174,25 +174,27 @@ def test_all_services_client_with_service_filter(
 
 
 @pytest.mark.django_db
-def test_all_services_client_timeout_handling(
+def test_all_services_client_async_returns_immediately(
     simulated_controller_resource_api,
     simmulated_hub_resource_api,
     simulated_eda_resource_api,
     admin_user,
 ):
-    """Test that timeout exceptions are handled when wait_for_response=False"""
+    """wait_for_response=False returns empty dict immediately without waiting."""
     client = PatchedAllServicesClient(user=admin_user, wait_for_response=False)
 
-    # Mock requests.request to raise a Timeout
-    with patch('aap_gateway_api.utils.resources_client.requests.request') as mock_request:
-        mock_request.side_effect = Timeout("Request timed out")
-
+    mock_executor = MagicMock()
+    with patch('aap_gateway_api.utils.resources_client._get_executor', return_value=mock_executor):
         responses = client._make_request("GET", "/test/")
 
-        # Should return None for all services that timed out
-        assert all(response is None for response in responses.values())
-        # Should have attempted all services
-        assert len(responses) == ServiceAPIRoute.objects.exclude(service_cluster__service_type__name="gateway").count()
+    assert responses == {}
+    expected_count = (
+        ServiceAPIRoute.objects.exclude(service_cluster__service_type__name="gateway")
+        .exclude(service_cluster__service_type__service_index_path__isnull=True)
+        .exclude(service_cluster__service_type__service_index_path='')
+        .count()
+    )
+    assert mock_executor.submit.call_count == expected_count
 
 
 @pytest.mark.django_db
@@ -202,27 +204,25 @@ def test_all_services_client_timeout_raises_when_wait_for_response_true(
     simulated_eda_resource_api,
     admin_user,
 ):
-    """Test that timeout exceptions are raised when wait_for_response=True"""
+    """Timeout exceptions are raised when wait_for_response=True."""
     client = PatchedAllServicesClient(user=admin_user, wait_for_response=True)
 
-    # Mock both JWT property and requests.request to isolate the timeout behavior
     with patch.object(type(client), 'jwt', new_callable=lambda: MagicMock(return_value="fake-jwt-token")):
         with patch('aap_gateway_api.utils.resources_client.requests.request') as mock_request:
             mock_request.side_effect = Timeout("Request timed out")
 
-            # Should raise the Timeout exception
             with pytest.raises(Timeout):
                 client._make_request("GET", "/test/")
 
 
 @pytest.mark.django_db
-def test_all_services_client_with_callback(
+def test_all_services_client_sync_callback(
     simulated_controller_resource_api,
     simmulated_hub_resource_api,
     simulated_eda_resource_api,
     admin_user,
 ):
-    """Test that callback is invoked for each service response"""
+    """Callback is invoked for each service response in the synchronous path."""
     callback_calls = []
 
     def test_callback(service, response):
@@ -230,44 +230,45 @@ def test_all_services_client_with_callback(
 
     client = PatchedAllServicesClient(user=admin_user).with_callback(test_callback)
 
-    # Mock the actual request execution
     with patch('aap_gateway_api.utils.resources_client.requests.request') as mock_request:
         mock_response = MagicMock(status_code=200)
         mock_request.return_value = mock_response
 
         responses = client._make_request("GET", "/test/")
 
-        # Callback should have been called for each service
-        expected_count = ServiceAPIRoute.objects.exclude(service_cluster__service_type__name="gateway").count()
+        expected_count = (
+            ServiceAPIRoute.objects.exclude(service_cluster__service_type__name="gateway")
+            .exclude(service_cluster__service_type__service_index_path__isnull=True)
+            .exclude(service_cluster__service_type__service_index_path='')
+            .count()
+        )
         assert len(callback_calls) == expected_count
-        # Each callback should have received the service and response from the responses dict
-        # This matches the serial version behavior: callback(service, responses[service.pk])
-        # Some callbacks may receive None if the service request failed (which is expected behavior)
         for service_pk, response in callback_calls:
-            # Verify the callback response matches what's in the responses dict
-            assert response == responses[service_pk], f"Callback response doesn't match stored response for service {service_pk}"
-            # Only check status_code if response is not None
+            assert response == responses[service_pk]
             if response is not None:
                 assert response.status_code == 200
 
 
 @pytest.mark.django_db
-def test_all_services_client_exception_handling(
+def test_all_services_client_sync_exception_handling(
     simulated_controller_resource_api,
     simmulated_hub_resource_api,
     simulated_eda_resource_api,
     admin_user,
 ):
-    """Test that exceptions in thread pool are caught and logged"""
+    """Exceptions in synchronous path are caught and logged, responses set to None."""
     client = PatchedAllServicesClient(user=admin_user)
 
-    # Mock requests.request to raise a generic exception
     with patch('aap_gateway_api.utils.resources_client.requests.request') as mock_request:
         mock_request.side_effect = Exception("Something went wrong")
 
         responses = client._make_request("GET", "/test/")
 
-        # Should return None for all services that raised exceptions
         assert all(response is None for response in responses.values())
-        # Should have attempted all services
-        assert len(responses) == ServiceAPIRoute.objects.exclude(service_cluster__service_type__name="gateway").count()
+        expected_count = (
+            ServiceAPIRoute.objects.exclude(service_cluster__service_type__name="gateway")
+            .exclude(service_cluster__service_type__service_index_path__isnull=True)
+            .exclude(service_cluster__service_type__service_index_path='')
+            .count()
+        )
+        assert len(responses) == expected_count

--- a/aap_gateway_api/tests/utils/test_resources_client.py
+++ b/aap_gateway_api/tests/utils/test_resources_client.py
@@ -1,3 +1,4 @@
+from concurrent.futures import ThreadPoolExecutor
 from unittest import mock
 
 import pytest
@@ -10,95 +11,366 @@ def _mock_pref_value(section, name):
     return 30
 
 
-class TestMakeServiceRequestLogging:
-    """Test that _make_service_request uses logger.error for Timeout errors."""
+@pytest.fixture
+def _mock_deps():
+    """Patch external dependencies needed to instantiate AllServicesClient."""
+    with (
+        mock.patch(
+            'aap_gateway_api.utils.resources_client.get_preference_value',
+            side_effect=_mock_pref_value,
+        ),
+        mock.patch('aap_gateway_api.utils.resources_client.to_python_boolean', return_value=False),
+        mock.patch('aap_gateway_api.utils.resources_client.get_user_model') as mock_user_model,
+    ):
+        mock_user_model.return_value.objects.filter.return_value.first.return_value = mock.MagicMock()
+        yield
 
-    @pytest.fixture
-    def client(self):
-        """Create an AllServicesClient with mocked dependencies."""
+
+@pytest.fixture
+def client(_mock_deps):
+    """Create an AllServicesClient with mocked dependencies."""
+    from aap_gateway_api.utils.resources_client import AllServicesClient
+
+    return AllServicesClient(user=mock.MagicMock(), wait_for_response=False)
+
+
+@pytest.fixture
+def sync_client(_mock_deps):
+    """Create an AllServicesClient with wait_for_response=True."""
+    from aap_gateway_api.utils.resources_client import AllServicesClient
+
+    return AllServicesClient(user=mock.MagicMock(), wait_for_response=True)
+
+
+@pytest.fixture
+def mock_service():
+    """Create a mock service for testing."""
+    service = mock.MagicMock()
+    service.pk = 1
+    service.http_port.use_https = False
+    service.http_port.number = 8080
+    service.gateway_path = '/api'
+    service.service_cluster.service_type.service_index_path = '/v2/'
+    return service
+
+
+@pytest.fixture
+def mock_services():
+    """Create a list of mock services."""
+    services = []
+    for i in range(3):
+        svc = mock.MagicMock()
+        svc.pk = i + 1
+        svc.http_port.use_https = False
+        svc.http_port.number = 8080 + i
+        svc.gateway_path = '/api'
+        svc.service_cluster.service_type.service_index_path = '/v2/'
+        services.append(svc)
+    return services
+
+
+class TestMakeServiceRequest:
+    """Tests for _make_service_request (the single-service HTTP call)."""
+
+    def test_timeout_uses_logger_error(self, client, mock_service):
+        """Timeout logs error (not exception) when wait_for_response=False."""
         with (
-            mock.patch(
-                'aap_gateway_api.utils.resources_client.get_preference_value',
-                side_effect=_mock_pref_value,
-            ),
-            mock.patch('aap_gateway_api.utils.resources_client.to_python_boolean', return_value=False),
-            mock.patch('aap_gateway_api.utils.resources_client.get_user_model') as mock_user_model,
-        ):
-            mock_user_model.return_value.objects.filter.return_value.first.return_value = mock.MagicMock()
-            from aap_gateway_api.utils.resources_client import AllServicesClient
-
-            client = AllServicesClient(user=mock.MagicMock(), wait_for_response=False)
-            return client
-
-    @pytest.fixture
-    def mock_service(self):
-        """Create a mock service for testing."""
-        service = mock.MagicMock()
-        service.pk = 1
-        service.http_port.use_https = False
-        service.http_port.number = 8080
-        service.gateway_path = '/api'
-        service.service_cluster.service_type.service_index_path = '/v2/'
-        return service
-
-    def test_make_service_request_timeout_uses_logger_error(self, client, mock_service):
-        """Verify that _make_service_request calls logger.error (not logger.exception) on Timeout."""
-        with (
-            mock.patch('aap_gateway_api.utils.resources_client.requests.request', side_effect=Timeout("connection timed out")),
+            mock.patch('aap_gateway_api.utils.resources_client.requests.request', side_effect=Timeout("timed out")),
             mock.patch('aap_gateway_api.utils.resources_client.logger') as mock_logger,
         ):
-            client.wait_for_response = False
             client._make_service_request(mock_service, 'GET', '/test/', jwt='fake-jwt')
 
             mock_logger.error.assert_called_once()
-            call_args = mock_logger.error.call_args[0][0]
-            assert 'Resource client request timeout' in call_args
+            assert 'Resource client request timeout' in mock_logger.error.call_args[0][0]
             mock_logger.exception.assert_not_called()
 
-    def test_make_service_request_timeout_raises_when_waiting(self, client, mock_service):
-        """Verify that _make_service_request raises Timeout when wait_for_response is True."""
-        with mock.patch('aap_gateway_api.utils.resources_client.requests.request', side_effect=Timeout("connection timed out")):
+    def test_timeout_raises_when_waiting(self, client, mock_service):
+        """Timeout raises when wait_for_response=True."""
+        with mock.patch('aap_gateway_api.utils.resources_client.requests.request', side_effect=Timeout("timed out")):
             client.wait_for_response = True
             with pytest.raises(Timeout):
                 client._make_service_request(mock_service, 'GET', '/test/', jwt='fake-jwt')
 
+    def test_successful_request_returns_response(self, client, mock_service):
+        """Successful request returns (service_pk, response)."""
+        mock_resp = mock.MagicMock(status_code=200)
+        with mock.patch('aap_gateway_api.utils.resources_client.requests.request', return_value=mock_resp):
+            pk, resp = client._make_service_request(mock_service, 'GET', '/test/', jwt='fake-jwt')
+            assert pk == mock_service.pk
+            assert resp.status_code == 200
 
-class TestMakeRequestTimeoutLogging:
-    """Test that _make_request uses logger.error for Timeout errors in the futures loop."""
 
-    def test_future_timeout_uses_logger_error(self):
-        """Verify that the _make_request future handler calls logger.error on Timeout."""
+class TestAsyncWorker:
+    """Tests for _async_worker (background thread handler)."""
+
+    def test_successful_request_invokes_callback(self, client, mock_service):
+        """Callback receives service and response on success."""
+        mock_resp = mock.MagicMock(status_code=200)
+        callback = mock.MagicMock()
+
+        with mock.patch.object(client, '_make_service_request', return_value=(mock_service.pk, mock_resp)):
+            client._async_worker(mock_service, 'GET', '/test/', None, None, 'jwt', callback)
+
+        callback.assert_called_once_with(mock_service, mock_resp)
+
+    def test_timeout_logs_error_and_invokes_callback_with_none(self, client, mock_service):
+        """Timeout is caught, logged, and callback receives None."""
+        callback = mock.MagicMock()
+
         with (
-            mock.patch(
-                'aap_gateway_api.utils.resources_client.get_preference_value',
-                side_effect=_mock_pref_value,
-            ),
-            mock.patch('aap_gateway_api.utils.resources_client.to_python_boolean', return_value=False),
-            mock.patch('aap_gateway_api.utils.resources_client.get_user_model') as mock_user_model,
+            mock.patch.object(client, '_make_service_request', side_effect=Timeout("timed out")),
+            mock.patch('aap_gateway_api.utils.resources_client.logger') as mock_logger,
         ):
-            mock_user_model.return_value.objects.filter.return_value.first.return_value = mock.MagicMock()
-            from aap_gateway_api.utils.resources_client import AllServicesClient
+            client._async_worker(mock_service, 'GET', '/test/', None, None, 'jwt', callback)
 
-            client = AllServicesClient(user=mock.MagicMock(), wait_for_response=False)
+        mock_logger.error.assert_called_once()
+        callback.assert_called_once_with(mock_service, None)
 
-        mock_service = mock.MagicMock()
-        mock_service.pk = 42
+    def test_exception_logs_and_invokes_callback_with_none(self, client, mock_service):
+        """Generic exception is caught, logged, and callback receives None."""
+        callback = mock.MagicMock()
 
+        with (
+            mock.patch.object(client, '_make_service_request', side_effect=RuntimeError("boom")),
+            mock.patch('aap_gateway_api.utils.resources_client.logger') as mock_logger,
+        ):
+            client._async_worker(mock_service, 'GET', '/test/', None, None, 'jwt', callback)
+
+        mock_logger.exception.assert_called_once()
+        callback.assert_called_once_with(mock_service, None)
+
+    def test_no_callback_does_not_error(self, client, mock_service):
+        """No callback is fine — just runs the request."""
+        mock_resp = mock.MagicMock(status_code=200)
+        with mock.patch.object(client, '_make_service_request', return_value=(mock_service.pk, mock_resp)):
+            client._async_worker(mock_service, 'GET', '/test/', None, None, 'jwt', None)
+
+    def test_callback_exception_is_logged(self, client, mock_service):
+        """Callback exception is caught and logged, not propagated."""
+        mock_resp = mock.MagicMock(status_code=200)
+        callback = mock.MagicMock(side_effect=RuntimeError("callback boom"))
+
+        with (
+            mock.patch.object(client, '_make_service_request', return_value=(mock_service.pk, mock_resp)),
+            mock.patch('aap_gateway_api.utils.resources_client.logger') as mock_logger,
+        ):
+            client._async_worker(mock_service, 'GET', '/test/', None, None, 'jwt', callback)
+
+        callback.assert_called_once_with(mock_service, mock_resp)
+        mock_logger.exception.assert_called_once()
+        assert 'Callback failed' in mock_logger.exception.call_args[0][0]
+
+
+class TestMakeAsyncRequest:
+    """Tests for _make_async_request (fire-and-forget path)."""
+
+    def test_submits_to_executor_and_returns_immediately(self, client, mock_services):
+        """Each service is submitted to the lazily-initialized executor."""
+        mock_executor = mock.MagicMock()
+        with mock.patch('aap_gateway_api.utils.resources_client._get_executor', return_value=mock_executor):
+            result = client._make_async_request(mock_services, 'DELETE', '/test/', None, None, 'jwt')
+
+        assert result == {}
+        assert mock_executor.submit.call_count == len(mock_services)
+        for call in mock_executor.submit.call_args_list:
+            assert call[0][0] == client._async_worker
+
+    def test_passes_callback_to_workers(self, client, mock_services):
+        """Callback is captured and passed to each worker."""
+        callback = mock.MagicMock()
+        client.callback = callback
+        mock_executor = mock.MagicMock()
+
+        with mock.patch('aap_gateway_api.utils.resources_client._get_executor', return_value=mock_executor):
+            client._make_async_request(mock_services, 'DELETE', '/test/', None, None, 'jwt')
+
+        for call in mock_executor.submit.call_args_list:
+            assert call[0][-1] is callback
+
+    def test_add_done_callback_attached(self, client, mock_services):
+        """Each submitted future gets a done callback for error logging."""
+        mock_executor = mock.MagicMock()
+        mock_future = mock.MagicMock()
+        mock_executor.submit.return_value = mock_future
+
+        with mock.patch('aap_gateway_api.utils.resources_client._get_executor', return_value=mock_executor):
+            client._make_async_request(mock_services, 'DELETE', '/test/', None, None, 'jwt')
+
+        assert mock_future.add_done_callback.call_count == len(mock_services)
+
+
+class TestLogAsyncResult:
+    """Tests for _log_async_result (future done callback)."""
+
+    def test_logs_exception_from_future(self):
+        """Unhandled exceptions in futures are logged."""
+        from aap_gateway_api.utils.resources_client import AllServicesClient
+
+        mock_future = mock.MagicMock()
+        mock_future.exception.return_value = RuntimeError("boom")
+
+        with mock.patch('aap_gateway_api.utils.resources_client.logger') as mock_logger:
+            AllServicesClient._log_async_result(mock_future)
+
+        mock_logger.exception.assert_called_once()
+
+    def test_no_log_on_success(self):
+        """No logging when future completes without error."""
+        from aap_gateway_api.utils.resources_client import AllServicesClient
+
+        mock_future = mock.MagicMock()
+        mock_future.exception.return_value = None
+
+        with mock.patch('aap_gateway_api.utils.resources_client.logger') as mock_logger:
+            AllServicesClient._log_async_result(mock_future)
+
+        mock_logger.exception.assert_not_called()
+
+
+class TestGetExecutor:
+    """Tests for _get_executor (lazy initialization)."""
+
+    def test_creates_executor_on_first_call(self):
+        """Executor is lazily created on first call."""
+        import aap_gateway_api.utils.resources_client as rc
+
+        original = rc._fire_and_forget_executor
+        try:
+            rc._fire_and_forget_executor = None
+            executor = rc._get_executor()
+            assert isinstance(executor, ThreadPoolExecutor)
+            assert rc._fire_and_forget_executor is executor
+        finally:
+            if rc._fire_and_forget_executor is not original:
+                rc._fire_and_forget_executor.shutdown(wait=False)
+            rc._fire_and_forget_executor = original
+
+    def test_returns_same_executor_on_subsequent_calls(self):
+        """Second call returns the same executor instance."""
+        import aap_gateway_api.utils.resources_client as rc
+
+        original = rc._fire_and_forget_executor
+        try:
+            rc._fire_and_forget_executor = None
+            first = rc._get_executor()
+            second = rc._get_executor()
+            assert first is second
+        finally:
+            if rc._fire_and_forget_executor is not original:
+                rc._fire_and_forget_executor.shutdown(wait=False)
+            rc._fire_and_forget_executor = original
+
+
+class TestMakeSynchronousRequest:
+    """Tests for _make_synchronous_request (blocking path)."""
+
+    def test_returns_responses_for_all_services(self, sync_client, mock_services):
+        """All service responses are collected and returned."""
+        with mock.patch.object(
+            sync_client,
+            '_make_service_request',
+            side_effect=lambda svc, *args, **kwargs: (svc.pk, mock.MagicMock(status_code=200)),
+        ):
+            responses = sync_client._make_synchronous_request(mock_services, 'GET', '/test/', None, None, 'jwt')
+
+        assert len(responses) == len(mock_services)
+        for svc in mock_services:
+            assert svc.pk in responses
+            assert responses[svc.pk].status_code == 200
+
+    def test_timeout_raises(self, sync_client, mock_services):
+        """Timeout is re-raised in the synchronous path."""
+        with mock.patch.object(sync_client, '_make_service_request', side_effect=Timeout("timed out")):
+            with pytest.raises(Timeout):
+                sync_client._make_synchronous_request(mock_services, 'GET', '/test/', None, None, 'jwt')
+
+    def test_exception_logged_and_response_is_none(self, sync_client, mock_services):
+        """Generic exception is caught, logged, response set to None."""
+        with (
+            mock.patch.object(sync_client, '_make_service_request', side_effect=RuntimeError("boom")),
+            mock.patch('aap_gateway_api.utils.resources_client.logger') as mock_logger,
+        ):
+            responses = sync_client._make_synchronous_request(mock_services, 'GET', '/test/', None, None, 'jwt')
+
+        assert all(r is None for r in responses.values())
+        assert mock_logger.exception.call_count == len(mock_services)
+
+    def test_callback_invoked_for_each_service(self, sync_client, mock_services):
+        """Callback is called after each service response."""
+        callback_calls = []
+        sync_client.callback = lambda svc, resp: callback_calls.append((svc.pk, resp))
+
+        with mock.patch.object(
+            sync_client,
+            '_make_service_request',
+            side_effect=lambda svc, *args, **kwargs: (svc.pk, mock.MagicMock(status_code=200)),
+        ):
+            sync_client._make_synchronous_request(mock_services, 'GET', '/test/', None, None, 'jwt')
+
+        assert len(callback_calls) == len(mock_services)
+
+
+class TestMakeRequest:
+    """Tests for _make_request (routing logic)."""
+
+    def test_routes_to_async_when_not_waiting(self, client):
+        """wait_for_response=False routes to _make_async_request."""
+        with (
+            mock.patch.object(client, '_get_services', return_value=[mock.MagicMock()]),
+            mock.patch.object(client, '_make_async_request', return_value={}) as mock_async,
+            mock.patch.object(client, '_make_synchronous_request') as mock_sync,
+            mock.patch.object(type(client), 'jwt', new_callable=mock.PropertyMock, return_value='jwt'),
+        ):
+            client._make_request('GET', '/test/')
+
+        mock_async.assert_called_once()
+        mock_sync.assert_not_called()
+
+    def test_routes_to_sync_when_waiting(self, sync_client):
+        """wait_for_response=True routes to _make_synchronous_request."""
+        with (
+            mock.patch.object(sync_client, '_get_services', return_value=[mock.MagicMock()]),
+            mock.patch.object(sync_client, '_make_async_request') as mock_async,
+            mock.patch.object(sync_client, '_make_synchronous_request', return_value={}) as mock_sync,
+            mock.patch.object(type(sync_client), 'jwt', new_callable=mock.PropertyMock, return_value='jwt'),
+        ):
+            sync_client._make_request('GET', '/test/')
+
+        mock_sync.assert_called_once()
+        mock_async.assert_not_called()
+
+    def test_empty_services_returns_empty_dict(self, client):
+        """No services means immediate return with empty dict."""
+        with mock.patch.object(client, '_get_services', return_value=[]):
+            result = client._make_request('GET', '/test/')
+
+        assert result == {}
+
+
+class TestGetServices:
+    """Tests for _get_services (service discovery)."""
+
+    def test_excludes_gateway_and_empty_index_paths(self, client):
+        """Verifies the queryset excludes gateway and services without index paths."""
         mock_svc_qs = mock.MagicMock()
+        mock_svc_qs.select_related.return_value = mock_svc_qs
+        mock_svc_qs.exclude.return_value = mock_svc_qs
+
+        with mock.patch('aap_gateway_api.models.ServiceAPIRoute.objects', mock_svc_qs):
+            client._get_services()
+
+        mock_svc_qs.select_related.assert_called_once()
+        assert mock_svc_qs.exclude.call_count == 3
+
+    def test_applies_service_filter(self, client):
+        """service_filter kwarg is applied to the queryset."""
+        client.service_filter = {"service_cluster__service_type__name": "controller"}
+        mock_svc_qs = mock.MagicMock()
+        mock_svc_qs.select_related.return_value = mock_svc_qs
         mock_svc_qs.exclude.return_value = mock_svc_qs
         mock_svc_qs.filter.return_value = mock_svc_qs
-        mock_svc_qs.__iter__ = mock.MagicMock(return_value=iter([mock_service]))
 
-        with (
-            mock.patch('aap_gateway_api.utils.resources_client.logger') as mock_logger,
-            mock.patch.object(client, '_make_service_request', side_effect=Timeout("timed out")),
-            mock.patch.object(type(client), 'jwt', new_callable=mock.PropertyMock, return_value='fake-jwt'),
-            mock.patch('aap_gateway_api.models.ServiceAPIRoute.objects', mock_svc_qs),
-        ):
-            responses = client._make_request('GET', '/test/')
+        with mock.patch('aap_gateway_api.models.ServiceAPIRoute.objects', mock_svc_qs):
+            client._get_services()
 
-            mock_logger.error.assert_called_once()
-            call_args = mock_logger.error.call_args[0][0]
-            assert 'Resource client request timeout for service 42' in call_args
-            mock_logger.exception.assert_not_called()
-            assert responses[42] is None
+        mock_svc_qs.filter.assert_called_once_with(service_cluster__service_type__name="controller")

--- a/aap_gateway_api/utils/resources_client.py
+++ b/aap_gateway_api/utils/resources_client.py
@@ -2,6 +2,7 @@ import copy
 import logging
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from threading import Lock
 from typing import Callable
 
 import requests
@@ -21,6 +22,25 @@ from aap_gateway_api.utils.preferences import get_preference_value
 ResourceRequestBody = DABResourceRequestBody
 
 logger = logging.getLogger('aap.gateway.utils.resource_api_client')
+
+# Lazily-initialized executor for fire-and-forget resource sync.
+# Created post-fork (on first use) to avoid sharing threads across uWSGI workers.
+_fire_and_forget_executor: ThreadPoolExecutor | None = None
+_executor_lock = Lock()
+
+
+def _get_executor() -> ThreadPoolExecutor:
+    global _fire_and_forget_executor
+
+    if _fire_and_forget_executor is None:
+        with _executor_lock:
+            if _fire_and_forget_executor is None:
+                _fire_and_forget_executor = ThreadPoolExecutor(
+                    max_workers=10,
+                    thread_name_prefix="resource-sync",
+                )
+
+    return _fire_and_forget_executor
 
 
 class GWResourceAPIClient(DABResourceAPIClient):
@@ -145,41 +165,46 @@ class AllServicesClient(GWResourceAPIClient):
                 raise
             return service.pk, None
 
-    # Executes requests in parallel using ThreadPoolExecutor to improve performance when
-    # making requests to multiple services simultaneously.
-    def _make_request(
-        self,
-        method: str,
-        path: str,
-        data: dict = None,
-        params: dict = None,
-    ) -> dict[int, Response | None]:
-        from aap_gateway_api.models import ServiceAPIRoute
+    def _make_async_request(self, services, method, path, data, params, jwt_token):
+        """Submit requests to the shared executor and return immediately.
 
+        Each request runs in a background thread. Errors are logged via
+        add_done_callback so they are never silently swallowed.
+        The 15-minute reverse sync in each service catches any delivery failures.
+        """
+        executor = _get_executor()
+        callback = self.callback
+        for svc in services:
+            future = executor.submit(self._async_worker, svc, method, path, data, params, jwt_token, callback)
+            future.add_done_callback(self._log_async_result)
+        return {}
+
+    @staticmethod
+    def _log_async_result(future):
+        """Log any unhandled exception from a fire-and-forget future."""
+        exc = future.exception()
+        if exc is not None:
+            logger.exception(f"Unhandled error in async resource sync: {exc}", exc_info=exc)
+
+    def _async_worker(self, service, method, path, data, params, jwt, callback):
+        """Execute a single service request in a background thread."""
+        try:
+            _, response = self._make_service_request(service, method, path, data, params, jwt)
+        except Timeout:
+            logger.error(f"Resource client request timeout for service {service.pk}")  # NOSONAR
+            response = None
+        except Exception as e:
+            logger.exception(f"Error in async request for service {service.pk}: {e}")
+            response = None
+        if callback:
+            try:
+                callback(service, response)
+            except Exception:
+                logger.exception(f"Callback failed for service {service.pk}")
+
+    def _make_synchronous_request(self, services, method, path, data, params, jwt_token):
+        """Execute requests in parallel and wait for all responses."""
         responses = {}
-        # Exclude gateway (not a downstream service) and services without a
-        # service-index endpoint (e.g. metrics) to avoid AttributeError in
-        # get_url_for_service when service_index_path is None or empty.
-        svc_qs = (
-            ServiceAPIRoute.objects.exclude(service_cluster__service_type__name=DefaultServiceType.GATEWAY.value)
-            .exclude(service_cluster__service_type__service_index_path__isnull=True)
-            .exclude(service_cluster__service_type__service_index_path='')
-        )
-        if self.service_filter:
-            svc_qs = svc_qs.filter(**self.service_filter)
-
-        # Evaluate queryset once to avoid lazy evaluation issues in threads
-        services = list(svc_qs)
-
-        # Early return if no services to process
-        if not services:
-            return responses
-
-        # Prefetch JWT to avoid race conditions with multiple threads calling refresh_jwt()
-        jwt_token = self.jwt
-
-        # Execute all service requests in parallel
-        # Cap max_workers to avoid excessive thread creation
         max_workers = min(len(services), 10)
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = {executor.submit(self._make_service_request, svc, method, path, data, params, jwt_token): svc for svc in services}
@@ -189,19 +214,48 @@ class AllServicesClient(GWResourceAPIClient):
                 try:
                     _, response = future.result()
                     responses[service.pk] = response
-                except Timeout as e:
-                    # Re-raise timeout if we're supposed to wait for responses
-                    if self.wait_for_response:
-                        raise
-                    logger.error(f"Resource client request timeout for service {service.pk}: {type(e).__name__}")  # NOSONAR
-                    responses[service.pk] = None
+                except Timeout:
+                    raise
                 except Exception as e:
-                    # Log the error but continue processing other services
                     logger.exception(f"Error processing request for service {service.pk}: {e}")
                     responses[service.pk] = None
 
-                # Call callback after storing response, even if there was an exception
                 if self.callback:
                     self.callback(service, responses[service.pk])
 
         return responses
+
+    def _get_services(self):
+        """Return the list of downstream services to sync with.
+
+        Uses select_related to eagerly load related objects so that
+        background threads in _async_worker don't need DB access.
+        """
+        from aap_gateway_api.models import ServiceAPIRoute
+
+        svc_qs = (
+            ServiceAPIRoute.objects.select_related('http_port', 'service_cluster__service_type')
+            .exclude(service_cluster__service_type__name=DefaultServiceType.GATEWAY.value)
+            .exclude(service_cluster__service_type__service_index_path__isnull=True)
+            .exclude(service_cluster__service_type__service_index_path='')
+        )
+        if self.service_filter:
+            svc_qs = svc_qs.filter(**self.service_filter)
+        return list(svc_qs)
+
+    def _make_request(
+        self,
+        method: str,
+        path: str,
+        data: dict = None,
+        params: dict = None,
+    ) -> dict[int, Response | None]:
+        services = self._get_services()
+        if not services:
+            return {}
+
+        jwt_token = self.jwt
+
+        if self.wait_for_response:
+            return self._make_synchronous_request(services, method, path, data, params, jwt_token)
+        return self._make_async_request(services, method, path, data, params, jwt_token)


### PR DESCRIPTION
## Summary

`AllServicesClient._make_request()` uses `ThreadPoolExecutor` as a context manager, which calls `shutdown(wait=True)` on exit — blocking until all service sync threads complete even when `wait_for_response=False`. This makes org deletes wait for controller/hub/EDA to process every cascaded resource delete.

## Fix

Use a module-level shared `ThreadPoolExecutor` for fire-and-forget requests. `submit()` returns immediately, the threads run in the background, and any delivery failures are caught by the 15-minute reverse sync.

## Performance Impact

Tested on scalelab with ~9000 users, ~3000 teams:

| Teams | Before | After |
|-------|--------|-------|
| 5     | 2.4s   | 0.4s  |
| 10    | 4.1s   | TBD   |
| 20    | 8.0s   | TBD   |
| 40    | timeout | TBD  |

## Risk

Low — the reverse sync (runs every 15 min in each service) catches any failed resource deletes. The `wait_for_response=True` path (used for create/update) is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resource synchronization “fire-and-forget” requests now return immediately, without waiting for downstream processing.
  * Background sync failures are isolated: timeouts and unexpected errors are caught so they don’t block the caller.
  * Synchronous waiting behavior remains unchanged, while background work no longer impacts normal operation or shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->