### PR TITLE
AAP-87035 Fix pr-labels workflow failing on Node 24

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -284,8 +284,9 @@ jobs:
                   isInternal = true;
                   core.info(`${pr.user.login} is a member of the ansible org`);
                 } else if (resp.status === 302) {
-                  isInternal = true;
-                  core.info(`${pr.user.login} is a member of the ansible org (requester is not org member)`);
+                  core.warning(`Org membership check returned 302 — ORG_TOKEN owner is not an ansible org member; cannot determine membership for ${pr.user.login}`);
+                } else if (resp.status !== 404) {
+                  core.warning(`Unexpected status ${resp.status} checking org membership for ${pr.user.login}`);
                 }
               } catch (e) {
                 core.warning(`Failed to check org membership for ${pr.user.login}: ${e.message}`);

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -276,23 +276,19 @@ jobs:
 
             if (!isInternal) {
               try {
-                const { Octokit } = require('@octokit/rest');
-                const orgOctokit = new Octokit({ auth: process.env.ORG_TOKEN });
-                const { status } = await orgOctokit.orgs.checkMembershipForUser({
-                  org: 'ansible',
-                  username: pr.user.login,
-                });
-                if (status === 204) {
+                const resp = await fetch(
+                  `https://api.github.com/orgs/ansible/members/${pr.user.login}`,
+                  { headers: { Authorization: `token ${process.env.ORG_TOKEN}`, Accept: 'application/vnd.github+json' }, redirect: 'manual' }
+                );
+                if (resp.status === 204) {
                   isInternal = true;
                   core.info(`${pr.user.login} is a member of the ansible org`);
-                }
-              } catch (e) {
-                if (e.status === 302) {
+                } else if (resp.status === 302) {
                   isInternal = true;
                   core.info(`${pr.user.login} is a member of the ansible org (requester is not org member)`);
-                } else if (e.status !== 404) {
-                  core.warning(`Failed to check org membership for ${pr.user.login}: ${e.message}`);
                 }
+              } catch (e) {
+                core.warning(`Failed to check org membership for ${pr.user.login}: ${e.message}`);
               }
             }
 


### PR DESCRIPTION
## Summary
- Replace `require('@octokit/rest')` with native `fetch()` for the org membership check in the pr-labels workflow
- The `@octokit/rest` module is not bundled with `actions/github-script` and fails to load on Node 24

## Changes Made
- Switched from `Octokit` client to `fetch()` API for the GitHub org membership check
- Simplified error handling: 302 redirects (non-org-member requester) are now handled as a normal response status rather than a caught exception
- Removed the `@octokit/rest` dependency entirely from the workflow

## Test Plan
- [ ] Verify the pr-labels workflow runs successfully on a PR
- [ ] Confirm org membership detection works for ansible org members
- [ ] Confirm external contributors are correctly identified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved community membership verification for more reliable results.
  * Successful membership responses are now recognized correctly, while redirected responses are handled safely.
  * Unexpected verification responses and connection errors now generate warnings, improving visibility into membership-check issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->