### PR TITLE
[AAP-84893] Pin DAB transitive deps to prevent version drift

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -19,6 +19,10 @@ xds-protos>=1.58
 PyYAML
 # Not directly imported but pinned per dependabot alerts
 pyasn1>=0.6.4    # CVE-2026-59886 - DoS via crafted ASN.1 REAL values (transitive dep from DAB's python-ldap)
+# DAB transitive deps pinned to prevent version drift during container lockfile regeneration
+django-redis>=7.0.0
+python-ldap>=3.4.7
+redis>=8.0.1,<9  # 8.0.0 broke Unix socket connections (redis/redis-py#4086), fixed in 8.0.1
 urllib3>=2.7.0   # CVE-2026-44431 / CVE-2026-44432
 argon2-cffi
 dynaconf>=3.2.13,<4.0.0  # CVE-2026-33154; <4.0.0 because 4.x is expected to have breaking changes


### PR DESCRIPTION
## Description

- **What is being changed?**
  Add minimum version pins in `requirements/requirements.in` for DAB transitive dependencies:
  - `django-redis>=7.0.0`
  - `python-ldap>=3.4.7`
  - `redis>=8.0.1,<9` (8.0.0 broke Unix socket connections, fixed in 8.0.1)

- **Why is this change needed?**
  These DAB transitive dependencies are resolved by pip-compile but were not pinned. When lockfiles are regenerated, unpinned dependencies resolve to whatever version the pip resolver picks, causing version drift between branches.

- **How does this change address the issue?**
  Floor pins ensure lockfile regeneration always produces versions at or above the required minimums, preventing downgrades and maintaining consistency.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites
- ansible/django-ansible-base#1075 must be merged first (removes the `redis<8.0.0` cap that conflicts with `redis>=8.0.1`).

### Steps to Test
1. Run `cd requirements && ./updater.sh run`
2. Verify `django-redis`, `python-ldap`, `redis` resolve to versions at or above the pinned minimums

### Expected Results
- `requirements.txt` regenerates successfully
- `django-redis==7.0.0`, `python-ldap==3.4.7`, `redis` in `[8.0.1, 9.0.0)`

## Additional Context

requires: ansible/django-ansible-base#1075 — removes the stale `redis<8.0.0` cap that would conflict with `redis>=8.0.1,<9`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added version constraints for Redis-related and directory integration dependencies.
  * Limited Redis to supported 8.x releases for improved installation consistency.
  * Pinned compatible versions of supporting packages to improve installation reliability and maintain consistent environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->