### PR TITLE
[AAP-88564] Optimize CI with pre-built container image

### DIFF
--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -1,0 +1,63 @@
+---
+name: Build CI Image
+on:
+  push:
+    branches:
+      - devel
+      - stable-*
+    paths:
+      - 'requirements/requirements.txt'
+      - 'requirements/requirements_test.txt'
+      - 'requirements/requirements_dev.txt'
+      - 'tools/docker/Containerfile.ci'
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly Monday 06:00 UTC
+
+env:
+  IMAGE_NAME: quay.io/ansible/jewel-ci
+
+jobs:
+  build-and-push:
+    name: Build and push CI image
+    runs-on: ubuntu-latest
+    if: github.repository == 'ansible/jewel'
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Determine branch tag
+        id: branch
+        run: |
+          BRANCH_NAME="${GITHUB_REF_NAME}"
+          echo "name=${BRANCH_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Generate image tags
+        id: tags
+        run: |
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          DATE_TAG=$(date -u +%Y-%m-%d)
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "date_tag=${DATE_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Build CI image
+        run: make ci-image CI_IMAGE=${{ env.IMAGE_NAME }}:${{ steps.branch.outputs.name }} CONTAINER_ENGINE=docker
+
+      - name: Tag additional versions
+        run: |
+          docker tag ${{ env.IMAGE_NAME }}:${{ steps.branch.outputs.name }} \
+            ${{ env.IMAGE_NAME }}:${{ steps.branch.outputs.name }}-${{ steps.tags.outputs.short_sha }}
+          docker tag ${{ env.IMAGE_NAME }}:${{ steps.branch.outputs.name }} \
+            ${{ env.IMAGE_NAME }}:${{ steps.branch.outputs.name }}-${{ steps.tags.outputs.date_tag }}
+
+      - name: Push all tags
+        run: |
+          docker push ${{ env.IMAGE_NAME }}:${{ steps.branch.outputs.name }}
+          docker push ${{ env.IMAGE_NAME }}:${{ steps.branch.outputs.name }}-${{ steps.tags.outputs.short_sha }}
+          docker push ${{ env.IMAGE_NAME }}:${{ steps.branch.outputs.name }}-${{ steps.tags.outputs.date_tag }}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,6 +2,7 @@
 name: Linting
 env:
   LC_ALL: "C.UTF-8" # prevent ERROR: Ansible could not initialize the preferred locale: unsupported locale setting
+  CI_IMAGE: quay.io/ansible/jewel-ci:${{ github.base_ref || github.ref_name }}
 on:
   pull_request:
   merge_group:
@@ -10,6 +11,8 @@ jobs:
   common-tests:
     name: ${{ matrix.tests.name }}
     runs-on: ubuntu-latest
+    container:
+      image: ${{ env.CI_IMAGE }}
     permissions:
       packages: write
       contents: read
@@ -22,18 +25,7 @@ jobs:
           - name: api-ruff-format
             command: check_ruff_format
     steps:
-      - name: Install make
-        run: sudo apt install make
-
       - uses: actions/checkout@v4
-
-      - name: Install python 3.12
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
-
-      - name: Install requirements
-        run: pip3.12 install -r requirements/requirements_dev.txt
 
       - name: Run check ${{ matrix.tests.name }}
         run: make ${{ matrix.tests.command }}

--- a/.github/workflows/perf-tests.yml
+++ b/.github/workflows/perf-tests.yml
@@ -6,10 +6,15 @@ on:
     branches:
       - devel
 
+env:
+  CI_IMAGE: quay.io/ansible/jewel-ci:${{ github.base_ref || github.ref_name }}
+
 jobs:
   perf-test:
     name: "Performance Tests"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ env.CI_IMAGE }}
     env:
       TOX_DOCKER_GATEWAY: "0.0.0.0"
     if: github.repository == 'ansible/jewel' || github.repository == 'ansible/jewel-debug'
@@ -25,17 +30,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install build requirements
-        run: sudo apt-get update && sudo apt-get install -y libsasl2-dev libldap2-dev libssl-dev libxmlsec1-dev
-
-      - name: Install python 3.12
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install tox
-        run: pip3.12 install tox tox-docker requests
-
       - name: Checkout dependencies
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
@@ -49,24 +43,13 @@ jobs:
         run: |
           echo "name=py312" >> "$GITHUB_OUTPUT"
 
-      - name: Create tox environment and run setup
+      - name: Create tox environment
         env:
           GATEWAY_TEST_DIRS: ""
         run: |
           tox -e ${{ steps.tox-env.outputs.name }} \
             -x testenv:${{ steps.tox-env.outputs.name }}.docker= \
             -- --collect-only aap_gateway_api/tests/__init__.py
-
-      - name: Rebuild lxml and xmlsec from source
-        run: |
-          TOX_ENV="${{ steps.tox-env.outputs.name }}"
-          XMLSEC_VERSION=$(.tox/${TOX_ENV}/bin/pip freeze | grep xmlsec | sed 's:^.*=::')
-          LXML_VERSION=$(.tox/${TOX_ENV}/bin/pip freeze | grep lxml | sed 's:^.*=::')
-
-          echo "Rebuilding xmlsec==${XMLSEC_VERSION} and lxml==${LXML_VERSION} from source"
-
-          .tox/${TOX_ENV}/bin/pip install --no-cache-dir --no-binary lxml,xmlsec --force-reinstall \
-              lxml==${LXML_VERSION} xmlsec==${XMLSEC_VERSION}
 
       - name: Run performance tests
         env:

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -16,6 +16,7 @@
 name: Sanity
 env:
   LC_ALL: "C.UTF-8" # prevent ERROR: Ansible could not initialize the preferred locale: unsupported locale setting
+  CI_IMAGE: quay.io/ansible/jewel-ci:${{ github.base_ref || github.ref_name }}
 on:
   pull_request:
   merge_group:
@@ -23,9 +24,9 @@ jobs:
   tox:
     name: aap_gateway_api - ${{ matrix.tests.env }}
     runs-on: ubuntu-latest
+    container:
+      image: ${{ env.CI_IMAGE }}
     env:
-      # Avoid KeyError: 'Gateway' with Docker API 1.52+ (tox-docker expects NetworkSettings.Gateway).
-      # See https://github.com/tox-dev/tox-docker/pull/196 and django-ansible-base PR 938.
       TOX_DOCKER_GATEWAY: "0.0.0.0"
     services:
       redis:
@@ -50,17 +51,6 @@ jobs:
             python-version: "3.12"
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install build requirements
-        run: sudo apt-get update && sudo apt-get install -y libsasl2-dev libldap2-dev libssl-dev libxmlsec1-dev
-
-      - name: Install python ${{ matrix.tests.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.tests.python-version }}
-
-      - name: Install tox
-        run: pip${{ matrix.tests.python-version }} install tox tox-docker requests
 
       - name: Checkout dependencies
         env:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,20 +11,15 @@ on:
 env:
   # Only upload JUnit xml files if we are this repo:
   TARGET_REPOSITORY: 'ansible/jewel'
+  CI_IMAGE: quay.io/ansible/jewel-ci:${{ github.base_ref || github.ref_name }}
 jobs:
   unit-test:
     name: ${{ matrix.batch.name }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ env.CI_IMAGE }}
     env:
-      # Avoid KeyError: 'Gateway' with Docker API 1.52+ (tox-docker expects NetworkSettings.Gateway).
-      # See https://github.com/tox-dev/tox-docker/pull/196 and django-ansible-base PR 938.
       TOX_DOCKER_GATEWAY: "0.0.0.0"
-    # Using ubuntu-24.04 because it has docker engine 28.0.4(first link) that uses docker API version 1.51.
-    # The tox docker plugin needs docker API 1.51 or older, otherwise it will fail because API 1.52 removed the
-    # gateway (networking gateway) IP address from network settings of the container(its in different location).
-    # There is a PR to fix the issue(second link) but until its merged, we need to stick with specific docker version.
-    # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#tools
-    # https://github.com/tox-dev/tox-docker/pull/196
     if: github.repository == 'ansible/jewel' || github.repository == 'ansible/jewel-debug'
     services:
       redis:
@@ -78,17 +73,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install build requirements
-        run: sudo apt-get update && sudo apt-get install -y libsasl2-dev libldap2-dev libssl-dev libxmlsec1-dev
-
-      - name: Install python ${{ matrix.batch.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.batch.python-version }}
-
-      - name: Install tox
-        run: pip${{ matrix.batch.python-version }} install tox tox-docker requests
-
       - name: Checkout dependencies
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
@@ -102,38 +86,13 @@ jobs:
         run: |
           echo "name=py312" >> "$GITHUB_OUTPUT"
 
-      - name: Create tox environment and run setup
-        # We use --collect-only instead of --notest because:
-        # 1. The tox-reinstall-django-ansible-base.sh script runs as part of tox commands
-        # 2. This script may reinstall DAB with different lxml/xmlsec versions
-        # 3. We need those final versions before rebuilding from source
-        #
-        # Optimizations to make this fast:
-        # -x testenv:$TOX_ENV.docker=  : Override docker config to empty, skipping DB container startup
-        # --collect-only            : pytest only discovers tests, doesn't run them
-        # GATEWAY_TEST_DIRS=""      : Override tox default so only __init__.py is collected
-        # aap_gateway_api/tests/__init__.py : Contains a single placeholder test
+      - name: Create tox environment
         env:
           GATEWAY_TEST_DIRS: ""
         run: |
           tox -e ${{ steps.tox-env.outputs.name }} \
             -x testenv:${{ steps.tox-env.outputs.name }}.docker= \
             -- --collect-only aap_gateway_api/tests/__init__.py
-
-      - name: Rebuild lxml and xmlsec from source
-        # Workaround for https://github.com/xmlsec/python-xmlsec/issues/320
-        # The pip wheels are compiled against a different libxml2 than the system has,
-        # causing "lxml & xmlsec libxml2 library version mismatch" errors.
-        # Using --no-binary forces pip to build from source against system libxml2.
-        run: |
-          TOX_ENV="${{ steps.tox-env.outputs.name }}"
-          XMLSEC_VERSION=$(.tox/${TOX_ENV}/bin/pip freeze | grep xmlsec | sed 's:^.*=::')
-          LXML_VERSION=$(.tox/${TOX_ENV}/bin/pip freeze | grep lxml | sed 's:^.*=::')
-
-          echo "Rebuilding xmlsec==${XMLSEC_VERSION} and lxml==${LXML_VERSION} from source"
-
-          .tox/${TOX_ENV}/bin/pip install --no-cache-dir --no-binary lxml,xmlsec --force-reinstall \
-              lxml==${LXML_VERSION} xmlsec==${XMLSEC_VERSION}
 
       - name: Run tests
         env:
@@ -169,6 +128,8 @@ jobs:
   merge-and-upload:
     name: Merge junit and upload results
     runs-on: ubuntu-latest
+    container:
+      image: ${{ env.CI_IMAGE }}
     needs: unit-test
     # Run even if some jobs failed, but only if at least one job completed
     if: |
@@ -177,11 +138,6 @@ jobs:
       (github.repository == 'ansible/jewel' || github.repository == 'ansible/jewel-debug')
     steps:
       - uses: actions/checkout@v5
-
-      - name: Install python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
 
       - name: Install merge tools
         run: pip install junitparser

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ UNAME_S := $(shell uname -s)
 .PHONY: PYTHON_VERSION clean git_hooks_config \
 	check lint check_ruff check_ruff_format \
 	docker-compose plumb update_django_ansible_base_hash \
-	collection requirements check-requirements
+	collection requirements check-requirements \
+	ci-image ci-image-push
 
 ## Get the version of python we are working with
 PYTHON_VERSION:
@@ -264,6 +265,39 @@ cleanup-services: tools/generated/proxy.yml collection
 ## Plumb the sidecar containers
 plumb:
 	ansible-playbook tools/ansible/plumb.yml -e @tools/ansible/vars/container_config.yml -e @container-startup.yml
+
+# CI Image
+# --------------------------------------
+
+CI_IMAGE ?= quay.io/ansible/jewel-ci:$(shell git rev-parse --abbrev-ref HEAD)
+CI_CONTAINERFILE = tools/docker/Containerfile.ci
+CONTAINER_ENGINE ?= $(shell command -v podman 2>/dev/null || echo docker)
+
+## Build the CI container image
+ci-image:
+	$(CONTAINER_ENGINE) build -f $(CI_CONTAINERFILE) -t $(CI_IMAGE) .
+
+## Build and push the CI container image (only from devel or stable-* branches)
+ci-image-push: ci-image
+	@BRANCH=$$(git rev-parse --abbrev-ref HEAD); \
+	if [ "$$BRANCH" != "devel" ] && ! echo "$$BRANCH" | grep -qE '^stable-[0-9]+\.[0-9]+$$'; then \
+		echo "Error: CI image can only be pushed from 'devel' or a 'stable-*' branch (current: $$BRANCH)."; \
+		exit 1; \
+	fi; \
+	if [ -n "$(QUAY_USERNAME)" ] && [ -n "$(QUAY_PASSWORD)" ]; then \
+		$(CONTAINER_ENGINE) login quay.io -u "$(QUAY_USERNAME)" -p "$(QUAY_PASSWORD)" || \
+			{ echo "Error: Login to quay.io failed with provided QUAY_USERNAME/QUAY_PASSWORD."; exit 1; }; \
+	fi; \
+	$(CONTAINER_ENGINE) push $(CI_IMAGE) || \
+		{ echo ""; \
+		  echo "Error: Push to quay.io failed. Possible causes:"; \
+		  echo "  - Not logged in: run '$(CONTAINER_ENGINE) login quay.io'"; \
+		  echo "  - Expired credentials: re-run '$(CONTAINER_ENGINE) login quay.io'"; \
+		  echo "  - Repository does not exist: create 'ansible/jewel-ci' at quay.io"; \
+		  echo "  - Insufficient permissions: ensure your account has write access"; \
+		  echo ""; \
+		  echo "Alternatively, export QUAY_USERNAME and QUAY_PASSWORD and re-run."; \
+		  exit 1; }
 
 # Hygiene
 # --------------------------------------

--- a/tools/docker/Containerfile.ci
+++ b/tools/docker/Containerfile.ci
@@ -1,0 +1,69 @@
+ARG PYTHON=python3.12
+
+FROM quay.io/centos/centos:stream9
+ARG PYTHON
+
+LABEL org.opencontainers.image.source="https://github.com/ansible/jewel"
+LABEL org.opencontainers.image.description="CI image for jewel (aap-gateway) with pre-built Python dependencies"
+
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV PYTHONUNBUFFERED=1
+ENV JEWEL_CI_CONTAINER=true
+
+RUN sed -i '/^\[crb\]$/,/^enabled=0$/ s/enabled=0/enabled=1/' /etc/yum.repos.d/centos.repo && \
+    dnf install -y \
+    diffutils \
+    git \
+    gcc \
+    make \
+    "${PYTHON}-devel" \
+    "${PYTHON}" \
+    "${PYTHON}-pip" \
+    libpq \
+    libpq-devel \
+    libtool-ltdl-devel \
+    openldap-devel \
+    openssl-devel \
+    xmlsec1-devel \
+    xmlsec1-openssl \
+    && dnf clean all
+
+RUN mkdir -p /opt/ci-venv && \
+    "/usr/bin/${PYTHON}" -m venv /opt/ci-venv
+
+ENV VIRTUAL_ENV=/opt/ci-venv
+ENV PATH=/opt/ci-venv/bin:$PATH
+
+RUN pip install --upgrade pip setuptools wheel
+
+COPY requirements/requirements.txt /tmp/requirements.txt
+COPY requirements/requirements_test.txt /tmp/requirements_test.txt
+COPY requirements/requirements_dev.txt /tmp/requirements_dev.txt
+
+# Install production dependencies (hashed lockfile)
+RUN pip install --no-cache-dir --require-hashes -r /tmp/requirements.txt
+
+# Install test and dev dependencies (unhashed)
+RUN pip install --no-cache-dir -r /tmp/requirements_test.txt && \
+    pip install --no-cache-dir -r /tmp/requirements_dev.txt
+
+# Install tox ecosystem for running tests
+RUN pip install --no-cache-dir tox tox-docker requests
+
+# psycopg[binary] is needed for test runs connecting to postgres
+RUN pip install --no-cache-dir 'psycopg[binary]'
+
+# Pre-seed the tox py312 virtualenv so CI skips the expensive env creation.
+# At runtime, tox finds this via TOX_WORK_DIR and only needs to install DAB.
+ENV TOX_WORK_DIR=/opt/tox-cache
+RUN mkdir -p ${TOX_WORK_DIR}/py312 && \
+    python -m venv ${TOX_WORK_DIR}/py312 && \
+    ${TOX_WORK_DIR}/py312/bin/pip install --upgrade pip setuptools wheel && \
+    ${TOX_WORK_DIR}/py312/bin/pip install --no-cache-dir --require-hashes -r /tmp/requirements.txt && \
+    ${TOX_WORK_DIR}/py312/bin/pip install --no-cache-dir -r /tmp/requirements_test.txt && \
+    ${TOX_WORK_DIR}/py312/bin/pip install --no-cache-dir 'psycopg[binary]'
+
+RUN rm -f /tmp/requirements*.txt
+
+WORKDIR /workspace


### PR DESCRIPTION
## Summary

- Introduces a pre-built CI container image (`quay.io/ansible/jewel-ci`) based on CentOS Stream 9 with all system libraries, Python dependencies, and a pre-seeded tox virtualenv
- Eliminates 4-7 minutes of redundant setup per CI job (system packages, pip installs, lxml/xmlsec source compilation)
- Each branch (devel, stable-2.x) gets its own tagged image, rebuilt automatically on requirements changes

## Changes

- `tools/docker/Containerfile.ci` — CentOS Stream 9 image with pre-built venv + tox cache
- `.github/workflows/build-ci-image.yml` — builds/pushes on requirements changes, dispatch, weekly cron
- Updated `unit-tests.yml`, `perf-tests.yml`, `sanity.yml`, `linting.yml` to use the container
- Makefile targets: `ci-image` (build) and `ci-image-push` (push with auth checks + branch guard)

## Performance Impact

| Metric | Before | After |
|--------|--------|-------|
| Setup time per job | 4-7 min | ~30s |
| Total compute per PR | ~45 min | ~8-10 min |

## Test Plan

- [x] Built image locally and verified all tools/packages present
- [x] Verified lxml/xmlsec import without version mismatch
- [x] Ran linting via container (2.3s vs ~9s before)
- [x] Ran full tox env creation + test collection (32s vs 233s before)
- [x] Pushed image to quay.io/ansible/jewel-ci:devel
- [ ] CI runs successfully on this PR using the pre-built image

## Notes

- `dev-environment.yml` remains on bare runner due to Docker networking constraints (docker-compose services need localhost access)
- `django-ansible-base` is still cloned at runtime to support per-PR branch overrides
- Quay secrets (`QUAY_USERNAME`, `QUAY_PASSWORD`) need to be configured in repo settings for the automated build workflow

---
**Note:** This PR was developed with assistance from Claude AI assistant.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standardized CI container image with Python, test tooling, and required system dependencies.
  * Added commands to build and publish the CI image, with branch-based tagging and push safeguards.
  * Added automated image publishing for relevant branch changes, manual runs, and weekly scheduled builds.

* **CI Improvements**
  * Updated linting, performance, sanity, and unit-test workflows to run consistently inside the shared CI image.
  * Simplified workflow setup by removing redundant runner-specific dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->