### PR TITLE
[AAP-84892] Pin jwcrypto>=1.5.8 for CVE-2026-39373

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -18,6 +18,7 @@ uwsgi
 xds-protos>=1.58
 PyYAML
 # Not directly imported but pinned per dependabot alerts
+jwcrypto>=1.5.8  # CVE-2026-39373 - Memory exhaustion via crafted compressed JWE tokens (transitive dep from DAB)
 pyasn1>=0.6.4    # CVE-2026-59886 - DoS via crafted ASN.1 REAL values (transitive dep from DAB's python-ldap)
 urllib3>=2.7.0   # CVE-2026-44431 / CVE-2026-44432
 argon2-cffi

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -97,8 +97,9 @@ jsonschema==4.25.1
     #   drf-spectacular
 jsonschema-specifications==2025.9.1
     # via jsonschema
-jwcrypto==1.5.7
+jwcrypto==1.5.8
     # via
+    #   -r requirements/requirements.in
     #   django-ansible-base
     #   django-oauth-toolkit
 ldap-filter==1.0.1


### PR DESCRIPTION
## Description

- **What is being changed?**
  Add `jwcrypto>=1.5.8` to `requirements/requirements.in` and regenerate `requirements/requirements.txt`.

- **Why is this change needed?**
  jwcrypto is a DAB transitive dependency that resolves to 1.5.7, which is vulnerable to CVE-2026-39373 (memory exhaustion via crafted compressed JWE tokens). Without a floor pin, lockfile regeneration can produce 1.5.7, reverting any manual version sync.

- **How does this change address the issue?**
  The floor pin ensures pip-compile always resolves jwcrypto to at least 1.5.8, preventing downgrades during lockfile regeneration.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites
None.

### Steps to Test
1. Run `cd requirements && ./updater.sh run`
2. Verify `jwcrypto==1.5.8` in `requirements/requirements.txt`

### Expected Results
- `requirements.txt` regenerates successfully
- `jwcrypto` resolves to 1.5.8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application security by incorporating an updated cryptographic component that addresses a known vulnerability.
  * Maintained existing functionality while applying the security update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->