### PR TITLE
[AAP-77766] fix(Dockerfile): add missing env vars to runtime stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,26 +19,21 @@ Jewel provides the source code for the Gateway that connects Ansible services an
 
 ## Container Image
 
-A pre-built container image is published to the GitHub Container Registry on every push to the `devel` branch. The published image does **not** include the platform UI.
+A pre-built container image is published to the GitHub Container Registry on every push to the `devel` branch. The published image ships the Jewel API server without the platform UI.
 
 ```bash
 docker pull ghcr.io/ansible/jewel:latest
-docker run -p 8000:8000 ghcr.io/ansible/jewel:latest
 ```
 
-Available tags:
+> **Note:** Jewel requires PostgreSQL, Redis, and configuration to run. A standalone `docker run` won't work out of the box. Use `make docker-compose` for a full working environment — see the development setup below.
+
+There are currently no versioned releases. The `latest` tag always points to the most recent `devel` build. Per-commit SHA tags are available for pinning:
 
 | Tag | Description |
 |---|---|
 | `latest` | Most recent build from `devel` |
 | `sha-<short>` | Pinned to a specific commit (short SHA) |
 | `sha-<full>` | Pinned to a specific commit (full SHA) |
-
-To build locally with the platform UI included:
-
-```bash
-docker build --target jewel-ui -f tools/docker/Dockerfile .
-```
 
 ## Communication
 

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -3,8 +3,8 @@ ARG PYTHON=python3.12
 FROM quay.io/centos/centos:stream9 AS builder
 ARG PYTHON
 
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
 
 ARG DJANGO_SETTINGS_MODULE=aap_gateway_api.settings
 ENV DJANGO_SETTINGS_MODULE=$DJANGO_SETTINGS_MODULE
@@ -86,6 +86,8 @@ RUN for dir in \
 # to be compatible with protobuf 3.21+. This should be removed
 # once a new version of xds-protos is available
 ENV PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+ENV DJANGO_SETTINGS_MODULE=aap_gateway_api.settings
+ENV PYTHONUNBUFFERED=1
 
 COPY aap_gateway_api /opt/aap_gateway/src/aap_gateway_api/
 ENV PATH=/opt/aap_gateway/venv/bin:$PATH


### PR DESCRIPTION
## Summary

- **`DJANGO_SETTINGS_MODULE`** and **`PYTHONUNBUFFERED`** were only set in the `builder` stage of the Dockerfile and not carried over to the `jewel` runtime stage. This caused the published GHCR image to fail on startup with `"settings are not configured"` when run standalone.
- Also fixes legacy `ENV` format warnings (`ENV key value` -> `ENV key=value`) flagged by the build workflow.

## How to reproduce

```bash
docker pull ghcr.io/ansible/jewel:latest
docker run -p 8000:8000 ghcr.io/ansible/jewel:latest
# Fails with: "You must either define the environment variable DJANGO_SETTINGS_MODULE..."
```

## Test plan

- [ ] Verify the build workflow passes
- [ ] Pull the newly built image and confirm `docker run` no longer errors on settings
- [ ] Confirm `DJANGO_SETTINGS_MODULE` is set: `docker inspect ghcr.io/ansible/jewel:latest | grep DJANGO_SETTINGS_MODULE`

---
**Note:** This PR was developed with assistance from Claude AI assistant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container environment variable configuration.
  * Added runtime settings to improve application startup and logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->