### PR TITLE
[AAP-85471] Enable ANSIBLE_BASE_ALLOW_TEAM_ORG_MEMBER in Gateway

### DIFF
--- a/aap_gateway_api/defaults.py
+++ b/aap_gateway_api/defaults.py
@@ -382,6 +382,7 @@ ANSIBLE_BASE_ALLOW_SINGLETON_ROLES_API = True
 ANSIBLE_BASE_ALLOW_SINGLETON_TEAM_ROLES = True
 ANSIBLE_BASE_ALLOW_SINGLETON_USER_ROLES = True
 ANSIBLE_BASE_ALLOW_TEAM_ORG_ADMIN = False
+ANSIBLE_BASE_ALLOW_TEAM_ORG_MEMBER = True
 # Rely on the remote service's RBAC enforcement instead of local checks.
 # See aap_gateway_api/views/api/v1/role.py for the remote permission validation path.
 ANSIBLE_BASE_ENFORCE_REMOTE_OBJECT_PERMISSIONS = False


### PR DESCRIPTION
## Summary
- Gateway inherits the DAB default `ANSIBLE_BASE_ALLOW_TEAM_ORG_MEMBER = False`, while Controller overrides it to `True` (`awx/settings/defaults.py:1111`).
- This mismatch causes reverse-sync of org-scoped team role assignments (any role containing `member_organization`) to be rejected by Gateway with a 400, which propagates as an unhandled HTTP 500 to the Controller API consumer.
- Setting the flag to `True` in Gateway aligns it with Controller and eliminates the root cause.

Companion PR in django-ansible-base adds defensive error handling for reverse-sync failures: https://github.com/ansible/django-ansible-base/pull/1084

## Test plan
- [ ] Verify `POST /api/controller/v2/role_team_assignments/` with `org_jt_admin` returns 201 instead of 500
- [ ] Verify `Organization Project Admin`, `Organization Member`, and other org-scoped roles with `member_organization` can be assigned to teams
- [ ] Verify `role_user_assignments` (unaffected path) still works
- [ ] Run `tests/rbac/test_projects.py::TestControllerProjectsRBAC::test_team_can_create_projects_with_role`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled support for team organization member roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->