### PR TITLE
[AAP-92202] Fix: do not cache empty xDS CDS/LDS responses during bootstrap

### DIFF
--- a/aap_gateway_api/tests/views/api/envoy/test_rest_control_plane.py
+++ b/aap_gateway_api/tests/views/api/envoy/test_rest_control_plane.py
@@ -102,8 +102,10 @@ def test_cds_bootstrap_recovery_path(unauthenticated_api_client, full_service_hi
     """CDS bootstrap → recovery: empty initially, then populated after resources created."""
     from django.core.cache import cache
 
-    # Clear all resources and cache to simulate bootstrap
-    from aap_gateway_api.models import Route
+    from aap_gateway_api.models import HTTPPort, Route
+    from aap_gateway_api.models.service_cluster import ServiceCluster
+    from aap_gateway_api.models.service_type import DefaultServiceType, ServiceType
+
     Route.objects.all().delete()
     cache.clear()
 
@@ -117,12 +119,18 @@ def test_cds_bootstrap_recovery_path(unauthenticated_api_client, full_service_hi
     assert "resources" not in empty_response.data or len(empty_response.data.get("resources", [])) == 0
 
     # Step 2: Create resources (operator reconciles)
-    from aap_gateway_api.models.service_cluster import ServiceCluster
-    from aap_gateway_api.models.service_type import DefaultServiceType
-    sc = ServiceCluster.objects.create(name="test-cluster", service_type=DefaultServiceType.get_or_create_controller_type())
+
+    st, _ = ServiceType.objects.get_or_create(name=DefaultServiceType.CONTROLLER.value)
+    sc = ServiceCluster.objects.create(name="test-cluster", service_type=st)
+    http_port = HTTPPort.objects.create(name="test-port-8001", number=8001)
     Route.objects.create(
-        envoy_cluster_name="test-route",
+        name="test-route",
+        http_port=http_port,
         service_cluster=sc,
+        service_port=8888,
+        gateway_path="/",
+        service_path="/",
+        is_service_https=False,
     )
 
     # Step 3: Poll again (recovery phase) — should now get non-empty response and cache it
@@ -142,8 +150,10 @@ def test_lds_bootstrap_recovery_path(unauthenticated_api_client, full_service_hi
     """LDS bootstrap → recovery: empty initially, then populated after resources created."""
     from django.core.cache import cache
 
-    # Clear all resources and cache to simulate bootstrap
-    from aap_gateway_api.models import HTTPPort
+    from aap_gateway_api.models import HTTPPort, Route
+    from aap_gateway_api.models.service_cluster import ServiceCluster
+    from aap_gateway_api.models.service_type import DefaultServiceType, ServiceType
+
     HTTPPort.objects.all().delete()
     cache.clear()
 
@@ -157,17 +167,21 @@ def test_lds_bootstrap_recovery_path(unauthenticated_api_client, full_service_hi
     assert "resources" not in empty_response.data or len(empty_response.data.get("resources", [])) == 0
 
     # Step 2: Create resources (operator reconciles)
-    from aap_gateway_api.models.service_cluster import ServiceCluster
-    from aap_gateway_api.models.service_type import DefaultServiceType
-    sc = ServiceCluster.objects.create(name="test-gw-cluster", service_type=DefaultServiceType.get_or_create_gateway_type())
-    HTTPPort.objects.create(
+    st, _ = ServiceType.objects.get_or_create(name=DefaultServiceType.GATEWAY.value)
+    sc = ServiceCluster.objects.create(name="test-gw-cluster", service_type=st)
+    http_port = HTTPPort.objects.create(
         name="port-8000",
-        port=8000,
+        number=8000,
     )
-    from aap_gateway_api.models import Route
+
     Route.objects.create(
-        envoy_cluster_name="test-gw-route",
+        name="test-gw-route",
+        http_port=http_port,
         service_cluster=sc,
+        service_port=8888,
+        gateway_path="/",
+        service_path="/",
+        is_service_https=False,
     )
 
     # Step 3: Poll again (recovery phase) — should now get non-empty response and cache it

--- a/aap_gateway_api/tests/views/api/envoy/test_rest_control_plane.py
+++ b/aap_gateway_api/tests/views/api/envoy/test_rest_control_plane.py
@@ -69,6 +69,34 @@ def test_lds_no_gateway_cluster(unauthenticated_api_client, full_service_hierarc
     assert response.status_code == 200
 
 
+@pytest.mark.django_db
+def test_cds_empty_response_not_cached_during_bootstrap(unauthenticated_api_client):
+    """CDS does not cache empty responses during bootstrap (before routes exist)."""
+    from django.core.cache import cache
+
+    cache.clear()
+    url = reverse("cds")
+    # First call with no routes in DB
+    first = unauthenticated_api_client.post(url, data={})
+    assert first.status_code == 200
+    # Cache should be empty since there are no routes
+    assert cache.get(XDS_CACHE_KEY_CDS) is None
+
+
+@pytest.mark.django_db
+def test_lds_empty_response_not_cached_during_bootstrap(unauthenticated_api_client):
+    """LDS does not cache empty responses during bootstrap (before HTTPPorts exist)."""
+    from django.core.cache import cache
+
+    cache.clear()
+    url = reverse("lds")
+    # First call with no HTTPPorts in DB
+    first = unauthenticated_api_client.post(url, data={})
+    assert first.status_code == 200
+    # Cache should be empty since there are no ports
+    assert cache.get(XDS_CACHE_KEY_LDS) is None
+
+
 @pytest.mark.parametrize(
     "setup_certs",
     [

--- a/aap_gateway_api/tests/views/api/envoy/test_rest_control_plane.py
+++ b/aap_gateway_api/tests/views/api/envoy/test_rest_control_plane.py
@@ -97,6 +97,91 @@ def test_lds_empty_response_not_cached_during_bootstrap(unauthenticated_api_clie
     assert cache.get(XDS_CACHE_KEY_LDS) is None
 
 
+@pytest.mark.django_db
+def test_cds_bootstrap_recovery_path(unauthenticated_api_client, full_service_hierarchy_controller):
+    """CDS bootstrap → recovery: empty initially, then populated after resources created."""
+    from django.core.cache import cache
+
+    # Clear all resources and cache to simulate bootstrap
+    from aap_gateway_api.models import Route
+    Route.objects.all().delete()
+    cache.clear()
+
+    url = reverse("cds")
+
+    # Step 1: Poll with empty DB (bootstrap phase)
+    empty_response = unauthenticated_api_client.post(url, data={})
+    assert empty_response.status_code == 200
+    assert cache.get(XDS_CACHE_KEY_CDS) is None  # Empty response NOT cached
+    # Verify response is truly empty (no resources)
+    assert "resources" not in empty_response.data or len(empty_response.data.get("resources", [])) == 0
+
+    # Step 2: Create resources (operator reconciles)
+    from aap_gateway_api.models.service_cluster import ServiceCluster
+    from aap_gateway_api.models.service_type import DefaultServiceType
+    sc = ServiceCluster.objects.create(name="test-cluster", service_type=DefaultServiceType.get_or_create_controller_type())
+    Route.objects.create(
+        envoy_cluster_name="test-route",
+        service_cluster=sc,
+    )
+
+    # Step 3: Poll again (recovery phase) — should now get non-empty response and cache it
+    populated_response = unauthenticated_api_client.post(url, data={})
+    assert populated_response.status_code == 200
+    # Response now has resources
+    assert "resources" in populated_response.data
+    assert len(populated_response.data.get("resources", [])) > 0
+    # Cache should now be populated
+    cached = cache.get(XDS_CACHE_KEY_CDS)
+    assert cached is not None
+    assert cached == populated_response.data
+
+
+@pytest.mark.django_db
+def test_lds_bootstrap_recovery_path(unauthenticated_api_client, full_service_hierarchy_controller):
+    """LDS bootstrap → recovery: empty initially, then populated after resources created."""
+    from django.core.cache import cache
+
+    # Clear all resources and cache to simulate bootstrap
+    from aap_gateway_api.models import HTTPPort
+    HTTPPort.objects.all().delete()
+    cache.clear()
+
+    url = reverse("lds")
+
+    # Step 1: Poll with empty DB (bootstrap phase)
+    empty_response = unauthenticated_api_client.post(url, data={})
+    assert empty_response.status_code == 200
+    assert cache.get(XDS_CACHE_KEY_LDS) is None  # Empty response NOT cached
+    # Verify response is truly empty (no resources)
+    assert "resources" not in empty_response.data or len(empty_response.data.get("resources", [])) == 0
+
+    # Step 2: Create resources (operator reconciles)
+    from aap_gateway_api.models.service_cluster import ServiceCluster
+    from aap_gateway_api.models.service_type import DefaultServiceType
+    sc = ServiceCluster.objects.create(name="test-gw-cluster", service_type=DefaultServiceType.get_or_create_gateway_type())
+    HTTPPort.objects.create(
+        name="port-8000",
+        port=8000,
+    )
+    from aap_gateway_api.models import Route
+    Route.objects.create(
+        envoy_cluster_name="test-gw-route",
+        service_cluster=sc,
+    )
+
+    # Step 3: Poll again (recovery phase) — should now get non-empty response and cache it
+    populated_response = unauthenticated_api_client.post(url, data={})
+    assert populated_response.status_code == 200
+    # Response now has resources
+    assert "resources" in populated_response.data
+    assert len(populated_response.data.get("resources", [])) > 0
+    # Cache should now be populated
+    cached = cache.get(XDS_CACHE_KEY_LDS)
+    assert cached is not None
+    assert cached == populated_response.data
+
+
 @pytest.mark.parametrize(
     "setup_certs",
     [

--- a/aap_gateway_api/views/api/envoy/rest_control_plane.py
+++ b/aap_gateway_api/views/api/envoy/rest_control_plane.py
@@ -123,7 +123,9 @@ class ClusterDiscoverServiceView(XDSView):
 
         clusters = [x.get_xds_cluster_config() for x in routes]
         response_data = self.get_xds_response(Cluster, clusters)
-        cache.set(XDS_CACHE_KEY_CDS, response_data)
+        # Only cache if we have resources; empty responses during bootstrap should not be cached
+        if clusters:
+            cache.set(XDS_CACHE_KEY_CDS, response_data)
         return Response(response_data)
 
 
@@ -153,7 +155,9 @@ class ListenerDiscoverServiceView(XDSView):
         listeners = [x.get_xds_listener_config(gateway_cluster_name=gw_cluster_name) for x in ports]
 
         response_data = self.get_xds_response(Listener, listeners)
-        cache.set(XDS_CACHE_KEY_LDS, response_data)
+        # Only cache if we have resources; empty responses during bootstrap should not be cached
+        if listeners:
+            cache.set(XDS_CACHE_KEY_LDS, response_data)
         return Response(response_data)
 
 


### PR DESCRIPTION
## Summary

Fixes **AAP-92202**: Gateway caches empty xDS responses during bootstrap, which can leave Envoy without port-8000 listener.

## Problem

During startup, Envoy polls `/v3/discovery:clusters` and `/v3/discovery:listeners` before the gateway's DB resources (HTTPPort, Route, ServiceCluster) are created. The xDS endpoints return empty responses and cache them unconditionally. Later when resources are created, the stale empty cache persists and is served instead of fresh data, leaving Envoy without a listener on port 8000.

## Solution

- Only cache CDS/LDS responses when they contain resources
- Empty responses during bootstrap are not cached
- Subsequent polls after resources are created will fetch fresh, non-empty data
- Existing cache invalidation signals still work correctly for non-empty responses

## Test Plan

- Add tests for bootstrap scenario verifying empty responses are not cached
- Existing cache hit tests verify non-empty responses are still cached
- Manual testing: Deploy gateway before DB initialization to verify Envoy can reach port 8000 after resources are created

---

Related: PR #154 (AAP-87633) which introduced xDS caching

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Empty bootstrap responses for cluster and listener discovery are no longer cached when no routes or HTTP ports are available.
  - Newly available configuration can now be returned after routes or HTTP ports are created, instead of being delayed by stale empty responses.
  - Discovery responses continue to be cached once resources are available, improving recovery during configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->