### PR TITLE
[AAP-83613] fix: make renovate config valid to auto open pipeline bundle updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,15 +1,14 @@
+// -*- mode: jsonc -*-
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "enabledManagers": ["tekton"],
   "tekton": {
-    "schedule": ["0 * * * *"]
-  },
-  "packageRules": [
-    {
-      "description": "Update aap-ci tekton-catalog pipeline bundles",
-      "matchPackageNames": ["/^quay\\.io\\/aap-ci\\/tekton-catalog\\/pipeline\\/"],
-      "matchManagers": ["tekton"],
-      "automerge": true
+    "enabled": true,
+    "automerge": true,
+    "schedule": ["* 9-17 * * 1-5"],
+    // Disable post upgrade tasks to avoid pipeline-migration-tool failures (not applicable to tekton pipeline bundles)
+    "postUpgradeTasks": {
+      "commands": []
     }
-  ]
+  }
 }


### PR DESCRIPTION
## Description

<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
The previous renovate configuration was invalid and not allowing for automatic updates for tekton pipeline bundle tag bumps. This commit revises the configuration to align with other ansible repositories and disables post upgrade tasks.

This will help allow us to remove the need for manual PRs to update the tekton pipeline bundle and allow mint maker to handle this automatically.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Configuration change

For https://redhat.atlassian.net/browse/AAP-83613

Closes #210 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores

* Improved automated dependency update handling.
* Updates now run on weekdays from 09:00 to 17:00.
* Eligible updates can be merged automatically.
* Removed a package-specific automatic merge rule.
* Disabled post-update commands for a more predictable process.
* Enabled automated updates for Tekton components.
* Updated configuration formatting for improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->