### PR TITLE
[AAP-79121] Add x-ai-description for status and feature flags endpoints

### DIFF
--- a/aap_gateway_api/views/api/v1/feature_flags.py
+++ b/aap_gateway_api/views/api/v1/feature_flags.py
@@ -8,6 +8,7 @@ from ansible_base.lib.utils.views.permissions import IsSuperuserOrAuditor
 from ansible_base.oauth2_provider.permissions import OAuth2ScopePermission
 from django.conf import settings
 from django.shortcuts import get_object_or_404
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import status
 from rest_framework.response import Response
 
@@ -18,6 +19,9 @@ from aap_gateway_api.views.api.v1.common import GatewayModelViewSet, ResourceAPI
 logger = logging.getLogger(__name__)
 
 
+@extend_schema_view(
+    retrieve=extend_schema(extensions={'x-ai-description': 'Returns the current state of all feature flags on the Gateway platform.'}),
+)
 class AAPFlagViewSet(ResourceAPIUpdateMixin, GatewayModelViewSet):
     """API endpoint that allows feature flags to be viewed or edited."""
 

--- a/aap_gateway_api/views/api/v1/status.py
+++ b/aap_gateway_api/views/api/v1/status.py
@@ -249,6 +249,7 @@ def services_to_dict(services: List[Dict]) -> Dict:
         serializers=[StatusSerializer, ServiceKeysStatusSerializer],
         resource_type_field_name=None,
     ),
+    extensions={'x-ai-description': 'Returns the current Gateway platform status, including service health and version.'},
 )
 class StatusView(AnsibleBaseView):
     """API endpoint that shows status of platform services."""


### PR DESCRIPTION
## Summary
- Added `x-ai-description` to 2 Gateway endpoints that had vague auto-generated descriptions
- `status_retrieve`: "Retrieve single status" → "Returns the current Gateway platform status, including service health and version."
- `feature_flags_state_retrieve`: "Retrieve single feature flags state" → "Returns the current state of all feature flags on the Gateway platform."

## Test plan
- [ ] Verify MCP server picks up the new descriptions via `tools/list`
- [ ] Confirm existing endpoint behavior is unchanged (description-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced API documentation for the feature-flag state endpoint.
  * Added descriptive metadata to the Gateway platform status endpoint response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->