### PR TITLE
[AAP-88904] Mitigate downstream 500 errors from corrupt preferences

### DIFF
--- a/aap_gateway_api/tests/preferences/test_preferences.py
+++ b/aap_gateway_api/tests/preferences/test_preferences.py
@@ -324,6 +324,159 @@ def test_get_default_value_by_preference(register_preference, is_encrypted):
     assert preferences.get_default_value_by_preference(preference, is_encrypted) == ENCRYPTED_STRING if is_encrypted else 'iam_default'
 
 
+@pytest.mark.django_db
+@mock.patch("aap_gateway_api.utils.preferences.logger")
+def test_get_preference_value_returns_default_on_invalid_token(mock_logger, register_preference):
+    """When a preference's stored value triggers InvalidToken during decryption,
+    get_preference_value should return the registry default and log critical."""
+    from cryptography.fernet import InvalidToken
+
+    register_preference(
+        section="general",
+        preference_name="corrupt_pref",
+        default="safe_default",
+        encrypted=False,
+        preference_type="string",
+    )
+
+    original_get = preferences.gateway_preference_registry.manager().__class__.get
+
+    def side_effect(self, key, *args, **kwargs):
+        if "corrupt_pref" in key:
+            raise InvalidToken("bad token")
+        return original_get(self, key, *args, **kwargs)
+
+    with patch.object(
+        preferences.gateway_preference_registry.manager().__class__,
+        "get",
+        side_effect,
+    ):
+        value = preferences.get_preference_value("general", "corrupt_pref")
+
+    assert value == "safe_default"
+    assert mock_logger.critical.call_count > 0
+    assert any("Failed to read preference" in str(call) for call in mock_logger.critical.call_args_list)
+    assert "general__corrupt_pref" in preferences._degraded_preferences
+
+    preferences._degraded_preferences.discard("general__corrupt_pref")
+
+
+@pytest.mark.django_db
+@mock.patch("aap_gateway_api.utils.preferences.logger")
+def test_get_preference_value_returns_default_on_serialization_error(mock_logger, register_preference):
+    """When a preference's stored value triggers SerializationError,
+    get_preference_value should return the registry default and log critical."""
+    register_preference(
+        section="general",
+        preference_name="corrupt_int_pref",
+        default=42,
+        encrypted=False,
+        preference_type="int",
+    )
+
+    original_get = preferences.gateway_preference_registry.manager().__class__.get
+
+    def side_effect(self, key, *args, **kwargs):
+        if "corrupt_int_pref" in key:
+            raise SerializationError("Value cannot be converted to int")
+        return original_get(self, key, *args, **kwargs)
+
+    with patch.object(
+        preferences.gateway_preference_registry.manager().__class__,
+        "get",
+        side_effect,
+    ):
+        value = preferences.get_preference_value("general", "corrupt_int_pref")
+
+    assert value == 42
+    assert mock_logger.critical.call_count > 0
+    assert "general__corrupt_int_pref" in preferences._degraded_preferences
+
+    preferences._degraded_preferences.discard("general__corrupt_int_pref")
+
+
+@pytest.mark.django_db
+def test_get_preference_value_clears_degraded_on_success(register_preference):
+    """After a preference recovers (successful read), it should be removed from the degraded set."""
+    register_preference(
+        section="general",
+        preference_name="recovering_pref",
+        default="default_val",
+        encrypted=False,
+        preference_type="string",
+    )
+
+    preferences._degraded_preferences.add("general__recovering_pref")
+    assert "general__recovering_pref" in preferences._degraded_preferences
+
+    value = preferences.get_preference_value("general", "recovering_pref")
+    assert value == "default_val"
+    assert "general__recovering_pref" not in preferences._degraded_preferences
+
+
+@pytest.mark.django_db
+def test_get_degraded_preferences_returns_copy(register_preference):
+    """get_degraded_preferences() should return a copy, not the internal set."""
+    preferences._degraded_preferences.add("test__key")
+    result = preferences.get_degraded_preferences()
+    assert "test__key" in result
+
+    result.add("extra_key")
+    assert "extra_key" not in preferences._degraded_preferences
+
+    preferences._degraded_preferences.discard("test__key")
+
+
+@pytest.mark.django_db
+def test_update_preference_value_clears_degraded(register_preference):
+    """Updating a preference should remove it from the degraded set."""
+    register_preference(
+        section="general",
+        preference_name="fixable_pref",
+        default="old_default",
+        encrypted=False,
+        preference_type="string",
+    )
+
+    preferences._degraded_preferences.add("general__fixable_pref")
+    assert "general__fixable_pref" in preferences._degraded_preferences
+
+    preferences.update_preference_value("general", "fixable_pref", "new_value")
+    assert "general__fixable_pref" not in preferences._degraded_preferences
+
+
+@pytest.mark.django_db
+@mock.patch("aap_gateway_api.utils.preferences.logger")
+def test_get_setting_returns_default_on_corrupt_preference(mock_logger, register_preference):
+    """get_setting() delegates to get_preference_value(), which should catch corruption."""
+    register_preference(
+        section="general",
+        preference_name="corrupt_setting",
+        default="fallback",
+        encrypted=False,
+        preference_type="string",
+    )
+
+    original_get = preferences.gateway_preference_registry.manager().__class__.get
+
+    def side_effect(self, key, *args, **kwargs):
+        if "corrupt_setting" in key:
+            raise SerializationError("corrupt")
+        return original_get(self, key, *args, **kwargs)
+
+    with patch.object(
+        preferences.gateway_preference_registry.manager().__class__,
+        "get",
+        side_effect,
+    ):
+        value = preferences.get_setting("corrupt_setting")
+
+    assert value == "fallback"
+    assert mock_logger.critical.call_count > 0
+
+    preferences._degraded_preferences.discard("general__corrupt_setting")
+
+
 def test_absolute_path_or_url_preference(register_preference, preference_manager):
     register_preference(
         section="general",

--- a/aap_gateway_api/tests/views/api/v1/preference/test_preferences_view.py
+++ b/aap_gateway_api/tests/views/api/v1/preference/test_preferences_view.py
@@ -1,9 +1,12 @@
 from http import HTTPStatus
 from types import NoneType
+from unittest import mock
 
 import pytest
 from ansible_base.lib.utils.encryption import ENCRYPTED_STRING
 from ansible_base.lib.utils.response import get_relative_url
+from cryptography.fernet import InvalidToken
+from dynamic_preferences.serializers import SerializationError
 
 from aap_gateway_api.models import Preference
 from aap_gateway_api.preferences import gateway_preference_registry
@@ -530,3 +533,47 @@ def test_auditor_gateway_settings_options_request(platform_auditor_api_client, c
 
     # Additional verification that GET action has the expected structure
     assert response.data['actions']['GET'] is not None
+
+
+@pytest.mark.django_db
+def test_get_single_preference_returns_503_on_invalid_token(admin_api_client, register_preference):
+    """When Preference.objects.get() triggers InvalidToken due to corrupt data,
+    the view should return 503 with a meaningful error message."""
+    register_preference(
+        section="general",
+        preference_name="corrupt_single",
+        default="safe",
+        encrypted=True,
+        preference_type="string",
+    )
+
+    url = get_relative_url("setting-detail", kwargs={"category_slug": "general", "preference_name": "corrupt_single"})
+
+    with mock.patch.object(Preference.objects, "get", side_effect=InvalidToken("bad token")):
+        response = admin_api_client.get(url)
+
+    assert response.status_code == 503
+    assert "corrupt or undecryptable data" in response.data["detail"]
+    assert "corrupt_single" in response.data["detail"]
+
+
+@pytest.mark.django_db
+def test_get_single_preference_returns_503_on_serialization_error(admin_api_client, register_preference):
+    """When Preference.objects.get() triggers SerializationError due to corrupt data,
+    the view should return 503 with a meaningful error message."""
+    register_preference(
+        section="general",
+        preference_name="corrupt_serial",
+        default=42,
+        encrypted=False,
+        preference_type="int",
+    )
+
+    url = get_relative_url("setting-detail", kwargs={"category_slug": "general", "preference_name": "corrupt_serial"})
+
+    with mock.patch.object(Preference.objects, "get", side_effect=SerializationError("cannot convert")):
+        response = admin_api_client.get(url)
+
+    assert response.status_code == 503
+    assert "corrupt or undecryptable data" in response.data["detail"]
+    assert "corrupt_serial" in response.data["detail"]

--- a/aap_gateway_api/tests/views/api/v1/status/test_status.py
+++ b/aap_gateway_api/tests/views/api/v1/status/test_status.py
@@ -507,5 +507,38 @@ class TestCheckRedisUnixSocket:
         assert 'Socket not found' in result['exception']
 
 
+def test_status_includes_degraded_preferences(admin_api_client):
+    """When preferences are degraded, the status endpoint should include them."""
+    from aap_gateway_api.utils import preferences
+
+    with mock.patch('aap_gateway_api.views.api.v1.status.get_redis_status', return_value=_REDIS_GOOD):
+        preferences._degraded_preferences.add("proxy__request_timeout")
+        preferences._degraded_preferences.add("proxy__jwt_private_key")
+        try:
+            url = get_relative_url("status-view")
+            response = admin_api_client.get(url)
+            assert response.status_code == 200
+            assert "degraded_preferences" in response.data
+            assert sorted(response.data["degraded_preferences"]) == [
+                "proxy__jwt_private_key",
+                "proxy__request_timeout",
+            ]
+        finally:
+            preferences._degraded_preferences.discard("proxy__request_timeout")
+            preferences._degraded_preferences.discard("proxy__jwt_private_key")
+
+
+def test_status_omits_degraded_preferences_when_empty(admin_api_client):
+    """When no preferences are degraded, the status response should not include the field."""
+    from aap_gateway_api.utils import preferences
+
+    with mock.patch('aap_gateway_api.views.api.v1.status.get_redis_status', return_value=_REDIS_GOOD):
+        preferences._degraded_preferences.clear()
+        url = get_relative_url("status-view")
+        response = admin_api_client.get(url)
+        assert response.status_code == 200
+        assert "degraded_preferences" not in response.data
+
+
 def get_service_by_name(data: List, name: str):
     return next((s for s in data["services"] if s["service_name"] == name), None)

--- a/aap_gateway_api/utils/preferences.py
+++ b/aap_gateway_api/utils/preferences.py
@@ -3,10 +3,12 @@ from typing import Any, Optional
 
 from ansible_base.lib.utils.encryption import ENCRYPTED_STRING, ansible_encryption
 from ansible_base.lib.utils.settings import SettingNotSetException, is_aoc_instance
+from cryptography.fernet import InvalidToken
 from django.conf import settings
 from django.utils.translation import gettext as _
 from dynamic_preferences import types
 from dynamic_preferences.preferences import Section
+from dynamic_preferences.serializers import SerializationError
 from rest_framework import serializers
 
 from aap_gateway_api.fields.serializers import JSONListField
@@ -29,9 +31,16 @@ separator = getattr(settings, 'DYNAMIC_PREFERENCES', {}).get('SECTION_KEY_SEPARA
 
 logger = logging.getLogger("aap.gateway.utils.preferences")
 
+_degraded_preferences: set[str] = set()
+
 
 class TooManyPreferencesException(Exception):
     """Raised when multiple preferences match a single setting name lookup."""
+
+
+def get_degraded_preferences() -> set[str]:
+    """Return the set of preference keys that failed to load due to corrupt data."""
+    return _degraded_preferences.copy()
 
 
 def update_preference_value(section: str, name: str, value: str, validate: bool = True) -> None:
@@ -39,6 +48,8 @@ def update_preference_value(section: str, name: str, value: str, validate: bool 
         preference = gateway_preference_registry.get(name, section)
         preference.validate(value)
     gateway_preference_registry.manager().update_db_pref(section, name, value)
+    preference_key = get_preference_key(section, name)
+    _degraded_preferences.discard(preference_key)
 
 
 def get_preference_value_by_preference(preference: object, encrypted: bool = True) -> str:
@@ -74,16 +85,28 @@ def get_preference_value(section: str, name: str, encrypted: bool = True) -> str
         raise ValueError(_("A settings_bound preference can not have a None value"))
 
     preference_name = get_preference_key(section, name)
-    value = gateway_preference_registry.manager().get(preference_name)
 
-    if (preference := gateway_preference_registry.get(name, section)).encrypted:
-        if encrypted:
-            return get_encrypted_string_for_preference(preference)
-        # Note: values can be retrieved from cache instead of the DB.
-        # However, decrypt_string() can identify encrypted values and decrypt them,
-        # returning the non encrypted values unchanged.
-        value = ansible_encryption.decrypt_string(value)
+    try:
+        value = gateway_preference_registry.manager().get(preference_name)
 
+        if (preference := gateway_preference_registry.get(name, section)).encrypted:
+            if encrypted:
+                return get_encrypted_string_for_preference(preference)
+            value = ansible_encryption.decrypt_string(value)
+    except (InvalidToken, SerializationError, ValueError, TypeError):
+        _degraded_preferences.add(preference_name)
+        preference = gateway_preference_registry.get(name, section)
+        logger.critical(
+            "Failed to read preference '%s'. This may indicate a SECRET_KEY mismatch "
+            "or corrupt data. Returning the default value. The preference will remain "
+            "degraded until the issue is resolved. "
+            "Consider running 'gateway-manage rotate_secret_key' to re-encrypt preferences.",
+            preference_name,
+            exc_info=True,
+        )
+        return getattr(preference, 'default', None)
+
+    _degraded_preferences.discard(preference_name)
     return value
 
 

--- a/aap_gateway_api/views/api/v1/preference.py
+++ b/aap_gateway_api/views/api/v1/preference.py
@@ -4,9 +4,11 @@ import logging
 from ansible_base.lib.utils.response import get_relative_url
 from ansible_base.lib.utils.views.permissions import IsSuperuserOrAuditor
 from ansible_base.oauth2_provider.permissions import OAuth2ScopePermission
+from cryptography.fernet import InvalidToken
 from django.utils.translation import gettext_lazy as _
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from dynamic_preferences.exceptions import NotFoundInRegistry
+from dynamic_preferences.serializers import SerializationError
 from rest_framework import status
 from rest_framework.response import Response
 
@@ -172,6 +174,19 @@ class SettingPreferenceView(AnsibleBaseView):
         except Preference.DoesNotExist:
             message = format_err_message(category_slug, preference_name, err_detail="not_found")
             return Response({"detail": message}, status=status.HTTP_404_NOT_FOUND)
+        except (InvalidToken, SerializationError):
+            logger.critical(
+                "Preference '%s' in category '%s' has corrupt data and cannot be decrypted. "
+                "Consider running 'gateway-manage rotate_secret_key' to re-encrypt preferences.",
+                preference_name,
+                category_slug,
+                exc_info=True,
+            )
+            message = _(
+                "Preference '%(preference_name)s' in category '%(category_slug)s' has corrupt or undecryptable data. "
+                "An administrator must resolve this before the value can be read."
+            ) % {"preference_name": preference_name, "category_slug": category_slug}
+            return Response({"detail": message}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
 
         serializer = SettingPreferenceSerializer(preference)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/aap_gateway_api/views/api/v1/status.py
+++ b/aap_gateway_api/views/api/v1/status.py
@@ -19,7 +19,7 @@ from rest_framework.response import Response
 
 from aap_gateway_api.models import Route, ServiceNode
 from aap_gateway_api.serializers.status import ServiceKeysStatusSerializer, StatusSerializer
-from aap_gateway_api.utils.preferences import get_preference_value
+from aap_gateway_api.utils.preferences import get_degraded_preferences, get_preference_value
 from aap_gateway_api.views.api.v1.common import AnsibleBaseView
 
 logger = logging.getLogger('aap.gateway.views.api.v1.status')
@@ -285,6 +285,10 @@ class StatusView(AnsibleBaseView):
             results = executor.map(check_node, processes)
 
         response = create_response(results)
+
+        degraded = get_degraded_preferences()
+        if degraded:
+            response['degraded_preferences'] = sorted(degraded)
 
         if services_format_with_keys:
             new_services = services_to_dict(response['services'])


### PR DESCRIPTION
## Description

- **What is being changed?** Adds layered error handling so that corrupt/undecryptable preferences no longer cause unhandled HTTP 500 errors across the gateway at runtime.
- **Why is this change needed?** [AAP-76853](https://redhat.atlassian.net/browse/AAP-76853) / [PR #146](https://github.com/ansible/jewel/pull/146) ensures `initialize_preferences()` does not crash on startup. However, once the gateway starts degraded, any subsequent request that accesses a corrupt preference hits an unhandled `InvalidToken` or `SerializationError` and returns a 500. Nearly every preference access point is unprotected.
- **How does this change address the issue?** Three layers of defense:
  1. **Central guard in `get_preference_value()`** -- catches `InvalidToken`, `SerializationError`, `ValueError`, `TypeError`, logs critical with remediation guidance, returns the registry default, and tracks the preference in a `_degraded_preferences` set.
  2. **`SettingPreferenceView.get()`** -- catches decryption/deserialization errors from `Preference.objects.get()` (which bypasses `get_preference_value`) and returns 503 with an actionable message.
  3. **Status endpoint** -- includes `degraded_preferences` in the response when any preferences are degraded, giving operators visibility.
  4. **Auto-recovery** -- when a preference is successfully updated via `update_preference_value()`, it is removed from the degraded set.

JIRA: [AAP-88904](https://redhat.atlassian.net/browse/AAP-88904) (linked to [AAP-76853](https://redhat.atlassian.net/browse/AAP-76853))

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites
- A running AAP gateway instance (or local dev environment)

### Steps to Test
1. Register a test preference and corrupt its database value (e.g., replace the stored value with an invalid encrypted string)
2. Call `get_preference_value()` for the corrupted preference -- it should return the default value and log CRITICAL
3. Verify `get_degraded_preferences()` includes the corrupted preference key
4. `GET /api/gateway/v1/settings/<category>/<pref_name>/` for a corrupted preference should return 503 (not 500)
5. `GET /api/gateway/v1/status/` should include `degraded_preferences` when any are degraded
6. Update the preference via `update_preference_value()` -- it should be removed from the degraded set
7. Run unit tests: `pytest aap_gateway_api/tests/preferences/test_preferences.py aap_gateway_api/tests/views/api/v1/preference/test_preferences_view.py aap_gateway_api/tests/views/api/v1/status/test_status.py -v`

### Expected Results
- No 500 errors from corrupt preferences -- degraded preferences return defaults
- Status endpoint reports degraded preferences for operator visibility
- All new and existing tests pass

## Additional Context

### Files Changed
| File | Change |
|------|--------|
| `aap_gateway_api/utils/preferences.py` | Central guard in `get_preference_value()`, `_degraded_preferences` tracking, `get_degraded_preferences()` helper, auto-recovery in `update_preference_value()` |
| `aap_gateway_api/views/api/v1/preference.py` | `SettingPreferenceView.get()` returns 503 on corrupt preference |
| `aap_gateway_api/views/api/v1/status.py` | Status endpoint includes `degraded_preferences` when non-empty |
| `aap_gateway_api/tests/preferences/test_preferences.py` | Unit tests for central guard, degraded tracking, auto-recovery |
| `aap_gateway_api/tests/views/api/v1/preference/test_preferences_view.py` | Tests for 503 response on corrupt preference |
| `aap_gateway_api/tests/views/api/v1/status/test_status.py` | Tests for degraded_preferences in status response |

---
**Note:** This PR was developed with assistance from Claude AI assistant.

[AAP-76853]: https://redhat.atlassian.net/browse/AAP-76853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAP-88904]: https://redhat.atlassian.net/browse/AAP-88904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrupted or unreadable preferences now fall back to their default values instead of failing silently.
  * Individual preference requests return a clear service-unavailable response when data cannot be decrypted or deserialized.
  * Successfully reading or updating a preference clears its degraded status.

* **Improvements**
  * System status now reports preferences requiring attention, helping administrators identify configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->