### PR TITLE
[AAP-90726][AAP-90732] Note sqlparse>=0.6.0 also fixes CVE-2026-71491 and CVE-2026-54284

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -13,7 +13,7 @@ protobuf>=5.29.5  # CVE-2025-4565
 psycopg
 pyjwt>=2.13.0  # AAP-78775
 requests
-sqlparse>=0.6.0  # CVE-2026-59893 / CVE-2026-71491
+sqlparse>=0.6.0  # CVE-2026-59893 / CVE-2026-71491 / CVE-2026-54284
 uwsgi
 xds-protos>=1.58
 PyYAML

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -13,7 +13,7 @@ protobuf>=5.29.5  # CVE-2025-4565
 psycopg
 pyjwt>=2.13.0  # AAP-78775
 requests
-sqlparse>=0.6.0  # CVE-2026-59893
+sqlparse>=0.6.0  # CVE-2026-59893 / CVE-2026-71491
 uwsgi
 xds-protos>=1.58
 PyYAML


### PR DESCRIPTION
## Description
- **What is being changed?** Updating the comment on the `sqlparse>=0.6.0` pin in `requirements/requirements.in` to reference two additional CVEs: CVE-2026-71491 and CVE-2026-54284.
- **Why is this change needed?**
  - CVE-2026-71491: denial of service via quadratic CPU consumption in comment grouping.
  - CVE-2026-54284: denial of service via quadratic CPU consumption in SQL parsing (nested `TokenList` flattening in `group_parenthesis`/`group_case`).
  - Both are fixed upstream in `sqlparse` 0.6.0.
- **How does this change address the issue?** The `sqlparse>=0.6.0` minimum version pin added previously (for CVE-2026-59893) already satisfies the fixed version for both additional CVEs, so no version bump or lockfile regeneration is required. This change only documents that the existing pin covers all three CVEs.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [x] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites
None.

### Steps to Test
1. Run `requirements/updater.sh check` to confirm `requirements.txt` still satisfies all constraints in `requirements.in`.

### Expected Results
`requirements.txt satisfies all constraints.` is printed, confirming no lockfile regeneration is needed since the resolved `sqlparse` version (0.6.0) is unchanged.

## Additional Context
No functional or dependency version changes; comment-only update for CVE tracking clarity across AAP-90726 and AAP-90732.