### PR TITLE
Fix RFC 1034/1035 non-compliant container names breaking JWT auth

### DIFF
--- a/tools/ansible/roles/keycloak/tasks/initialize.yml
+++ b/tools/ansible/roles/keycloak/tasks/initialize.yml
@@ -24,7 +24,7 @@
     - name: See if keycloak database already exists
       community.docker.docker_container_exec:
         command: /usr/bin/psql -U {{ db_username }} --command "SELECT 1 FROM pg_database WHERE datname = 'keycloak';"
-        container: aap_gw_db_pgsql_1
+        container: aap-gw-db-pgsql-1
         docker_host: "{{ docker_host | default(omit) }}"
       changed_when: False
       retries: 3
@@ -34,7 +34,7 @@
     - name: Create the keycloak database
       community.docker.docker_container_exec:
         command: /usr/bin/psql -U postgres --command 'CREATE DATABASE keycloak WITH OWNER="{{ db_username }}" encoding "UTF8";'
-        container: aap_gw_db_pgsql_1
+        container: aap-gw-db-pgsql-1
         docker_host: "{{ docker_host | default(omit) }}"
       register: pg_initialization
       when: "'0 rows' in db_check.stdout"
@@ -94,7 +94,7 @@
     - name: See if the gateway realm already exists
       community.docker.docker_container_exec:
         command: /usr/bin/psql -U {{ db_username }} keycloak --command "SELECT 1 FROM realm WHERE id = 'gateway';"
-        container: aap_gw_db_pgsql_1
+        container: aap-gw-db-pgsql-1
         docker_host: "{{ docker_host | default(omit) }}"
       changed_when: False
       register: realm_check

--- a/tools/ansible/roles/sources/templates/docker-compose-stage.yml.j2
+++ b/tools/ansible/roles/sources/templates/docker-compose-stage.yml.j2
@@ -11,7 +11,7 @@ services:
       dockerfile: tools/generated/Dockerfile
     command:
       - /usr/bin/launch-gateway
-    container_name: aap_gw_{{ container_id }}
+    container_name: aap-gw-{{ container_id }}
     hostname: gateway{{ container_id }}
     depends_on:
       - db
@@ -82,7 +82,7 @@ services:
         hard: 4096
 
   redis_sidecar{{ container_id }}:
-    container_name: aap_gw_redis_sidecar_{{ container_id }}
+    container_name: aap-gw-redis-sidecar-{{ container_id }}
     hostname: redis_sidecar{{ container_id }}
     image: {{ redis_container_image }}:{{ redis_container_version }}
     entrypoint: ["sh", "-c", "chmod 777 /var/run/redis && exec redis-server /usr/local/etc/redis/redis-sidecar.conf"]
@@ -196,7 +196,7 @@ services:
 {% endif %}
 
   db:
-    container_name: aap_gw_db_pgsql_1
+    container_name: aap-gw-db-pgsql-1
     command: run-postgresql -c log_destination=stderr -c log_min_messages=info
     environment:
       - POSTGRESQL_DATABASE=gateway
@@ -215,7 +215,7 @@ services:
 {% if not enabled_containers['haproxy']|bool %}
 {# If we are not enabling haproxy then we will just run with 1 envoy server #}
   proxy1:
-    container_name: aap_gw_proxy1
+    container_name: aap-gw-proxy1
     hostname: proxy1
     image: {{ envoy_proxy_image }}:{{ envoy_proxy_version }}
     entrypoint: /usr/local/bin/envoy
@@ -252,7 +252,7 @@ services:
   {% set exposed_port = 9079 + container_id | int %}
   {% set exposed_admin_port = 18999 + container_id | int %}
   proxy{{ container_id }}:
-    container_name: aap_gw_proxy_{{ container_id }}
+    container_name: aap-gw-proxy-{{ container_id }}
     hostname: proxy{{ container_id }}
     image: {{ envoy_proxy_image }}:{{ envoy_proxy_version }}
     entrypoint: /usr/local/bin/envoy
@@ -286,7 +286,7 @@ services:
 {% if enabled_containers['haproxy']|bool %}
   haproxy:
     image: haproxy:{{ proxy_container_version }}
-    container_name: aap_gw_haproxy_1
+    container_name: aap-gw-haproxy-1
     hostname: haproxy
     user: "${UID}"
     ports:
@@ -309,7 +309,7 @@ services:
 {% if enabled_containers['keycloak']|bool %}
   keycloak:
     image: {{ keycloak_image }}:{{ keycloak_image_version }}
-    container_name: aap_gw_keycloak_1
+    container_name: aap-gw-keycloak-1
     hostname: keycloak
     user: "${UID:-1000}"
     ports:
@@ -332,7 +332,7 @@ services:
 {% if enabled_containers['ldap'] | bool %}
   ldap:
     image: bitnamilegacy/openldap:{{ ldap_image_version }}
-    container_name: aap_gw_ldap_1
+    container_name: aap-gw-ldap-1
     hostname: ldap
     user: "${UID:-1000}"
     ports:
@@ -359,7 +359,7 @@ services:
 {% if enabled_containers['tacacs'] | bool %}
   tacacs:
     image: dchidell/docker-tacacs:{{ tacacs_container_version }}
-    container_name: aap_gw_tacacs_1
+    container_name: aap-gw-tacacs-1
     hostname: tacacs
     ports:
       - "{{ tacacs_exposed_tacacs_port }}:49"
@@ -370,7 +370,7 @@ services:
 {% if enabled_containers['radius'] | bool %}
   radius:
     image: {{ radius_image }}:{{ radius_image_version }}
-    container_name: aap_gw_radius_1
+    container_name: aap-gw-radius-1
     hostname: radius
     command: ['-f', '-x', '-l', 'stdout']
     volumes:

--- a/tools/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -10,7 +10,7 @@ services:
       dockerfile: tools/generated/Dockerfile
     command:
       - /usr/bin/launch-gateway
-    container_name: aap_gw_{{ container_id }}
+    container_name: aap-gw-{{ container_id }}
     hostname: gateway{{ container_id }}
     depends_on:
       - db
@@ -95,7 +95,7 @@ services:
         hard: 4096
 
   redis_sidecar{{ container_id }}:
-    container_name: aap_gw_redis_sidecar_{{ container_id }}
+    container_name: aap-gw-redis-sidecar-{{ container_id }}
     hostname: redis_sidecar{{ container_id }}
     image: {{ redis_container_image }}:{{ redis_container_version }}
     entrypoint: ["sh", "-c", "chmod 777 /var/run/redis && exec redis-server /usr/local/etc/redis/redis-sidecar.conf"]
@@ -209,7 +209,7 @@ services:
 {% endif %}
 
   db:
-    container_name: aap_gw_db_pgsql_1
+    container_name: aap-gw-db-pgsql-1
     command: run-postgresql -c log_destination=stderr -c log_min_messages=info
     environment:
       - POSTGRESQL_DATABASE=gateway
@@ -228,7 +228,7 @@ services:
 {% if not enabled_containers['haproxy']|bool %}
 {# If we are not enabling haproxy then we will just run with 1 envoy server #}
   proxy1:
-    container_name: aap_gw_proxy1
+    container_name: aap-gw-proxy1
     hostname: proxy1
     image: {{ envoy_proxy_image }}:{{ envoy_proxy_version }}
     entrypoint: /usr/local/bin/envoy
@@ -265,7 +265,7 @@ services:
   {% set exposed_port = 9079 + container_id | int %}
   {% set exposed_admin_port = 18999 + container_id | int %}
   proxy{{ container_id }}:
-    container_name: aap_gw_proxy_{{ container_id }}
+    container_name: aap-gw-proxy-{{ container_id }}
     hostname: proxy{{ container_id }}
     image: {{ envoy_proxy_image }}:{{ envoy_proxy_version }}
     entrypoint: /usr/local/bin/envoy
@@ -299,7 +299,7 @@ services:
 {% if enabled_containers['haproxy']|bool %}
   haproxy:
     image: mirror.gcr.io/haproxy:{{ proxy_container_version }}
-    container_name: aap_gw_haproxy_1
+    container_name: aap-gw-haproxy-1
     hostname: haproxy
     user: "${UID}"
     ports:
@@ -322,7 +322,7 @@ services:
 {% if enabled_containers['keycloak']|bool %}
   keycloak:
     image: {{ keycloak_image }}:{{ keycloak_image_version }}
-    container_name: aap_gw_keycloak_1
+    container_name: aap-gw-keycloak-1
     hostname: keycloak
     user: "${UID:-1000}"
     ports:
@@ -358,7 +358,7 @@ services:
 {% if enabled_containers['ldap'] | bool %}
   ldap:
     image: mirror.gcr.io/bitnamilegacy/openldap:{{ ldap_image_version }}
-    container_name: aap_gw_ldap_1
+    container_name: aap-gw-ldap-1
     hostname: ldap
     user: "${UID:-1000}"
     ports:
@@ -385,7 +385,7 @@ services:
 {% if enabled_containers['tacacs'] | bool %}
   tacacs:
     image: mirror.gcr.io/dchidell/docker-tacacs:{{ tacacs_container_version }}
-    container_name: aap_gw_tacacs_1
+    container_name: aap-gw-tacacs-1
     hostname: tacacs
     ports:
       - "{{ tacacs_exposed_tacacs_port }}:49"
@@ -396,7 +396,7 @@ services:
 {% if enabled_containers['radius'] | bool %}
   radius:
     image: {{ radius_image }}:{{ radius_image_version }}
-    container_name: aap_gw_radius_1
+    container_name: aap-gw-radius-1
     hostname: radius
     command: ['-f', '-x', '-l', 'stdout']
     volumes:
@@ -409,7 +409,7 @@ services:
 {% if enabled_containers['otel_collector'] | bool %}
   otel_collector:
     image: {{ otel_collector_image }}:{{ otel_collector_image_version }}
-    container_name: aap_gw_otel_collector_1
+    container_name: aap-gw-otel-collector-1
     hostname: otel-collector
     command: ["--config=/etc/otel/otel-collector-config.yml"]
     ports:
@@ -432,7 +432,7 @@ services:
 {% if enabled_containers['loki'] | bool %}
   loki:
     image: {{ loki_image }}:{{ loki_image_version }}
-    container_name: aap_gw_loki_1
+    container_name: aap-gw-loki-1
     hostname: loki
     command: ["-config.file=/etc/loki/loki-config.yml"]
     ports:
@@ -447,7 +447,7 @@ services:
 {% if enabled_containers['tempo'] | bool %}
   tempo:
     image: {{ tempo_image }}:{{ tempo_image_version }}
-    container_name: aap_gw_tempo_1
+    container_name: aap-gw-tempo-1
     hostname: tempo
     command: ["-config.file=/etc/tempo/tempo-config.yml"]
     ports:
@@ -462,7 +462,7 @@ services:
 {% if enabled_containers['grafana'] | bool %}
   grafana:
     image: {{ grafana_image }}:{{ grafana_image_version }}
-    container_name: aap_gw_grafana_1
+    container_name: aap-gw-grafana-1
     hostname: grafana
     ports:
       - "{{ grafana_http_port }}:{{ grafana_http_port }}"

--- a/tools/ansible/switch_gateway_mode.yml
+++ b/tools/ansible/switch_gateway_mode.yml
@@ -25,12 +25,12 @@
     - name: Ensure the container is running
       community.docker.docker_container_info:
         docker_host: "{{ docker_host | default(omit) }}"
-        name: aap_gw_1
+        name: aap-gw-1
       register: gateway_container_status
 
     - name: Fail if the container is not running
       ansible.builtin.fail:
-        msg: "The aap_gw_1 container is not running"
+        msg: "The aap-gw-1 container is not running"
       when: gateway_container_status.container['State']['Status'] != 'running'
 
     - name: Determine services and port
@@ -47,7 +47,7 @@
     - name: "Stop process {{ stop_process }}"
       community.docker.docker_container_exec:
         docker_host: "{{ docker_host | default(omit) }}"
-        container: aap_gw_1
+        container: aap-gw-1
         command: "supervisorctl stop {{ stop_process }}"
       register: stop_output
       changed_when: "'ERROR' not in stop_output.stdout"
@@ -55,7 +55,7 @@
     - name: "Start process {{ start_process }}"
       community.docker.docker_container_exec:
         docker_host: "{{ docker_host | default(omit) }}"
-        container: aap_gw_1
+        container: aap-gw-1
         command: "supervisorctl start {{ start_process }}"
       register: start_output
       changed_when: "'ERROR' not in start_output.stdout"

--- a/tools/ansible/vars/container_config.yml
+++ b/tools/ansible/vars/container_config.yml
@@ -15,7 +15,7 @@ container_engine: docker
 gateway_image: 'quay.io/ansible/jewel:devel' # placeholder until public image available
 gateway_host_address: host-gateway
 gateway_services: "{{ enabled_services | default([], true) }}"
-gateway_container_name: aap_gw_1
+gateway_container_name: aap-gw-1
 
 ddt_enabled: "{{ enable_django_debug_toolbar | default(False) }}"
 
@@ -44,7 +44,7 @@ redis_sentinel_sentinel_nodes: 3
 redis_mode: "{{ redis_type | default(redis_mode_options[0]) }}"
 redis_node_count: "{{ redis_node_topology_count[redis_mode] | default(1) }}"
 redis_uses_tls: "{{ redis_tls_enabled | default(True) }}"
-redis_node_prefix: 'aap_gw_redis_'
+redis_node_prefix: 'aap-gw-redis-'
 cache_key_prefix: 'gateway'
 
 # Keycloak settings

--- a/tools/configs/container-startup-podman.yml
+++ b/tools/configs/container-startup-podman.yml
@@ -10,7 +10,7 @@ container_engine: podman
 gateway_image: 'quay.io/ansible/jewel:devel' # placeholder until public image available
 gateway_host_address: host.containers.internal
 gateway_services: ['hub','controller','eda']
-gateway_container_name: aap_gw_1
+gateway_container_name: aap-gw-1
 
 ### Redis
 ### Note: If you change the redis settings, please remove tools/generated/redis_cluster and let it rebuild


### PR DESCRIPTION
## Summary

- Replace underscores with hyphens in all `container_name` values across docker-compose templates, config files, and playbooks (e.g. `aap_gw_proxy1` → `aap-gw-proxy1`)

## Problem

Container names like `aap_gw_proxy1` contain underscores, which are **invalid per RFC 1034/1035**. When downstream services (e.g. AWX/Controller) attempt to reach the gateway using the container name as a hostname, Django rejects the request with a `DisallowedHost` error — *before* even checking `ALLOWED_HOSTS` — because the hostname fails RFC validation.

This breaks the JWT authentication flow between Gateway and Controller. When a user makes a request through the Envoy proxy to a downstream service, Gateway injects a signed JWT token. The downstream service then tries to fetch the JWT public key from `https://aap_gw_proxy1:9080/api/gateway/v1/jwt_key/` to validate that token, and gets a 400 back.

### Error logs from AWX/Controller

```
ERROR ansible_base.jwt_consumer.common.util Failed to validate x-trusted-proxy-header, unable to load cert Failed to get 200 response from the issuer: 400
ERROR ansible_base.jwt_consumer.common.auth Failed to get 200 response from the issuer: 400
ERROR ansible_base.lib.uitls.requests Unable to use headers from trusted proxy because shared secret was invalid!
```

### Envoy proxy logs

```
"GET /api/gateway/v1/jwt_key/ HTTP/1.1" 400 - "python-requests/2.32.5" "aap_gw_proxy1:9080"
"GET /api/controller/v2/jobs/ HTTP/1.1" 401 - "curl/8.18.0" "localhost"
```

### Django error response (from AWX curling the gateway)

```
Invalid HTTP_HOST header: 'aap_gw_proxy1:9080'. The domain name provided is not valid according to RFC 1034/1035.
```

### Symptom in the UI

JWT errors when accessing any proxied service (Controller, Hub, EDA) through the gateway.

## Files changed

- `docker-compose.yml.j2` / `docker-compose-stage.yml.j2` — all `container_name` values
- `container_config.yml` — `gateway_container_name` and `redis_node_prefix`
- `container-startup-podman.yml` — `gateway_container_name`
- `switch_gateway_mode.yml` — hardcoded container name references
- `keycloak/tasks/initialize.yml` — hardcoded db container name references

## Test plan

- [ ] `make docker-compose` starts all containers with hyphenated names
- [ ] Downstream services (Controller) can reach `/api/gateway/v1/jwt_key/` via the container hostname
- [ ] JWT authentication works end-to-end through the proxy
- [ ] `make keycloak` still initializes correctly
- [ ] `make switch-gateway-mode` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized container names to use hyphens across gateway, database, Redis, proxy, authentication, observability, and related services.
  * Improved container status checks, startup, shutdown, and database initialization by aligning references with the updated names.
  * Prevented service-management operations from failing due to inconsistent container naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->