### PR TITLE
[AAP-89359] Prefer Actions variable for USERNAME_MAPPING and improve ready-to-merge Slack notices

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -470,7 +470,7 @@ jobs:
             '
             ($title | gsub("&"; "&amp;") | gsub("<"; "&lt;") | gsub(">"; "&gt;")) as $safe_title
             | "Ready to merge: <" + $url + "|" + $safe_title + ">"
-              + "\nAssignees: " + $assignees
+              + "\nAssignee: " + $assignees
               + (if $reviewers == "" then "" else "\nReviewers: " + $reviewers end)
             ')
           PAYLOAD=$(jq -n --arg channel "$SLACK_CHANNEL" --arg text "$MESSAGE" \

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -418,15 +418,15 @@ jobs:
                       break;
                     }
                   }
-                  if (!mention) {
-                    mention = pr.user.login;
-                  }
                 }
 
                 core.setOutput('notify', 'true');
                 core.setOutput('slack_mention', mention);
                 core.setOutput('pr_url', pr.html_url);
-                const safeTitle = pr.title.replace(/[^\x20-\x7E]/g, '').slice(0, 200);
+                core.setOutput('pr_repo', `${owner}/${repo}`);
+                core.setOutput('pr_number', String(pr.number));
+                core.setOutput('pr_author', pr.user.login);
+                const safeTitle = pr.title.replace(/[^\x20-\x7E]/g, '').replace(/\|/g, '/').slice(0, 200);
                 core.setOutput('pr_title', safeTitle);
               }
             } else {
@@ -442,13 +442,28 @@ jobs:
           SLACK_MENTION: ${{ steps.labeler.outputs.slack_mention }}
           PR_URL: ${{ steps.labeler.outputs.pr_url }}
           PR_TITLE: ${{ steps.labeler.outputs.pr_title }}
+          PR_REPO: ${{ steps.labeler.outputs.pr_repo }}
+          PR_NUMBER: ${{ steps.labeler.outputs.pr_number }}
+          PR_AUTHOR: ${{ steps.labeler.outputs.pr_author }}
         run: |
           if [ -z "$SLACK_BOT_TOKEN" ] || [ -z "$SLACK_CHANNEL" ]; then
             echo "Slack secrets not configured — skipping notification"
             exit 0
           fi
-          SAFE_TITLE=$(echo "$PR_TITLE" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')
-          MESSAGE="${SLACK_MENTION} your PR is ready to merge: <${PR_URL}|${SAFE_TITLE}>"
+          MESSAGE=$(jq -n -r \
+            --arg mention "$SLACK_MENTION" \
+            --arg repo "$PR_REPO" \
+            --arg number "$PR_NUMBER" \
+            --arg author "$PR_AUTHOR" \
+            --arg url "$PR_URL" \
+            --arg title "$PR_TITLE" \
+            '
+            ($title | gsub("&"; "&amp;") | gsub("<"; "&lt;") | gsub(">"; "&gt;")) as $safe_title
+            | (if $mention == "" then "" else $mention + " " end)
+              + $repo + "#" + $number
+              + " by " + $author
+              + " is ready to merge: <" + $url + "|" + $safe_title + ">"
+            ')
           PAYLOAD=$(jq -n --arg channel "$SLACK_CHANNEL" --arg text "$MESSAGE" \
             '{channel: $channel, text: $text, unfurl_links: false}')
           curl -sf -X POST https://slack.com/api/chat.postMessage \

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -38,7 +38,8 @@ jobs:
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         id: labeler
         env:
-          USERNAME_MAPPING: ${{ vars.USERNAME_MAPPING || secrets.USERNAME_MAPPING }}
+          USERNAME_MAPPING: ${{ vars.USERNAME_MAPPING }}
+          USERNAME_MAPPING_SECRET: ${{ secrets.USERNAME_MAPPING }}
           ORG_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           script: |
@@ -231,15 +232,26 @@ jobs:
             }
 
             // --- Parse username mapping (repo variable, secret fallback) ---
-            let usernameMapping = {};
-            const mappingRaw = process.env.USERNAME_MAPPING;
-            if (mappingRaw) {
+            const parseUsernameMapping = (raw) => {
+              if (!raw) {
+                return null;
+              }
               try {
-                usernameMapping = JSON.parse(mappingRaw);
-                core.info(`Username mapping loaded (${Object.keys(usernameMapping).length} entries)`);
+                const parsed = JSON.parse(raw);
+                if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+                  return parsed;
+                }
+                core.warning('USERNAME_MAPPING must be a JSON object');
               } catch (e) {
                 core.warning(`Failed to parse USERNAME_MAPPING: ${e.message}`);
               }
+              return null;
+            };
+            const usernameMapping = parseUsernameMapping(process.env.USERNAME_MAPPING)
+              || parseUsernameMapping(process.env.USERNAME_MAPPING_SECRET)
+              || {};
+            if (Object.keys(usernameMapping).length > 0) {
+              core.info(`Username mapping loaded (${Object.keys(usernameMapping).length} entries)`);
             }
 
             // --- Auto-assign author ---

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         id: labeler
         env:
-          USERNAME_MAPPING: ${{ secrets.USERNAME_MAPPING }}
+          USERNAME_MAPPING: ${{ vars.USERNAME_MAPPING || secrets.USERNAME_MAPPING }}
           ORG_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           script: |
@@ -230,7 +230,7 @@ jobs:
               }
             }
 
-            // --- Parse username mapping from secret (if available) ---
+            // --- Parse username mapping (repo variable, secret fallback) ---
             let usernameMapping = {};
             const mappingRaw = process.env.USERNAME_MAPPING;
             if (mappingRaw) {
@@ -238,7 +238,7 @@ jobs:
                 usernameMapping = JSON.parse(mappingRaw);
                 core.info(`Username mapping loaded (${Object.keys(usernameMapping).length} entries)`);
               } catch (e) {
-                core.warning(`Failed to parse USERNAME_MAPPING secret: ${e.message}`);
+                core.warning(`Failed to parse USERNAME_MAPPING: ${e.message}`);
               }
             }
 
@@ -299,7 +299,7 @@ jobs:
               );
               if (normalizedMapping[pr.user.login.toLowerCase()]) {
                 isInternal = true;
-                core.info(`${pr.user.login} found in USERNAME_MAPPING secret`);
+                core.info(`${pr.user.login} found in USERNAME_MAPPING`);
               }
             }
 

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -416,28 +416,30 @@ jobs:
                 const normalizedMappingForSlack = Object.fromEntries(
                   Object.entries(usernameMapping).map(([k, v]) => [k.toLowerCase(), v])
                 );
-                let mention = '';
-                const authorSlackId = normalizedMappingForSlack[pr.user.login.toLowerCase()];
-                if (authorSlackId) {
-                  mention = `<@${authorSlackId}>`;
-                } else {
-                  const reviewers = pr.requested_reviewers || [];
-                  for (const reviewer of reviewers) {
-                    const reviewerSlackId = normalizedMappingForSlack[reviewer.login.toLowerCase()];
-                    if (reviewerSlackId) {
-                      mention = `<@${reviewerSlackId}>`;
-                      core.info(`Author not in USERNAME_MAPPING — mentioning reviewer ${reviewer.login}`);
-                      break;
-                    }
+                const slackPerson = (login) => {
+                  const id = normalizedMappingForSlack[login.toLowerCase()];
+                  return id ? `<@${id}>` : login;
+                };
+                const isMapped = (login) => Boolean(
+                  normalizedMappingForSlack[login.toLowerCase()]
+                );
+                const assigneeLogins = (pr.assignees && pr.assignees.length)
+                  ? pr.assignees.map((a) => a.login)
+                  : [pr.user.login];
+                const assigneesText = assigneeLogins.map(slackPerson).join(', ');
+                let reviewersText = '';
+                if (!assigneeLogins.some(isMapped)) {
+                  const reviewerLogins = (pr.requested_reviewers || []).map((r) => r.login);
+                  if (reviewerLogins.length) {
+                    reviewersText = reviewerLogins.map(slackPerson).join(', ');
+                    core.info('No mapped assignee — including Reviewers in Slack notice');
                   }
                 }
 
                 core.setOutput('notify', 'true');
-                core.setOutput('slack_mention', mention);
                 core.setOutput('pr_url', pr.html_url);
-                core.setOutput('pr_repo', `${owner}/${repo}`);
-                core.setOutput('pr_number', String(pr.number));
-                core.setOutput('pr_author', pr.user.login);
+                core.setOutput('pr_assignees', assigneesText);
+                core.setOutput('pr_reviewers', reviewersText);
                 const safeTitle = pr.title.replace(/[^\x20-\x7E]/g, '').replace(/\|/g, '/').slice(0, 200);
                 core.setOutput('pr_title', safeTitle);
               }
@@ -451,30 +453,25 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
-          SLACK_MENTION: ${{ steps.labeler.outputs.slack_mention }}
           PR_URL: ${{ steps.labeler.outputs.pr_url }}
           PR_TITLE: ${{ steps.labeler.outputs.pr_title }}
-          PR_REPO: ${{ steps.labeler.outputs.pr_repo }}
-          PR_NUMBER: ${{ steps.labeler.outputs.pr_number }}
-          PR_AUTHOR: ${{ steps.labeler.outputs.pr_author }}
+          PR_ASSIGNEES: ${{ steps.labeler.outputs.pr_assignees }}
+          PR_REVIEWERS: ${{ steps.labeler.outputs.pr_reviewers }}
         run: |
           if [ -z "$SLACK_BOT_TOKEN" ] || [ -z "$SLACK_CHANNEL" ]; then
             echo "Slack secrets not configured — skipping notification"
             exit 0
           fi
           MESSAGE=$(jq -n -r \
-            --arg mention "$SLACK_MENTION" \
-            --arg repo "$PR_REPO" \
-            --arg number "$PR_NUMBER" \
-            --arg author "$PR_AUTHOR" \
+            --arg assignees "$PR_ASSIGNEES" \
+            --arg reviewers "$PR_REVIEWERS" \
             --arg url "$PR_URL" \
             --arg title "$PR_TITLE" \
             '
             ($title | gsub("&"; "&amp;") | gsub("<"; "&lt;") | gsub(">"; "&gt;")) as $safe_title
-            | (if $mention == "" then "" else $mention + " " end)
-              + $repo + "#" + $number
-              + " by " + $author
-              + " is ready to merge: <" + $url + "|" + $safe_title + ">"
+            | "Ready to merge: <" + $url + "|" + $safe_title + ">"
+              + "\nAssignees: " + $assignees
+              + (if $reviewers == "" then "" else "\nReviewers: " + $reviewers end)
             ')
           PAYLOAD=$(jq -n --arg channel "$SLACK_CHANNEL" --arg text "$MESSAGE" \
             '{channel: $channel, text: $text, unfurl_links: false}')


### PR DESCRIPTION
## Description
AAP-89359

- What is being changed?
  - PR Labels reads `USERNAME_MAPPING` from a GitHub Actions variable first, with the existing secret as fallback.
  - Invalid variable values (`null`, arrays, non-objects, malformed JSON) are rejected so they cannot wipe a valid secret mapping or crash the job.
  - Ready-to-merge Slack notices use GitHub sidebar wording (`Assignee`, `Reviewers`), a title link, and no repo or PR number.
- Why is this change needed?
  - The GitHub-to-Slack user map is configuration, not a credential, so it belongs in a variable (readable and easier to update).
  - The old Slack text ("your PR is ready to merge") was wrong when the ping went to a reviewer or when nobody was mapped.
- How does this change address the issue?
  - The workflow loads `vars.USERNAME_MAPPING` when it is a JSON object, otherwise `secrets.USERNAME_MAPPING`.
  - Slack text is `Ready to merge: <url|title>` plus `Assignee:`. `Reviewers:` is added only when no assignee is in the mapping.

Example Slack text:

Mapped assignee:

```
Ready to merge: <url|title>
Assignee: <@SlackId>
```

Unmapped assignee (requested reviewers only then):

```
Ready to merge: <url|title>
Assignee: community-user
Reviewers: <@SlackId>
```

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [x] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites
- Repo admin access to create Actions variables
- Existing `USERNAME_MAPPING` secret JSON (GitHub login → Slack user ID)

### Steps to Test
1. Create repository variable `USERNAME_MAPPING` with the same JSON currently stored in the secret (Settings → Secrets and variables → Actions → Variables).
2. Merge this PR. `pull_request_target` runs the workflow from `devel`, so the new Slack wording only appears after merge.
3. Confirm the workflow log shows `Username mapping loaded (N entries)`.
4. When a PR first becomes ready to merge, confirm `#aap-gateway` gets `Ready to merge:` with a title link and `Assignee:`. `Reviewers:` should appear only if no assignee is mapped.
5. After a successful run using the variable, delete the `USERNAME_MAPPING` secret.

TEST samples of both Slack layouts were posted to `#aap-gateway` before merge.

### Expected Results
- Community labeling and ready-to-merge Slack mentions keep working.
- If the variable is missing or not a JSON object, the secret fallback still loads the map.
- Slack text does not include repo or PR number and does not say "your PR".

## Additional Context
### Required Actions
- [ ] Requires documentation updates
- [ ] Requires downstream repository changes
- [x] Requires infrastructure/deployment changes
  Create `USERNAME_MAPPING` as a repository Actions variable, then remove the secret after a successful run.
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: #XXX
