### PR TITLE
[AAP-87884] fix: explicitly clean up team RBAC assignments on org delete

### DIFF
--- a/aap_gateway_api/views/api/v1/organization.py
+++ b/aap_gateway_api/views/api/v1/organization.py
@@ -28,3 +28,20 @@ class OrganizationViewSet(ResourceAPIUpdateMixin, RoleModelViewSet):
             return Response(status=status.HTTP_400_BAD_REQUEST, data={"details": _("Managed organizations cannot be deleted.")})
         else:
             return super().destroy(request, *args, **kwargs)
+
+    def perform_destroy(self, instance):
+        team_pks = list(instance.teams.values_list('pk', flat=True))
+        super().perform_destroy(instance)
+        if team_pks:
+            self._cleanup_team_rbac_assignments(team_pks)
+
+    @staticmethod
+    def _cleanup_team_rbac_assignments(team_pks):
+        from ansible_base.rbac.models import DABContentType, RoleTeamAssignment, RoleUserAssignment
+
+        from aap_gateway_api.models import Team
+
+        team_ct = DABContentType.objects.get_for_model(Team)
+        str_pks = [str(pk) for pk in team_pks]
+        RoleUserAssignment.objects.filter(object_id__in=str_pks, content_type=team_ct).delete()
+        RoleTeamAssignment.objects.filter(object_id__in=str_pks, content_type=team_ct).delete()


### PR DESCRIPTION
## Summary
- When an organization is deleted via the API, the deferred RBAC flush (`cleanup_deleted_team_roles`) deletes ObjectRoles for cascade-deleted teams, but the associated `RoleUserAssignment` records can survive as orphans
- This adds explicit cleanup of team role assignments in `OrganizationViewSet.perform_destroy()`, capturing team PKs before the delete and removing orphaned records afterward
- The cleanup runs inside the same outer transaction, so rollback semantics (tested by `TestOrgDeleteRBACFlushRollback`) are preserved

## Root cause analysis
The `test_successful_delete_cleans_up_everything` test in Views A-R CI began failing on stable-2.6. The org-level `RoleUserAssignment` records are properly cleaned up, but team-level records survive. The issue is in the DAB deferred RBAC flush path where `cleanup_deleted_team_roles()` deletes ObjectRoles for the team but the CASCADE to `RoleUserAssignment` does not reliably propagate. This defensive fix in gateway ensures team RBAC assignments are explicitly removed regardless of DAB's cascade behavior.

The upstream root-cause fix is in ansible/django-ansible-base PR #1098.

## Test plan
- [x] Existing `TestOrgDeleteCleansUpRBAC::test_successful_delete_cleans_up_everything` should now pass
- [x] Existing `TestOrgDeleteRBACFlushRollback::test_flush_failure_rolls_back_delete` should remain passing (cleanup is inside the outer transaction)
- [ ] Monitor Views A-R CI on this PR

Resolves: https://redhat.atlassian.net/browse/AAP-87884

Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting an organization now also removes associated team access assignments.
  * Prevents leftover role-based access permissions after organization deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->