### PR TITLE
[AAP-84060] fix(ci): skip SonarCloud on merge queue events

### DIFF
--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -33,6 +33,8 @@
 #
 # JOB 3: sonar-branch-analysis (for long-lived branches)
 # - Runs when: Unit Tests finished after a push to a matched branch
+# - Skips: merge_group events (PR analysis already ran; merge queue branches
+#          compare against devel and flag pre-existing issues as "new")
 # - Steps: Download coverage → Run SonarCloud branch analysis
 # - Scans: Full codebase
 # - Quality gate: Focuses on overall project health
@@ -78,11 +80,23 @@ jobs:
           EVENT_TYPE: ${{ github.event.workflow_run.event }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          if [ "$EVENT_TYPE" = "pull_request" ] || [ "$EVENT_TYPE" = "merge_group" ]; then
+          if [ "$EVENT_TYPE" = "merge_group" ]; then
+            # Merge queue branches are ephemeral (gh-readonly-queue/<base>/<sha>).
+            # SonarCloud branch analysis compares against sonar.newCode.referenceBranch
+            # (devel), but the merge queue branch diverges from a stable-* branch, so
+            # the diff is massive and flags dozens of pre-existing issues as "new".
+            # The PR already passed SonarCloud PR analysis before entering the queue,
+            # so skipping here avoids false quality-gate failures.
+            echo "branch=$HEAD_BRANCH" >> "$GITHUB_OUTPUT"
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+            echo "⏭️ merge_group event — skipping SonarCloud (PR analysis already ran)"
+            exit 0
+          fi
+
+          if [ "$EVENT_TYPE" = "pull_request" ]; then
             # workflow_run doesn't expose the PR base branch, so we can't check it here.
-            # Allow PRs and merge_group events through the gate; the PR analysis job
-            # resolves the base branch via the GitHub API and rechecks it against
-            # SONAR_BRANCHES before scanning. Merge group events run a branch analysis.
+            # Allow PRs through the gate; the PR analysis job resolves the base branch
+            # via the GitHub API and rechecks it against SONAR_BRANCHES before scanning.
             echo "branch=$HEAD_BRANCH" >> "$GITHUB_OUTPUT"
             echo "allowed=true" >> "$GITHUB_OUTPUT"
             echo "✅ $EVENT_TYPE event — allowing through gate"
@@ -295,12 +309,12 @@ jobs:
       actions: read
     if: |
       needs.gate.outputs.allowed == 'true' &&
-      (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'merge_group')
+      github.event.workflow_run.event == 'push'
     steps:
       # Pin to the exact commit that the Unit Tests workflow ran against,
       # since workflow_run context defaults to the repo's default branch.
       #
-      # SONAR githubactions:S7631 - safe: this job only runs for push events (see the 'if' above), which come from repo collaborators, never from forks
+      # SONAR githubactions:S7631 - safe: this job only runs for push events, which come from repo collaborators, never from forks
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Summary

- Skip SonarCloud analysis for `merge_group` events to prevent false quality-gate failures
- Merge queue branches (`gh-readonly-queue/<base>/<sha>`) ran branch analysis comparing against `devel`, but PRs targeting `stable-*` branches diverge significantly from `devel`, causing dozens of pre-existing issues to be flagged as "new"
- The PR already passes SonarCloud PR analysis before entering the queue, so the merge queue re-check is redundant

## Root cause

When a PR enters the merge queue, GitHub fires a `merge_group` event. The sonar workflow's gate passed this through, and the branch analysis job picked it up. Branch analysis uses `sonar.newCode.referenceBranch=devel` (from `sonar-project.properties`), but the merge queue branch for `stable-2.5` has a large diff against `devel` — so SonarCloud flagged 42 pre-existing issues as "new" and failed the quality gate with D ratings on Security and Reliability.

Example: [aap-gateway PR #1553](https://github.com/ansible-automation-platform/aap-gateway/pull/1553) was blocked by [this SonarCloud failure](https://github.com/ansible-automation-platform/aap-gateway/runs/90674298673) despite passing all PR checks.

## Changes

1. **Gate job**: Split the `pull_request || merge_group` condition — `merge_group` now sets `allowed=false` with an explanatory log message
2. **Branch analysis job**: Removed `merge_group` from the `if` condition (now only triggers on `push`)
3. Updated header comments and inline annotations to reflect the new behavior

## Test plan

- [ ] Verify PRs targeting `devel` still get SonarCloud PR analysis
- [ ] Verify pushes to `devel` still get SonarCloud branch analysis
- [ ] Verify merge queue events are skipped with the "⏭️ merge_group event" log message
- [ ] Backport to aap-gateway and verify PR #1553 can merge

Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code quality checks for pull requests by ensuring merge queue events are handled separately.
  * Prevented branch analysis from running during merge queue processing, reducing unnecessary checks.
  * Preserved quality gate validation for pull request events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->