### PR TITLE
[AAP-84893] Regenerate lockfile: redis 7.4.1 → 8.1.0

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -59,7 +59,9 @@ django-flags==5.0.13
 django-oauth-toolkit==2.3.0
     # via django-ansible-base
 django-redis==7.0.0
-    # via django-ansible-base
+    # via
+    #   -r requirements/requirements.in
+    #   django-ansible-base
 djangorestframework==3.15.2
     # via
     #   -r requirements/requirements.in
@@ -218,6 +220,7 @@ pyrad==2.5.4
     # via django-ansible-base
 python-ldap==3.4.7
     # via
+    #   -r requirements/requirements.in
     #   django-ansible-base
     #   django-auth-ldap
 python3-openid==3.2.0
@@ -229,8 +232,9 @@ pyyaml==6.0.2
     #   -r requirements/requirements.in
     #   dispatcherd
     #   drf-spectacular
-redis==7.4.1
+redis==8.1.0
     # via
+    #   -r requirements/requirements.in
     #   django-ansible-base
     #   django-redis
 referencing==0.36.2


### PR DESCRIPTION
## Description

- **What:** Regenerate the pip lockfile (`requirements/requirements.txt`) to resolve `redis` from 7.4.1 to 8.1.0.
- **Why:** The previous commit (b6d768ee, AAP-84893) added `redis>=8.0.1,<9` to `requirements.in` but deferred lockfile regeneration because DAB still had a `redis<8.0.0` version cap. That cap was removed in django-ansible-base#1075, but the lockfile was never updated. This causes the container build to fail — `pip install` sees the package metadata requiring `redis>=8.0.1` but the compiled lockfile only provides 7.4.1.
- **How:** Ran `./updater.sh run` to regenerate the lockfile. The only version change is `redis 7.4.1 → 8.1.0`; all other diff lines are cosmetic (`# via` comment path normalization by pip-compile).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites
None — this is a lockfile-only change.

### Steps to Test
1. Build the container with this version of the gateway
2. Verify the container builds successfully without `redis` version conflicts

### Expected Results
Container build completes without `Could not find a version that satisfies the requirement redis>=8.0.1` errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency attribution metadata for `django-redis`, `python-ldap`, and Redis.
  * Upgraded Redis from version 7.4.1 to 8.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->