### PR TITLE
NO_JIRA Prefix Renovate Tekton commits with NO_JIRA

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   "tekton": {
     "enabled": true,
     "automerge": true,
+    "commitMessagePrefix": "NO_JIRA:",
     "schedule": ["* 9-17 * * 1-5"],
     // Disable post upgrade tasks to avoid pipeline-migration-tool failures (not applicable to tekton pipeline bundles)
     "postUpgradeTasks": {


### PR DESCRIPTION
## Description

- What is being changed? Renovate's Tekton manager now prefixes commit messages with `NO_JIRA:`.
- Why is this change needed? Automated pipeline-bundle update commits do not have a JIRA key, so they fail commit-message checks.
- How does this change address the issue? Setting `commitMessagePrefix` to `NO_JIRA:` lets those Renovate PRs pass JIRA-key validation.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [x] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites
None. This is a Renovate config-only change.

### Steps to Test
1. Confirm `renovate.json` includes `"commitMessagePrefix": "NO_JIRA:"` under the `tekton` manager.
2. After merge, wait for the next Renovate Tekton update PR.
3. Verify the commit message on that PR starts with `NO_JIRA:` and that JIRA-key commit checks pass.

### Expected Results
Renovate Tekton PRs use `NO_JIRA:`-prefixed commits and are not blocked by JIRA commit-message validation.

## Additional Context

### Required Actions
- [ ] Requires documentation updates
- [ ] Requires downstream repository changes
- [ ] Requires infrastructure/deployment changes
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: #XXX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated dependency update commit messages to use the `NO_JIRA:` prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->