### PR TITLE
fix(proxy): redirect API paths to trailing slashes

### DIFF
--- a/aap_gateway_api/models/http_port.py
+++ b/aap_gateway_api/models/http_port.py
@@ -9,7 +9,14 @@ from django.db import models
 from django.utils.translation import gettext as _
 
 from aap_gateway_api.common.envoy import EXT_AUTH_FILTER, EXT_AUTH_PER_ROUTE
-from aap_gateway_api.utils.xds_configs import external_auth_filter, http_router_filter, network_manager_filter, path_rewrite_filter, transport_socket
+from aap_gateway_api.utils.xds_configs import (
+    external_auth_filter,
+    http_router_filter,
+    network_manager_filter,
+    path_rewrite_filter,
+    redirect_route,
+    transport_socket,
+)
 
 logger = logging.getLogger("aap_gateway_api.models.http_port")
 
@@ -73,6 +80,8 @@ class HTTPPort(UniqueNamedCommonModel, AuditableModel):
             "typed_per_filter_config": {EXT_AUTH_FILTER: {"@type": EXT_AUTH_PER_ROUTE, "disabled": True}},
         }
         routes.append(up_route)
+        if self.is_api_port:
+            routes.append(redirect_route("/api", "/api/"))
         for route in sorted(self.routes.all(), key=lambda r: r.order):
             routes.extend(route.get_xds_route_config(**kwargs))
 

--- a/aap_gateway_api/models/route.py
+++ b/aap_gateway_api/models/route.py
@@ -11,6 +11,7 @@ from aap_gateway_api.models.http_port import HTTPPort
 from aap_gateway_api.models.service_cluster import ServiceCluster
 from aap_gateway_api.models.service_type import DefaultServiceType
 from aap_gateway_api.utils.preferences import get_preference_value
+from aap_gateway_api.utils.xds_configs import redirect_route
 
 API_PREFIX = "/api/"
 TYPE_KEY = "@type"
@@ -264,7 +265,10 @@ class Route(UniqueNamedCommonModel, AuditableModel):
         if not self.gateway_path or not self.service_path or not self.envoy_cluster_name:
             return []
 
-        returned_routes = self.get_xds_login_logout_routes(gateway_cluster_name=gateway_cluster_name)
+        returned_routes = []
+        if self.gateway_path.startswith(API_PREFIX) and self.gateway_path.endswith("/"):
+            returned_routes.append(redirect_route(self.gateway_path.rstrip("/"), self.gateway_path))
+        returned_routes.extend(self.get_xds_login_logout_routes(gateway_cluster_name=gateway_cluster_name))
 
         timeout = self.get_effective_timeout_seconds()
         idle_timeout = self.get_effective_idle_timeout_seconds()

--- a/aap_gateway_api/tests/models/test_route.py
+++ b/aap_gateway_api/tests/models/test_route.py
@@ -163,9 +163,9 @@ class TestRoute:
             service_cluster=service_cluster_eda,
         )
         routes = route.get_xds_route_config()
-        assert len(routes) == 1
+        assert len(routes) == 2
 
-        ext_authz_config = routes[0]["typed_per_filter_config"]["envoy.filters.http.ext_authz"]
+        ext_authz_config = routes[-1]["typed_per_filter_config"]["envoy.filters.http.ext_authz"]
         assert 'disabled' not in ext_authz_config, "EDA event stream routes must NOT disable ext_auth"
         assert ext_authz_config["check_settings"]["context_extensions"]["auth_type"] == AUTH_TYPE_NONE
         assert ext_authz_config["check_settings"]["context_extensions"]["service_type"] == "eda"
@@ -229,10 +229,10 @@ class TestRoute:
     @pytest.mark.parametrize(
         "service,expected_route_len",
         [
-            ('controller', 3),
-            ('eda', 3),
-            ('hub', 3),
-            ('gateway', 1),
+            ('controller', 4),
+            ('eda', 4),
+            ('hub', 4),
+            ('gateway', 2),
         ],
     )
     @pytest.mark.django_db
@@ -493,9 +493,9 @@ class TestRoute:
             )
 
             routes = route.get_xds_route_config()
-            assert len(routes) == 1
-            assert routes[0]["route"]["timeout"] == "30s"
-            assert routes[0]["route"]["idle_timeout"] == "15s"
+            assert len(routes) == 2
+            assert routes[-1]["route"]["timeout"] == "30s"
+            assert routes[-1]["route"]["idle_timeout"] == "15s"
 
     @pytest.mark.django_db
     def test_xds_route_config_enable_mtls(self, service_cluster_eda):

--- a/aap_gateway_api/tests/views/api/envoy/test_xds.py
+++ b/aap_gateway_api/tests/views/api/envoy/test_xds.py
@@ -33,6 +33,47 @@ def test_xds_listener_discover_service_routes(unauthenticated_api_client, full_s
         assert route.envoy_cluster_name in listener_routes[0]['route']['cluster']
 
 
+def test_xds_redirects_api_root_and_service_prefixes(
+    unauthenticated_api_client,
+    service_api_route_gateway,
+    service_api_route_controller,
+):
+    response = unauthenticated_api_client.post(reverse("lds"), data={})
+    assert response.status_code == 200
+
+    routes = response.data["resources"][0]["filterChains"][0]["filters"][0]["typedConfig"]["routeConfig"]["virtualHosts"][0]["routes"]
+    redirects = {route["match"]["path"]: route for route in routes if "redirect" in route}
+
+    assert redirects["/api"]["redirect"] == {"pathRedirect": "/api/"}
+    controller_path = service_api_route_controller.gateway_path.rstrip("/")
+    gateway_path = service_api_route_gateway.gateway_path
+    assert redirects[controller_path]["redirect"] == {"pathRedirect": service_api_route_controller.gateway_path}
+    for redirect in (redirects["/api"], redirects[controller_path]):
+        assert redirect["typedPerFilterConfig"]["envoy.filters.http.ext_authz"]["disabled"] is True
+    gateway_route_index = next(i for i, route in enumerate(routes) if route["match"].get("prefix") == gateway_path)
+    assert routes.index(redirects["/api"]) < gateway_route_index
+
+
+@pytest.mark.parametrize("case", ["non_api_port", "non_api_prefix", "api_path_without_trailing_slash"])
+def test_xds_redirects_are_limited_to_api_boundaries(case, http_port_factory, service_cluster_eda, randname):
+    non_api_port = http_port_factory()
+    if case == "non_api_port":
+        routes = non_api_port.get_xds_listener_config()["filter_chains"][0]["filters"][0]["typed_config"]["route_config"]["virtual_hosts"][0]["routes"]
+        assert not any(route.get("match", {}).get("path") == "/api" for route in routes)
+        return
+
+    gateway_path = "/webhooks/" if case == "non_api_prefix" else "/api/my-service"
+    route = AdditionalRoute(
+        gateway_path=gateway_path,
+        service_path="/",
+        envoy_cluster_name=randname("envoy cluster"),
+        service_cluster=service_cluster_eda,
+    )
+    routes = route.get_xds_route_config()
+
+    assert not any("redirect" in route for route in routes)
+
+
 @pytest.mark.parametrize("outlier_detection_enabled", [True, False])
 def test_xds_cluster_discover_service_outlier_detection(outlier_detection_enabled, admin_api_client, full_service_hierarchy_controller):
     url = reverse("service_cluster-detail", kwargs={"pk": full_service_hierarchy_controller.service_cluster.pk})
@@ -333,10 +374,14 @@ def get_lds_routes(admin_api_client):
     assert response.status_code == 200
     filter = response.data['resources'][0]["filterChains"][0]["filters"][0]
     for route in filter["typedConfig"]["routeConfig"]["virtualHosts"][0]["routes"]:
-        if route["match"]["prefix"] == "/up":
+        match = route.get("match", {})
+        if "prefix" not in match or "cluster" not in route.get("route", {}):
+            # Ignore exact-path redirects and other non-cluster routes.
+            continue
+        if match["prefix"] == "/up":
             # Avoid envoy self-hosted /up route
             continue
-        routes[route["match"]["prefix"]] = route["route"]["cluster"]
+        routes[match["prefix"]] = route["route"]["cluster"]
     return routes
 
 

--- a/aap_gateway_api/utils/xds_configs.py
+++ b/aap_gateway_api/utils/xds_configs.py
@@ -2,6 +2,8 @@ from django.conf import settings
 
 from aap_gateway_api.common.envoy import (
     DOWNSTREAM_TLS_CONTEXT,
+    EXT_AUTH_FILTER,
+    EXT_AUTH_PER_ROUTE,
     EXT_AUTHZ_FILTER,
     HTTP_CONNECTION_MANAGER,
     HTTP_ROUTER,
@@ -46,6 +48,14 @@ def external_auth_filter():
 
 def http_router_filter():
     return {"name": "envoy.filters.http.router", "typed_config": {"@type": HTTP_ROUTER}}
+
+
+def redirect_route(path, redirect_path):
+    return {
+        "match": {"path": path},
+        "redirect": {"path_redirect": redirect_path, "response_code": "MOVED_PERMANENTLY"},
+        "typed_per_filter_config": {EXT_AUTH_FILTER: {"@type": EXT_AUTH_PER_ROUTE, "disabled": True}},
+    }
 
 
 def network_manager_filter(http_filters=[], routes=[]):


### PR DESCRIPTION
## Description

This change updates the gateway’s xDS route generation to redirect API requests that do not include the required trailing slash. Requests to /api are permanently redirected
to /api/, while API service prefixes such as /api/controller are redirected to their canonical slash-terminated paths.

Redirect routes are generated only for API ports and API service paths. Because these routes do not forward requests to downstream services, external authentication is
disabled for them. Non-API ports, non-API prefixes, and API paths that are not configured with a trailing slash are unaffected.

The change also adds xDS test coverage for redirect behavior, route ordering, authentication settings, and API boundary conditions. These tests verify that redirects are
generated only where appropriate and appear before the corresponding service routes.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites

- Python 3.12 and the project development dependencies
- A working tox environment

### Steps to Test

1. Run the focused model and xDS tests:
  ```bash
    GATEWAY_TEST_DIRS="" tox -e py312 -- \
      aap_gateway_api/tests/models/test_route.py \
      aap_gateway_api/tests/views/api/envoy/test_xds.py -v
  ```
2. Run the full test suite:
  ```bash
    tox -e py312
  ```
3. Inspect the generated xDS route configuration for an API listener and verify the redirect routes.

### Expected Results

- /api produces a permanent redirect to /api/.
- API service prefixes without trailing slashes produce permanent redirects to their slash-terminated paths.
- Redirect routes have external authentication disabled.
- Redirects are not generated for non-API ports, non-API prefixes, or API paths that do not end in a trailing slash.
- Redirect routes appear before the corresponding service routes.
- All focused and full test suites pass.

### Additional Context

N/A

### Required Actions

- [ ] Requires documentation updates
- [ ] Requires downstream repository changes
- [ ] Requires infrastructure/deployment changes
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: #XXX

### Screenshots/Logs

Not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added permanent redirects from `/api` to `/api/`.
  - Added redirects for API gateway paths missing their trailing slash.
  - Redirects are limited to API boundaries and do not affect non-API routes.

- **Bug Fixes**
  - Improved API route handling by ensuring requests use the expected trailing-slash format.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->