### PR TITLE
AAP-91661 | fix: feature flag test still uses database

### DIFF
--- a/aap_gateway_api/tests/feature_flags/test_feature_flag_api.py
+++ b/aap_gateway_api/tests/feature_flags/test_feature_flag_api.py
@@ -247,14 +247,12 @@ def test_feature_flag_detail_and_metadata(admin_api_client):
     assert isinstance(flag['labels'], list), "labels should be array per test plan"
 
 
-def test_feature_flags_detail_patch_forbidden(admin_api_client, runtime_feature_flags_disabled):
+def test_feature_flags_detail_patch_forbidden(admin_api_client, runtime_feature_flags_disabled, runtime_feature_flag):
     """
     Test that that a 403 is returned if RUNTIME_FEATURE_FLAGS is unset or False
     """
-    created_flag = AAPFlag.objects.filter(value='False', toggle_type='run-time').first()
-    assert created_flag is not None, "At least one run-time AAPFlag with value='False' must exist"
-    feature_flag = created_flag.name
-    url = get_relative_url("aap_flag-detail", kwargs={'pk': created_flag.pk})
+    feature_flag = runtime_feature_flag.name
+    url = get_relative_url("aap_flag-detail", kwargs={'pk': runtime_feature_flag.pk})
     response = admin_api_client.get(url)
     assert response.status_code == status.HTTP_200_OK
     assert response.data['name'] == feature_flag


### PR DESCRIPTION
## Description

<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?

Replace test's use of the database to get a feature flag changed to use a temporarily-created fixture-based feature flag

- Why is this change needed?

One test in the `test_feature_flag_api.py` file still used the database + a real feature flag, and since we removed the feature flag it was supposed to use, and no other feature flag has the same type + value, it fails

- How does this change address the issue?

By using the temporary fixture-based feature flag, we never risk this test breaking due to missing flags in different databases

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [X] I have performed a self-review of my code
- [X] I have added relevant comments to complex code sections
- [X] I have updated documentation where needed
- [X] I have considered the security impact of these changes
- [X] I have considered performance implications
- [X] I have thought about error handling and edge cases
- [X] I have tested the changes in my local environment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated feature flag API test setup to use a dedicated runtime feature flag fixture.
  * Removed reliance on a database lookup and an explicit flag-existence assertion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->