### PR TITLE
[AAP-89170] Recreate managed roles after transactional perf test flush

### DIFF
--- a/aap_gateway_api/tests/views/api/v1/organization/test_organization_delete_perf.py
+++ b/aap_gateway_api/tests/views/api/v1/organization/test_organization_delete_perf.py
@@ -16,10 +16,15 @@ from aap_gateway_api.models import Organization, Team, User
 
 
 def _create_org_with_teams(name_prefix, num_teams, users_per_team):
-    """Create an org with teams and user role assignments."""
+    """Create an org with teams and user role assignments.
+
+    Use RoleDefinition.objects.managed (get_or_create) rather than .get() by
+    name. TransactionTestCase flush wipes data-migration RoleDefinitions, and
+    create_preload_data skips recreation when post_migrate has no plan.
+    """
     org = Organization.objects.create(name=f"{name_prefix}-org")
-    team_member_rd = RoleDefinition.objects.get(name="Team Member")
-    org_member_rd = RoleDefinition.objects.get(name="Organization Member")
+    team_member_rd = RoleDefinition.objects.managed.team_member
+    org_member_rd = RoleDefinition.objects.managed.org_member
 
     users = []
     for i in range(num_teams):
@@ -44,6 +49,25 @@ def _time_api_delete(client, org):
     elapsed = time.monotonic() - start
     assert response.status_code == 204, f"Delete failed with {response.status_code}"
     return elapsed
+
+
+@pytest.mark.django_db(transaction=True)
+def test_create_org_with_teams_after_managed_roles_missing(local_authenticator):
+    """Setup must work after TransactionTestCase flush wipes managed roles.
+
+    transaction=True tests flush data-migration RoleDefinitions. create_preload_data
+    skips recreation when post_migrate has no plan, which is what flush sends.
+    The helper must recreate Team Member / Organization Member instead of assuming
+    those rows still exist.
+    """
+    RoleDefinition.objects.filter(name__in=["Team Member", "Organization Member"]).delete()
+
+    org, users = _create_org_with_teams("missing-roles", num_teams=1, users_per_team=1)
+
+    assert org.pk
+    assert len(users) == 1
+    assert RoleDefinition.objects.filter(name="Team Member").exists()
+    assert RoleDefinition.objects.filter(name="Organization Member").exists()
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
## Description

Gateway Performance Tests CI fails in `test_org_delete_time_scales_sublinearly` with `RoleDefinition.DoesNotExist` when looking up `Team Member`. This is independent of the change under test (seen on multiple PRs, including #215).

`transaction=True` perf tests flush the database after they run. `create_preload_data` skips recreating managed roles on flush (no `plan` kwarg). The org-delete helper then called `RoleDefinition.objects.get(name="Team Member")`, which fails if an earlier transactional perf test ran on the same xdist worker.

The helper now uses `RoleDefinition.objects.managed` (`get_or_create`), matching the sibling org-delete tests. A regression test deletes those roles first, then rebuilds an org.

Jira: https://issues.redhat.com/browse/AAP-89170

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites
Gateway unit test environment (`tox -e py312` with Postgres).

### Steps to Test
1. Run `aap_gateway_api/tests/views/api/v1/organization/test_organization_delete_perf.py::test_create_org_with_teams_after_managed_roles_missing`.
2. Run `tox -e py312 -- -m perf` (xdist) so transactional xDS cache tests share workers with the org-delete tests.

### Expected Results
- Missing-role setup test recreates `Team Member` / `Organization Member` and passes.
- `test_org_delete_time_scales_sublinearly` passes even after other `transaction=True` perf tests flush the DB.
- Full `-m perf` suite is green.

## Additional Context

### Required Actions
- [ ] Requires documentation updates
- [ ] Requires downstream repository changes
- [ ] Requires infrastructure/deployment changes
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: #XXX


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Organization and team creation now succeeds even when managed role definitions are missing.
  * Missing managed roles are automatically recreated during setup.
  * Added regression coverage to verify both required roles are restored correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->