### PR TITLE
[AAP-87092] Regenerate requirements.txt with hashes and add CI drift check

### DIFF
--- a/.github/workflows/requirements-check.yml
+++ b/.github/workflows/requirements-check.yml
@@ -1,0 +1,36 @@
+---
+name: Requirements check
+on:
+  pull_request:
+    paths:
+      - 'requirements/**'
+  merge_group:
+    paths:
+      - 'requirements/**'
+jobs:
+  check-requirements:
+    name: requirements.txt satisfies constraints
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install dependencies
+        run: pip3.12 install packaging requests
+
+      - name: Clone DAB
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python tools/scripts/get_pr_checkout.py \
+            --always-clone-repos 'ansible/django-ansible-base'
+
+      - name: Check requirements
+        run: make check-requirements

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,7 @@ See [Reporting Bugs](#reporting-bugs) above.
 ## Development setup
 
 * **Python**: 3.11 or later (3.12 preferred)
+* **[uv](https://docs.astral.sh/uv/)**: Required for regenerating `requirements.txt` (`make requirements`). Install from https://docs.astral.sh/uv/.
 * **Git hooks**: Run `make git_hooks_config` to enable pre-commit linting checks.
 * **Tests**: Always run tests through tox, not pytest directly:
   ```

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ UNAME_S := $(shell uname -s)
 .PHONY: PYTHON_VERSION clean git_hooks_config \
 	check lint check_ruff check_ruff_format \
 	docker-compose plumb update_django_ansible_base_hash \
-	collection
+	collection requirements check-requirements
 
 ## Get the version of python we are working with
 PYTHON_VERSION:
@@ -245,11 +245,13 @@ endif
 tools/generated/proxy.yml: $(shell find tools/ansible/roles/proxy-config/templates -type f)
 	ansible-playbook tools/ansible/generate-proxy-configs.yml -e @tools/ansible/vars/container_config.yml -e @container-startup.yml
 
-## Build the requirements.txt file
-requirements/requirements.txt: requirements/requirements.in
-	cd requirements && \
-	    ./updater.sh run
-	@-cd .. || true
+## Regenerate requirements.txt from requirements.in
+requirements: requirements/requirements.in
+	cd requirements && ./updater.sh run
+
+## Verify requirements.txt is in sync with requirements.in
+check-requirements:
+	cd requirements && ./updater.sh check
 
 ## Register services and ports
 register-services: tools/generated/proxy.yml collection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,11 +166,7 @@ legacy_tox_ini = """
         PYTHONPATH = {toxinidir}:{toxinidir}/django-ansible-base/
         GATEWAY_SECRET_KEY_FILE = {toxinidir}/tools/configs/dev_secret_key
         DATABASE_ENGINE = django.db.backends.dummy
-    deps =
-        -r{toxinidir}/requirements/requirements.txt
-        -r{toxinidir}/requirements/requirements_git.txt
-        -r{toxinidir}/requirements/requirements_test.txt
-        psycopg[binary]
+    install_command = ./tools/scripts/ci/install_django_venv.sh {envname} {opts} {packages}
     commands =
         ./tools/scripts/ci/tox-reinstall-django-ansible-base.sh {envname}
         python3 -m aap_gateway_api check
@@ -183,11 +179,7 @@ legacy_tox_ini = """
         PYTHONPATH = {toxinidir}:{toxinidir}/django-ansible-base/
         GATEWAY_SECRET_KEY_FILE = {toxinidir}/tools/configs/dev_secret_key
         DATABASE_ENGINE = django.db.backends.dummy
-    deps =
-        -r{toxinidir}/requirements/requirements.txt
-        -r{toxinidir}/requirements/requirements_git.txt
-        -r{toxinidir}/requirements/requirements_test.txt
-         psycopg[binary]
+    install_command = ./tools/scripts/ci/install_django_venv.sh {envname} {opts} {packages}
     commands =
         ./tools/scripts/ci/tox-reinstall-django-ansible-base.sh {envname}
         python3 -m aap_gateway_api makemigrations --check
@@ -200,11 +192,7 @@ legacy_tox_ini = """
         PYTHONPATH = {toxinidir}:{toxinidir}/django-ansible-base/
         GATEWAY_SECRET_KEY_FILE = {toxinidir}/tools/configs/dev_secret_key
         DATABASE_ENGINE = django.db.backends.dummy
-    deps =
-        -r{toxinidir}/requirements/requirements.txt
-        -r{toxinidir}/requirements/requirements_git.txt
-        -r{toxinidir}/requirements/requirements_test.txt
-        psycopg[binary]
+    install_command = ./tools/scripts/ci/install_django_venv.sh {envname} {opts} {packages}
     commands =
         ./tools/scripts/ci/tox-reinstall-django-ansible-base.sh {envname}
         python3 -m aap_gateway_api check --deploy --tag oauth2_permissions

--- a/requirements/updater.sh
+++ b/requirements/updater.sh
@@ -1,88 +1,50 @@
 #!/usr/bin/env bash
 set -ue
 
-PYTHON=python3.12
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-for FILE in requirements.in requirements.txt ; do
-	if [[ ! -f ${FILE} ]] ; then
-		touch ${FILE}
-	fi
-done
-requirements_in="$(readlink -f ./requirements.in)"
-requirements_txt="$(readlink -f ./requirements.txt)"
-requirements_git="$(readlink -f ./requirements_git.txt)"
-pip_compile="pip-compile --no-header --quiet -r --allow-unsafe"
-
-_cleanup() {
-  cd /
-  [[ "${KEEP_TMP:-0}" = 1 ]] || rm -rf "${_tmp}"
+require_uv() {
+  if ! command -v uv &>/dev/null; then
+    echo "ERROR: uv is required but not found. Install it from https://docs.astral.sh/uv/" >&2
+    exit 1
+  fi
 }
 
-generate_requirements() {
-  venv="`pwd`/venv"
-  echo $venv
-  ${PYTHON} -m venv "${venv}"
-  # shellcheck disable=SC1090
-  source ${venv}/bin/activate
-
-  ${venv}/bin/python -m pip install -U 'pip' pip-tools
-
-  ${pip_compile} "${requirements_in}" "${requirements_git}" --output-file requirements.txt
+compile_requirements() {
+  require_uv
+  local uv_compile="uv pip compile --generate-hashes --python-version=3.12 --no-header"
+  if [[ "${UV_UPGRADE:-}" == "1" ]]; then
+    uv_compile="${uv_compile} --upgrade"
+  fi
+  local output_file="$1"
+  cd "${SCRIPT_DIR}"
+  ${uv_compile} \
+    --no-emit-package django-ansible-base \
+    --output-file "${output_file}" \
+    requirements.in \
+    requirements_git.txt
 }
 
-main() {
-  base_dir=$(pwd)
-
-  _tmp=$(${PYTHON} -c "import tempfile; print(tempfile.mkdtemp(suffix='.aap-gw-requirements', dir='/tmp'))")
-
-  trap _cleanup INT TERM EXIT
-
-  case $1 in
-    "run")
-      NEEDS_HELP=0
-    ;;
-    "upgrade")
-      NEEDS_HELP=0
-      pip_compile="${pip_compile} --upgrade"
-    ;;
-    "help")
-      NEEDS_HELP=1
-    ;;
-    *)
-      echo ""
-      echo "ERROR: Parameter $1 not valid"
-      echo ""
-      NEEDS_HELP=1
-    ;;
-  esac 
-
-  if [[ "$NEEDS_HELP" == "1" ]] ; then
+case "${1:-}" in
+  "run")
+    compile_requirements requirements.txt
+  ;;
+  "upgrade")
+    UV_UPGRADE=1 compile_requirements requirements.txt
+  ;;
+  "check")
+    python3 "${SCRIPT_DIR}/../tools/scripts/check_requirements.py"
+  ;;
+  *)
     echo "This script generates requirements.txt from requirements.in"
     echo ""
-    echo "Usage: $0 [run|upgrade]"
+    echo "Usage: $0 [run|upgrade|check]"
     echo ""
     echo "Commands:"
-    echo "help      Print this message"
-    echo "run       Run the process only upgrading pinned libraries from requirements.in"
-    echo "upgrade   Upgrade all libraries to latest while respecting pinnings"
+    echo "  run       Resolve dependencies, only upgrading where required by pins"
+    echo "  upgrade   Upgrade all packages to latest while respecting pins"
+    echo "  check     Verify requirements.txt is in sync with requirements.in"
     echo ""
-    exit
-  fi
-
-  cp -vf ${requirements_txt} "${_tmp}"
-  cd "${_tmp}"
-
-  generate_requirements
-
-  echo "Changing $base_dir to requirements"
-  # Strip the django-ansible-base git reference from pip-compile output;
-  # it belongs only in requirements_git.txt, but keep its pinned transitives
-  awk '/^django-ansible-base/{skip=1; next} /^[^ #]/{skip=0} !skip' requirements.txt \
-    | sed "s:$base_dir:requirements:" > "${requirements_txt}"
-
-  _cleanup
-}
-
-# set EVAL=1 in case you want to source this script
-[[ "${EVAL:-0}" -eq "1" ]] || main "${1:-}"
-
+    exit 1
+  ;;
+esac

--- a/tools/ansible/roles/sources/templates/Dockerfile.j2
+++ b/tools/ansible/roles/sources/templates/Dockerfile.j2
@@ -34,7 +34,8 @@ RUN /usr/bin/${PYTHON} -m venv /opt/aap_gateway/venv
 COPY requirements/requirements.txt /tmp/requirements.txt
 COPY requirements/requirements_dev.txt /tmp/requirements_dev.txt
 COPY requirements/requirements_git.txt /tmp/requirements_git.txt
-RUN /opt/aap_gateway/venv/bin/pip --no-cache-dir install -r /tmp/requirements.txt -r /tmp/requirements_dev.txt
+RUN /opt/aap_gateway/venv/bin/pip --no-cache-dir install --require-hashes -r /tmp/requirements.txt
+RUN /opt/aap_gateway/venv/bin/pip --no-cache-dir install -r /tmp/requirements_dev.txt
 ARG DJANGO_ANSIBLE_BASE_DEVEL_SHA
 RUN /opt/aap_gateway/venv/bin/pip --no-cache-dir install -r /tmp/requirements_git.txt
 

--- a/tools/scripts/check_requirements.py
+++ b/tools/scripts/check_requirements.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Verify that requirements.txt satisfies all constraints from gateway and DAB requirements."""
+
+import re
+import sys
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+
+def parse_pinned(path):
+    """Parse pinned versions from a compiled requirements.txt (package==version)."""
+    pins = {}
+    for line in Path(path).read_text().splitlines():
+        m = re.match(r'^([a-zA-Z0-9_.-]+)(?:\[[^\]]*\])?==([^\s\\]+)', line)
+        if m:
+            pins[m.group(1).lower().replace('-', '_')] = Version(m.group(2))
+    return pins
+
+
+def parse_constraints(path):
+    """Parse package constraints from a .in file, skipping comments and blank lines."""
+    constraints = []
+    for line in Path(path).read_text().splitlines():
+        line = line.split('#')[0].strip()
+        if not line or line.startswith('-'):
+            continue
+        try:
+            constraints.append(Requirement(line))
+        except Exception as exc:
+            print(f"WARNING: skipping unparseable line in {path}: {line!r} ({exc})", file=sys.stderr)
+            continue
+    return constraints
+
+
+def parse_dab_extras(requirements_git_path):
+    """Extract the extras list from requirements_git.txt (e.g. [extra1,extra2,...])."""
+    text = requirements_git_path.read_text()
+    m = re.search(r'django-ansible-base\[([^\]]+)\]', text)
+    if not m:
+        return []
+    return [e.strip().replace('-', '_') for e in m.group(1).split(',')]
+
+
+def find_dab_constraint_files(req_dir, extras):
+    """Find DAB requirements .in files for the given extras."""
+    dab_dir = req_dir.parent / 'django-ansible-base' / 'requirements'
+    if not dab_dir.is_dir():
+        return []
+
+    files = [dab_dir / 'requirements.in']
+    for extra in extras:
+        files.append(dab_dir / f'requirements_{extra}.in')
+
+    return [f for f in files if f.exists()]
+
+
+def main():
+    req_dir = Path(__file__).resolve().parent.parent.parent / 'requirements'
+    pins = parse_pinned(req_dir / 'requirements.txt')
+
+    input_files = [
+        req_dir / 'requirements.in',
+    ]
+
+    requirements_git = req_dir / 'requirements_git.txt'
+    if requirements_git.exists():
+        extras = parse_dab_extras(requirements_git)
+        dab_files = find_dab_constraint_files(req_dir, extras)
+        if dab_files:
+            input_files.extend(dab_files)
+            print(f"Including {len(dab_files)} DAB requirements file(s)", file=sys.stderr)
+        else:
+            print("WARNING: django-ansible-base not checked out, skipping DAB constraints", file=sys.stderr)
+
+    constraints = []
+    for path in input_files:
+        constraints.extend(parse_constraints(path))
+
+    errors = []
+    for req in constraints:
+        name = req.name.lower().replace('-', '_')
+        if name not in pins:
+            errors.append(f"  {req.name}: required by {req} but not found in requirements.txt")
+            continue
+        pinned = pins[name]
+        if not req.specifier.contains(pinned, prereleases=True):
+            errors.append(f"  {req.name}: pinned {pinned} does not satisfy {req.specifier}")
+
+    if errors:
+        print("requirements.txt does not satisfy input constraints:", file=sys.stderr)
+        for e in errors:
+            print(e, file=sys.stderr)
+        print("\nRun 'make requirements' to regenerate.", file=sys.stderr)
+        sys.exit(1)
+
+    print("requirements.txt satisfies all constraints.")
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/scripts/ci/install_django_venv.sh
+++ b/tools/scripts/ci/install_django_venv.sh
@@ -24,5 +24,7 @@ if ! pip show django-ansible-base > /dev/null 2>&1; then
     GIT_REQUIREMENTS="-r requirements/requirements_git.txt"
 fi
 
-# Install all dependencies from requirements.txt (includes pinned Django version)
-pip install psycopg[binary] -r requirements/requirements.txt ${GIT_REQUIREMENTS} "$@"
+# Install hashed production requirements separately so pip's --require-hashes
+# mode does not conflict with unhashed test/dev dependencies.
+pip install --require-hashes --no-cache-dir -r requirements/requirements.txt
+pip install 'psycopg[binary]' ${GIT_REQUIREMENTS} "$@"


### PR DESCRIPTION
## Depends On
Depends on #199 being merged first. This PR is currently based off #199 to ensure we get green CI but we want #199 to merge first and then have this one rebased and merged. This will help with any kind of backporting we need to do in the future.

## Summary

- **Fix**: Regenerate `requirements.txt` to resolve redis version mismatch (7.4.1 → 8.1.0) caused by `requirements.in` being updated without recompiling the lockfile
- **Improvement**: Switch `updater.sh` from `pip-compile` to `uv pip compile --generate-hashes` — adds hash verification for supply-chain security and avoids the pip-tools/pip 26.x incompatibility
- **New**: Add `check_requirements.py` + CI workflow to validate that pinned versions in `requirements.txt` satisfy all constraints from `requirements.in` and DAB requirements files, preventing future drift
- **Dev env**: Split pip install in Dockerfile and CI to separate hashed production requirements from unhashed dev/test dependencies

## Root cause

`requirements.in` was updated with `redis>=8.0.1,<9` but `requirements.txt` was not recompiled, leaving redis pinned at 7.4.1. The aap-gateway wheel metadata (from `pyproject.toml` dynamic dependencies) declares `redis>=8.0.1`, so the container build fails when it can only find 7.4.1. The new CI check prevents this class of drift.

## Changes from original PR

Removed `requirements_container.in`. Container infrastructure dependencies (dumb-init, supervisor, psycopg[c]) are managed by the downstream container repository, not the upstream gateway repo. This avoids creating a second source of truth with no sync mechanism and keeps release-specific concerns out of the upstream repo.

## Test plan

- [x] `make requirements` regenerates `requirements.txt` with hashes
- [x] `make check-requirements` passes (validates all constraints satisfied)
- [x] CI workflow runs on PR and passes
- [x] Dev container builds successfully