### PR TITLE
[TEST ONLY][AAP-85052] Validate ATF skip logic for service cluster tests

### DIFF
--- a/aap_gateway_api/tests/models/test_route.py
+++ b/aap_gateway_api/tests/models/test_route.py
@@ -1,3 +1,5 @@
+"""Unit tests for Route model xDS config generation and ext_auth behaviour."""
+
 import pytest
 from ansible_base.feature_flags.utils import create_initial_data as seed_feature_flags
 


### PR DESCRIPTION
## Summary

Test PR to validate that the updated ATF test suite ([MR !176](https://gitlab.cee.redhat.com/ansible/testing/platform-services-test-suite/-/merge_requests/176)) correctly skips service cluster write tests (`test_patch_service_cluster_health_check_field`, `test_patch_outlier_detection_field`) when `enable_gateway_auth=True`.

The MR adds runtime detection of the gateway service's `enable_gateway_auth` config and skips PATCH tests in environments where `enable_gateway_auth=True` (where the 403 is expected behaviour, not the AAP-82539 regression).

### Expected outcome

- Tier 1 ATF tests should **pass** (the two PATCH tests should be **skipped** in CI dev environments)
- All other tests remain unaffected

### Tracking

- Jira: https://redhat.atlassian.net/browse/AAP-85052
- Test suite MR: https://gitlab.cee.redhat.com/ansible/testing/platform-services-test-suite/-/merge_requests/176

> **Note:** This is a validation-only PR and should be closed after confirming CI results. The only change is a module docstring addition to `test_route.py`.

---
**Note:** This PR was developed with assistance from Claude AI assistant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added descriptive documentation to the Route model test module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->