### PR TITLE
[AAP-88508] Fix flaky org delete RBAC test caused by stale ContentType cache

### DIFF
--- a/aap_gateway_api/tests/views/api/v1/organization/test_organization.py
+++ b/aap_gateway_api/tests/views/api/v1/organization/test_organization.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.rbac.models import ObjectRole, RoleDefinition, RoleUserAssignment
+from ansible_base.rbac.permission_registry import permission_registry
 
 from aap_gateway_api.models import Organization, Team
 
@@ -222,7 +223,25 @@ def test_managed_organization_field_manual(admin_api_client):
 class TestOrgDeleteCleansUpRBAC:
     """Verify that a successful org delete removes all RBAC data consistently."""
 
+    @staticmethod
+    def _invalidate_permission_registry_ct_cache():
+        """Invalidate stale cached_property values on permission_registry.
+
+        transaction=True tests truncate and reload all tables, which can
+        reassign ContentType PKs.  permission_registry caches team_ct_id
+        and org_ct_id as @cached_property so they survive across tests
+        within the same xdist worker, leading to stale lookups in the
+        RBAC flush path (AAP-88508).
+        """
+        for attr in ('team_ct_id', 'org_ct_id'):
+            try:
+                delattr(permission_registry, attr)
+            except AttributeError:
+                pass
+
     def test_successful_delete_cleans_up_everything(self, admin_api_client, organization, team, user):
+        self._invalidate_permission_registry_ct_cache()
+
         RoleDefinition.objects.managed.org_member.give_permission(user, organization)
         RoleDefinition.objects.managed.team_member.give_permission(user, team)
 


### PR DESCRIPTION
## Description

- `TestOrgDeleteCleansUpRBAC::test_successful_delete_cleans_up_everything` fails intermittently on GH Actions due to stale `@cached_property` values in `permission_registry`
- `permission_registry.team_ct_id` and `org_ct_id` cache ContentType PKs, but `transaction=True` tests truncate and reload tables between tests, which can reassign those PKs
- The cached value survives across tests within the same xdist worker, so `cleanup_deleted_team_roles()` queries with a stale content type ID (e.g., `11` instead of `68`) and silently misses the team's ObjectRole
- Fix: invalidate the `cached_property` values at test start so they recompute against the current DB state

## Type of Change

- [x] Test update

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites
None — this fixes an existing flaky test.

### Steps to Test
1. Run the Views A-R unit test suite multiple times on a GH Actions runner
2. `TestOrgDeleteCleansUpRBAC::test_successful_delete_cleans_up_everything` should no longer fail intermittently

### Expected Results
The test passes consistently. Previously it failed ~1 in 3 CI runs due to `permission_registry.team_ct_id` holding a stale ContentType PK from a prior non-`transaction=True` test.

## Additional Context

Debugged via [PR #1595](https://github.com/ansible-automation-platform/aap-gateway/pull/1595) (README-only change confirming the failure is pre-existing) and [PR #1597](https://github.com/ansible-automation-platform/aap-gateway/pull/1597) (instrumented debug run that captured the root cause):

```
team_ct_id (cached): 11
team_ct_id (fresh):  68
```

The stale cache was introduced by the RBAC context manager refactor (AAP-82668, commit `67238a1`) which added `cleanup_deleted_team_roles()` — a new function that relies on `permission_registry.team_ct_id`.

---
**Note:** This PR was developed with assistance from Claude AI assistant.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved organization deletion test reliability by preventing stale permission data from affecting results.
  * Ensured cached organization and team metadata is refreshed between transactional tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->