### PR TITLE
[AAP-88393] Remove stale shared content types with invalid app_label

### DIFF
--- a/aap_gateway_api/signals/preloaded_data.py
+++ b/aap_gateway_api/signals/preloaded_data.py
@@ -26,6 +26,7 @@ def create_preload_data(**kwargs) -> None:
         set_system_user_managed_flag,
         toggle_install_time_flags,
         remove_console_service_type,
+        remove_stale_shared_content_types,
     ]
 
     # Verbosity comes from the signal see https://docs.djangoproject.com/en/5.0/ref/signals/#post-migrate
@@ -180,3 +181,25 @@ def remove_console_service_type() -> bool:
         name="RED_HAT_CONSOLE_URL",
     ).delete()
     return (deleted_st + deleted_pref) > 0
+
+
+def remove_stale_shared_content_types() -> bool:
+    """Remove shared DABContentType rows whose app_label doesn't match any local app.
+
+    The metrics service incorrectly registered its User model in the
+    permission_registry, causing a (shared, core, user) DABContentType to be
+    exported via the role-types endpoint. When gateway imported this via
+    load_types_and_permissions, model_class() failed because the 'core' app
+    doesn't exist locally, resulting in a 500 on the role_definitions endpoint.
+    """
+    from ansible_base.rbac.models import DABContentType
+
+    deleted = False
+    for ct in DABContentType.objects.filter(service='shared'):
+        try:
+            global_apps.get_app_config(ct.app_label)
+        except LookupError:
+            logger.warning('Removing stale shared content type: service=%s, app_label=%s, model=%s', ct.service, ct.app_label, ct.model)
+            ct.delete()
+            deleted = True
+    return deleted

--- a/aap_gateway_api/tests/signals/test_preloaded_data.py
+++ b/aap_gateway_api/tests/signals/test_preloaded_data.py
@@ -180,12 +180,20 @@ class TestCreatePreloadedData:
         with expected_log('aap_gateway_api.signals.preloaded_data.logger', 'debug', 'Removed'):
             create_preload_data(verbosity=1, plan=[('0000', False)])
 
+    @staticmethod
+    def _next_ct_id():
+        """Return an ID that won't collide with rows created by create_DAB_contenttypes."""
+        from ansible_base.rbac.models import DABContentType
+        from django.db.models import Max
+
+        return (DABContentType.objects.aggregate(Max('id'))['id__max'] or 0) + 1
+
     @pytest.mark.django_db
     def test_remove_stale_shared_content_types(self):
         """remove_stale_shared_content_types deletes shared content types with invalid app_label."""
         from ansible_base.rbac.models import DABContentType
 
-        DABContentType.objects.create(service='shared', app_label='core', model='user')
+        DABContentType.objects.create(id=self._next_ct_id(), service='shared', app_label='core', model='user')
         assert remove_stale_shared_content_types() is True
         assert not DABContentType.objects.filter(service='shared', app_label='core', model='user').exists()
 
@@ -209,7 +217,7 @@ class TestCreatePreloadedData:
         """remove_stale_shared_content_types only targets service='shared' rows."""
         from ansible_base.rbac.models import DABContentType
 
-        ct = DABContentType.objects.create(service='eda', app_label='core', model='activation')
+        ct = DABContentType.objects.create(id=self._next_ct_id(), service='eda', app_label='core', model='activation')
         assert remove_stale_shared_content_types() is False
         assert DABContentType.objects.filter(pk=ct.pk).exists()
 
@@ -218,7 +226,7 @@ class TestCreatePreloadedData:
         """remove_stale_shared_content_types is wired into create_preload_data function_order."""
         from ansible_base.rbac.models import DABContentType
 
-        DABContentType.objects.create(service='shared', app_label='core', model='user')
+        DABContentType.objects.create(id=self._next_ct_id(), service='shared', app_label='core', model='user')
         create_preload_data(verbosity=0, plan=[('0000', False)])
         assert not DABContentType.objects.filter(service='shared', app_label='core', model='user').exists()
 
@@ -227,6 +235,6 @@ class TestCreatePreloadedData:
         """remove_stale_shared_content_types logs a warning for each removed row."""
         from ansible_base.rbac.models import DABContentType
 
-        DABContentType.objects.create(service='shared', app_label='core', model='user')
+        DABContentType.objects.create(id=self._next_ct_id(), service='shared', app_label='core', model='user')
         with expected_log('aap_gateway_api.signals.preloaded_data.logger', 'warning', 'Removing stale shared content type'):
             remove_stale_shared_content_types()

--- a/aap_gateway_api/tests/signals/test_preloaded_data.py
+++ b/aap_gateway_api/tests/signals/test_preloaded_data.py
@@ -7,6 +7,7 @@ from aap_gateway_api.signals.preloaded_data import (
     create_default_organization,
     create_preload_data,
     remove_console_service_type,
+    remove_stale_shared_content_types,
     set_system_user_managed_flag,
     set_system_user_password,
 )
@@ -178,3 +179,54 @@ class TestCreatePreloadedData:
 
         with expected_log('aap_gateway_api.signals.preloaded_data.logger', 'debug', 'Removed'):
             create_preload_data(verbosity=1, plan=[('0000', False)])
+
+    @pytest.mark.django_db
+    def test_remove_stale_shared_content_types(self):
+        """remove_stale_shared_content_types deletes shared content types with invalid app_label."""
+        from ansible_base.rbac.models import DABContentType
+
+        DABContentType.objects.create(service='shared', app_label='core', model='user')
+        assert remove_stale_shared_content_types() is True
+        assert not DABContentType.objects.filter(service='shared', app_label='core', model='user').exists()
+
+    @pytest.mark.django_db
+    def test_remove_stale_shared_content_types_preserves_valid(self):
+        """remove_stale_shared_content_types does not delete content types with valid app_label."""
+        from ansible_base.rbac.models import DABContentType
+
+        valid_ct = DABContentType.objects.get(service='shared', model='organization')
+        assert valid_ct.app_label == 'aap_gateway_api'
+        assert remove_stale_shared_content_types() is False
+        assert DABContentType.objects.filter(pk=valid_ct.pk).exists()
+
+    @pytest.mark.django_db
+    def test_remove_stale_shared_content_types_idempotent(self):
+        """remove_stale_shared_content_types is a no-op when no stale records exist."""
+        assert remove_stale_shared_content_types() is False
+
+    @pytest.mark.django_db
+    def test_remove_stale_shared_content_types_ignores_non_shared(self):
+        """remove_stale_shared_content_types only targets service='shared' rows."""
+        from ansible_base.rbac.models import DABContentType
+
+        ct = DABContentType.objects.create(service='eda', app_label='core', model='activation')
+        assert remove_stale_shared_content_types() is False
+        assert DABContentType.objects.filter(pk=ct.pk).exists()
+
+    @pytest.mark.django_db
+    def test_remove_stale_shared_content_types_via_preload_data(self):
+        """remove_stale_shared_content_types is wired into create_preload_data function_order."""
+        from ansible_base.rbac.models import DABContentType
+
+        DABContentType.objects.create(service='shared', app_label='core', model='user')
+        create_preload_data(verbosity=0, plan=[('0000', False)])
+        assert not DABContentType.objects.filter(service='shared', app_label='core', model='user').exists()
+
+    @pytest.mark.django_db
+    def test_remove_stale_shared_content_types_logs_warning(self, expected_log):
+        """remove_stale_shared_content_types logs a warning for each removed row."""
+        from ansible_base.rbac.models import DABContentType
+
+        DABContentType.objects.create(service='shared', app_label='core', model='user')
+        with expected_log('aap_gateway_api.signals.preloaded_data.logger', 'warning', 'Removing stale shared content type'):
+            remove_stale_shared_content_types()


### PR DESCRIPTION
## Summary
- The metrics service incorrectly registered `core.User` in its `permission_registry` (PR ansible/metrics-service#77, Dec 2025), causing a `(shared, core, user)` DABContentType row to be created on the metrics service.
- When gateway fetched role types from metrics via `load_types_and_permissions` (after metrics was added to `SERVICE_TYPE_ORDER` in AAP-80948, Jul 2026), this content type was imported with `app_label='core'`.
- Gateway has no `core` app installed, so `model_class()` raised `LookupError`, causing a 500 on `/api/gateway/v1/role_definitions/`.
- Adds a `post_migrate` cleanup step (via `create_preload_data`) that removes any shared `DABContentType` rows whose `app_label` doesn't correspond to a locally installed app.

## Related PRs
- **DAB defense-in-depth**: https://github.com/ansible/django-ansible-base/pull/1104
- **Metrics root cause fix**: https://github.com/ansible/metrics-service/pull/401

## Test plan
- [ ] Verify that a stale `(shared, core, user)` DABContentType row is removed after `post_migrate`
- [ ] Verify that valid shared content types (e.g. `shared.organization` with `app_label=aap_gateway_api`) are not removed
- [ ] Verify `/api/gateway/v1/role_definitions/` no longer returns 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically removes outdated shared content types that are no longer registered locally.
  * Improves data consistency during preload operations by cleaning up stale records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->