### PR TITLE
[AAP-86745] Update controller service_path to include api_slug prefix

### DIFF
--- a/tools/ansible/roles/proxy-config/templates/proxy.yml.j2
+++ b/tools/ansible/roles/proxy-config/templates/proxy.yml.j2
@@ -94,14 +94,14 @@ gateway_services:    # API Services (Hub/EDA/Controller/gateway)
 {% elif service == 'controller' %}
     # It configures proxy requests
     # - from https://<gateway url>:9080/api/controller/...
-    # - to https://localhost:8043/api/...  # localhost is taken from service node "Controller Node"
+    # - to https://localhost:8043/api/controller/...  # localhost is taken from service node "Controller Node"
   - name: Controller API
     description: Proxy to the Controller
     http_port: API Port
     api_slug: controller
     service_cluster: controller
     is_service_https: true
-    service_path: '/api/'
+    service_path: '/api/controller/'
     service_port: 8043
     order: 2
 


### PR DESCRIPTION
## Summary
- Previously, the gateway rewrote requests from `/api/controller/...` to `/api/...` before forwarding to the controller backend on port 8043. This change removes that rewrite by setting `service_path` to `/api/controller/`, so requests are forwarded with the path intact.
- This requires AWX to be configured with `OPTIONAL_API_URLPATTERN_PREFIX = 'controller'` so it can serve its API under `/api/controller/` instead of `/api/`.
- Fixes the issue where browseable API links in awx have the /api/v2/ prefix which will 404 when accessed from gateway
- Fixes issue in test suite client where returned related fields (e.g. instances_groups has a related field of 'instances') would not have the prefix and would 404
- Note, this change should only affect docker compose environment

## Test plan
- [x] Run `make docker-compose` and verify controller service registers with `service_path: /api/controller/`
- [x] Confirm requests to `https://gateway:9080/api/controller/v2/ping/` are forwarded to `https://localhost:8043/api/controller/v2/ping/` (no prefix rewrite)
- [x] Verify AWX has `OPTIONAL_API_URLPATTERN_PREFIX = 'controller'` set and responds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)