### PR TITLE
[AAP-64014] Stop logging expected API root lookup misses as ERROR

### DIFF
--- a/aap_gateway_api/tests/views/api/v1/test_gateway_v1.py
+++ b/aap_gateway_api/tests/views/api/v1/test_gateway_v1.py
@@ -1,4 +1,11 @@
+import logging
+
+import pytest
 from ansible_base.lib.utils.response import get_relative_url
+
+from aap_gateway_api.views.api.v1 import V1RootView
+
+MISSING_REVERSE_LOOKUP_MSG = "had neither a -list nor -view reverse lookup method, ignoring"
 
 
 def test_gateway_v1_view(unauthenticated_api_client):
@@ -10,3 +17,41 @@ def test_gateway_v1_view(unauthenticated_api_client):
     keys = ("me", "ping")
     for key in keys:
         assert key in response.data.keys()
+
+
+@pytest.mark.parametrize(
+    "endpoint,expected",
+    [
+        ("role_user_access", "role_user_access"),
+        ("role_team_access", "role_team_access"),
+        ("users", "user"),
+        ("settings", "setting"),
+        ("status", "status"),
+        ("ping", "ping"),
+    ],
+)
+def test_singularize_endpoint_does_not_truncate_access_suffix(endpoint, expected):
+    assert V1RootView._singularize_endpoint(endpoint) == expected
+
+
+def test_missing_reverse_lookup_logs_debug_not_error_for_access_endpoints(caplog):
+    view = V1RootView()
+    with caplog.at_level(logging.DEBUG, logger="aap.gateway.views"):
+        view._find_endpoints_reverse_lookup_names(["role_user_access", "role_team_access"])
+
+    error_messages = [record.message for record in caplog.records if record.levelno >= logging.ERROR]
+    assert not any(MISSING_REVERSE_LOOKUP_MSG in message for message in error_messages)
+
+    debug_messages = [record.message for record in caplog.records if record.levelno == logging.DEBUG]
+    assert any(f"role_user_access {MISSING_REVERSE_LOOKUP_MSG}" in message for message in debug_messages)
+    assert any(f"role_team_access {MISSING_REVERSE_LOOKUP_MSG}" in message for message in debug_messages)
+    assert not any("role_user_acce " in message or "role_team_acce " in message for message in debug_messages)
+
+
+def test_gateway_v1_view_does_not_log_missing_reverse_lookups_as_error(unauthenticated_api_client, caplog):
+    url = get_relative_url("api_gateway_v1_root_view")
+    with caplog.at_level(logging.ERROR, logger="aap.gateway.views"):
+        response = unauthenticated_api_client.get(url)
+
+    assert response.status_code == 200
+    assert not any(MISSING_REVERSE_LOOKUP_MSG in record.message for record in caplog.records)

--- a/aap_gateway_api/views/api/v1/__init__.py
+++ b/aap_gateway_api/views/api/v1/__init__.py
@@ -28,10 +28,23 @@ class V1RootView(AnsibleBaseView):
     name = _('v1')
     versioning_class = None
 
+    @staticmethod
+    def _singularize_endpoint(endpoint):
+        """Return a singular form for reverse-lookup name generation.
+
+        ``str.rstrip('s')`` strips every trailing 's', which truncates names
+        that end in 'ss' such as role_user_access -> role_user_acce.
+        """
+        if endpoint == 'status':
+            return endpoint
+        if endpoint.endswith('s') and not endpoint.endswith('ss'):
+            return endpoint[:-1]
+        return endpoint
+
     def _find_endpoints_reverse_lookup_names(self, endpoints):
         """
         Attempts to retrieve all possible endpoint names for reverse URL lookup.
-        If no matching endpoint name is found, logs an error message.
+        If no matching endpoint name is found, logs a debug message.
         Returns:
         - data(dict): A mapping of endpoint names to their corresponding URL paths
         """
@@ -41,9 +54,7 @@ class V1RootView(AnsibleBaseView):
             if endpoint in ignore_endpoints:
                 continue
 
-            singular_endpoint = endpoint.rstrip('s')
-            if endpoint == 'status':
-                singular_endpoint = endpoint
+            singular_endpoint = self._singularize_endpoint(endpoint)
 
             # Now, we try to form all possible view name patterns
             no_underscore = singular_endpoint.replace('_', '')
@@ -61,7 +72,7 @@ class V1RootView(AnsibleBaseView):
                     pass
 
             if endpoint not in data:
-                logger.error(f'{singular_endpoint} had neither a -list nor -view reverse lookup method, ignoring')
+                logger.debug(f'{singular_endpoint} had neither a -list nor -view reverse lookup method, ignoring')
 
         return data
 


### PR DESCRIPTION

## Description

Gateway API root endpoint discovery was logging expected reverse lookup misses
at ERROR level during normal operation.

The existing endpoint singularization logic used `rstrip('s')`, which
incorrectly truncated endpoint names ending in `ss`. For example:

- `role_user_access` became `role_user_acce`
- `role_team_access` became `role_team_acce`

This change:

- updates the endpoint singularization logic so endpoint names ending in `ss`
  are preserved
- continues to singularize normal plural endpoints such as `users` to `user`
- preserves the existing special handling for `status`
- changes expected missing reverse lookup messages from ERROR to DEBUG
- adds regression tests for endpoint singularization and logging behavior

This addresses AAP-64014 by preventing false ERROR messages from being emitted
during normal Gateway API root endpoint discovery.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites

- Development environment capable of running the repository's Python 3.12 tox tests
- PostgreSQL available as required by the Gateway test suite

### Steps to Test

1. Check out this PR branch.

2. Run the Gateway v1 API tests:

   ```bash
   GATEWAY_TEST_DIRS=aap_gateway_api/tests/views/api/v1/test_gateway_v1.py tox -e py312

3. Verify that the endpoint singularization tests preserve endpoint names ending
in ss and that missing reverse lookup messages are not emitted at ERROR
level.


Expected Results

The targeted test suite should pass successfully.

Local test result:
~~~
9 passed, 44 warnings
py312: OK
~~~

The missing reverse lookup messages for the affected endpoints should appear at DEBUG level using the complete endpoint names:
~~~
role_user_access had neither a -list nor -view reverse lookup method, ignoring
role_team_access had neither a -list nor -view reverse lookup method, ignoring
~~~

The incorrect truncated endpoint names such as **role_user_acce** and
**role_team_acce** should no longer be generated.

Additional Context

Jira: AAP-64014

The issue was caused by using **rstrip('s')** while deriving singular endpoint
names, which incorrectly truncated endpoints such as **role_user_access** and
**role_team_access**.

This fix preserves endpoint names ending in **ss**, changes the expected missing
reverse lookup message from ERROR to DEBUG, and adds regression tests for the
affected behavior.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected endpoint name singularization for names ending in “status” or “ss”.
  * Reduced reverse-lookup messages for missing matches to debug-level logging, avoiding unnecessary errors.
  * Ensured gateway root requests complete successfully without error-level messages.

* **Tests**
  * Added regression coverage for endpoint naming and reverse-lookup logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Requires: https://github.com/ansible/ansible.platform/pull/241