### PR TITLE
fix(envoy): redirect bare API and service paths to trailing slashes

### DIFF
--- a/aap_gateway_api/models/http_port.py
+++ b/aap_gateway_api/models/http_port.py
@@ -9,7 +9,14 @@ from django.db import models
 from django.utils.translation import gettext as _
 
 from aap_gateway_api.common.envoy import EXT_AUTH_FILTER, EXT_AUTH_PER_ROUTE
-from aap_gateway_api.utils.xds_configs import external_auth_filter, http_router_filter, network_manager_filter, path_rewrite_filter, transport_socket
+from aap_gateway_api.utils.xds_configs import (
+    external_auth_filter,
+    http_router_filter,
+    network_manager_filter,
+    path_rewrite_filter,
+    redirect_route,
+    transport_socket,
+)
 
 logger = logging.getLogger("aap_gateway_api.models.http_port")
 
@@ -73,6 +80,8 @@ class HTTPPort(UniqueNamedCommonModel, AuditableModel):
             "typed_per_filter_config": {EXT_AUTH_FILTER: {"@type": EXT_AUTH_PER_ROUTE, "disabled": True}},
         }
         routes.append(up_route)
+        if self.is_api_port:
+            routes.append(redirect_route("/api", "/api/"))
         for route in sorted(self.routes.all(), key=lambda r: r.order):
             routes.extend(route.get_xds_route_config(**kwargs))
 

--- a/aap_gateway_api/models/http_port.py
+++ b/aap_gateway_api/models/http_port.py
@@ -73,6 +73,7 @@ class HTTPPort(UniqueNamedCommonModel, AuditableModel):
         ]
 
         routes = []
+        configured_routes = sorted(self.routes.all(), key=lambda r: r.order)
         # Allow envoy to respond to /up itself without auth
         up_route = {
             "match": {"prefix": "/up"},
@@ -82,7 +83,10 @@ class HTTPPort(UniqueNamedCommonModel, AuditableModel):
         routes.append(up_route)
         if self.is_api_port:
             routes.append(redirect_route("/api", "/api/"))
-        for route in sorted(self.routes.all(), key=lambda r: r.order):
+            for svc_route in configured_routes:
+                if svc_route.gateway_path.startswith("/api/") and svc_route.gateway_path.endswith("/"):
+                    routes.append(redirect_route(svc_route.gateway_path.rstrip("/"), svc_route.gateway_path))
+        for route in configured_routes:
             routes.extend(route.get_xds_route_config(**kwargs))
 
         cfg = {

--- a/aap_gateway_api/models/http_port.py
+++ b/aap_gateway_api/models/http_port.py
@@ -89,10 +89,13 @@ class HTTPPort(UniqueNamedCommonModel, AuditableModel):
         }
         routes.append(up_route)
         if self.is_api_port:
-            routes.append(redirect_route("/api", "/api/"))
-            for svc_route in configured_routes:
-                if svc_route.gateway_path.startswith("/api/") and svc_route.gateway_path.endswith("/"):
-                    routes.append(redirect_route(svc_route.gateway_path.rstrip("/"), svc_route.gateway_path))
+            redirects = {"/api": "/api/"}
+            redirects.update(
+                (svc_route.gateway_path.rstrip("/"), svc_route.gateway_path)
+                for svc_route in configured_routes
+                if svc_route.gateway_path.startswith("/api/") and svc_route.gateway_path.endswith("/")
+            )
+            routes.extend(redirect_route(path, target) for path, target in redirects.items())
         for route in configured_routes:
             routes.extend(route.get_xds_route_config(**kwargs))
 

--- a/aap_gateway_api/models/http_port.py
+++ b/aap_gateway_api/models/http_port.py
@@ -64,7 +64,14 @@ class HTTPPort(UniqueNamedCommonModel, AuditableModel):
 
     def get_xds_listener_config(self, **kwargs):
         """
-        Returns the envoy listener configuration for this port.
+        Return the Envoy listener configuration for this port.
+
+        API ports also redirect bare ``/api`` and service API paths to their
+        trailing-slash forms without invoking external authorization.
+
+        Args:
+            **kwargs: Keyword arguments forwarded to each route's XDS
+                configuration builder.
         """
         http_filters = [
             path_rewrite_filter(),

--- a/aap_gateway_api/tests/views/api/envoy/test_xds.py
+++ b/aap_gateway_api/tests/views/api/envoy/test_xds.py
@@ -34,14 +34,29 @@ def test_xds_api_port_redirects_bare_api_to_api_slash(admin_api_client, http_api
     assert redirect["typedPerFilterConfig"]["envoy.filters.http.ext_authz"]["disabled"] is True
 
 
+def test_xds_api_port_redirects_bare_service_prefixes_to_slash(admin_api_client, service_api_route_controller):
+    response = admin_api_client.post(reverse("lds"), data={})
+    assert response.status_code == 200
+
+    listener = next(resource for resource in response.data["resources"] if resource["name"] == "port-9080")
+    routes = listener["filterChains"][0]["filters"][0]["typedConfig"]["routeConfig"]["virtualHosts"][0]["routes"]
+    bare_path = service_api_route_controller.gateway_path.rstrip("/")
+    redirect = next(route for route in routes if route["match"] == {"path": bare_path})
+
+    assert redirect["redirect"]["pathRedirect"] == service_api_route_controller.gateway_path
+    # Envoy omits MOVED_PERMANENTLY because it is the protobuf default.
+    assert redirect["redirect"].get("responseCode", "MOVED_PERMANENTLY") == "MOVED_PERMANENTLY"
+    assert redirect["typedPerFilterConfig"]["envoy.filters.http.ext_authz"]["disabled"] is True
+
+
 def test_xds_listener_discover_service_routes(unauthenticated_api_client, full_service_hierarchy_controller):
     url = reverse("lds")
     response = unauthenticated_api_client.post(url, data={})
     assert response.status_code == 200
 
     listener_routes = response.data['resources'][0]['filterChains'][0]['filters'][0]['typedConfig']['routeConfig']['virtualHosts'][0]['routes']
+    listener_routes = [route for route in listener_routes if route["match"] != {"prefix": "/up"} and "redirect" not in route]
     sc_routes = full_service_hierarchy_controller.service_cluster.routes.all()
-    listener_routes.pop(0)  # Discard /up static route
     assert sc_routes.count() > 0
     assert len(listener_routes) == sc_routes.count()
 

--- a/aap_gateway_api/tests/views/api/envoy/test_xds.py
+++ b/aap_gateway_api/tests/views/api/envoy/test_xds.py
@@ -40,6 +40,41 @@ def test_xds_api_port_redirects_bare_paths_to_slash(admin_api_client, service_ap
     assert redirect["typedPerFilterConfig"]["envoy.filters.http.ext_authz"]["disabled"] is True
 
 
+def test_xds_non_api_port_has_no_redirects(admin_api_client, http_port_factory):
+    """Non-API ports should not generate API redirects."""
+    non_api_port = http_port_factory()
+
+    response = admin_api_client.post(reverse("lds"), data={})
+    listener = next(resource for resource in response.data["resources"] if resource["name"] == f"port-{non_api_port.number}")
+    routes = listener["filterChains"][0]["filters"][0]["typedConfig"]["routeConfig"]["virtualHosts"][0]["routes"]
+
+    assert not [route for route in routes if "redirect" in route]
+
+
+def test_xds_service_route_without_trailing_slash_no_redirect(admin_api_client, service_api_route_controller):
+    """Service routes without trailing slashes should not generate redirects."""
+    service_api_route_controller.gateway_path = "/api/custom"
+    service_api_route_controller.save()
+
+    response = admin_api_client.post(reverse("lds"), data={})
+    listener = next(resource for resource in response.data["resources"] if resource["name"] == "port-9080")
+    routes = listener["filterChains"][0]["filters"][0]["typedConfig"]["routeConfig"]["virtualHosts"][0]["routes"]
+    redirects = [route for route in routes if "redirect" in route and route["match"].get("path") == "/api/custom"]
+
+    assert not redirects
+
+
+def test_xds_api_port_redirects_each_service_route(admin_api_client, service_api_route_controller, service_api_route_hub):
+    """Each service route should get its own trailing-slash redirect."""
+    response = admin_api_client.post(reverse("lds"), data={})
+    listener = next(resource for resource in response.data["resources"] if resource["name"] == "port-9080")
+    routes = listener["filterChains"][0]["filters"][0]["typedConfig"]["routeConfig"]["virtualHosts"][0]["routes"]
+    redirects = {route["match"]["path"]: route["redirect"]["pathRedirect"] for route in routes if "redirect" in route}
+
+    assert redirects[service_api_route_controller.gateway_path.rstrip("/")] == service_api_route_controller.gateway_path
+    assert redirects[service_api_route_hub.gateway_path.rstrip("/")] == service_api_route_hub.gateway_path
+
+
 def test_xds_api_port_deduplicates_api_redirect(admin_api_client, service_api_route_controller):
     """A service route at /api/ must not duplicate the bare API redirect."""
     ServiceAPIRoute.objects.filter(pk=service_api_route_controller.pk).update(gateway_path="/api/")

--- a/aap_gateway_api/tests/views/api/envoy/test_xds.py
+++ b/aap_gateway_api/tests/views/api/envoy/test_xds.py
@@ -20,6 +20,7 @@ def test_xds_listener_discover_service_httpport_count(unauthenticated_api_client
 
 @pytest.mark.parametrize("redirect_type", ["api", "service"])
 def test_xds_api_port_redirects_bare_paths_to_slash(admin_api_client, service_api_route_controller, redirect_type):
+    """Verify that bare API and service paths redirect to trailing slashes."""
     if redirect_type == "api":
         bare_path, redirect_path = "/api", "/api/"
     else:
@@ -40,6 +41,7 @@ def test_xds_api_port_redirects_bare_paths_to_slash(admin_api_client, service_ap
 
 
 def test_xds_listener_discover_service_routes(unauthenticated_api_client, full_service_hierarchy_controller):
+    """Verify that configured service routes are included in the listener."""
     url = reverse("lds")
     response = unauthenticated_api_client.post(url, data={})
     assert response.status_code == 200

--- a/aap_gateway_api/tests/views/api/envoy/test_xds.py
+++ b/aap_gateway_api/tests/views/api/envoy/test_xds.py
@@ -40,6 +40,20 @@ def test_xds_api_port_redirects_bare_paths_to_slash(admin_api_client, service_ap
     assert redirect["typedPerFilterConfig"]["envoy.filters.http.ext_authz"]["disabled"] is True
 
 
+def test_xds_api_port_deduplicates_api_redirect(admin_api_client, service_api_route_controller):
+    """A service route at /api/ must not duplicate the bare API redirect."""
+    ServiceAPIRoute.objects.filter(pk=service_api_route_controller.pk).update(gateway_path="/api/")
+
+    response = admin_api_client.post(reverse("lds"), data={})
+    assert response.status_code == 200
+
+    listener = next(resource for resource in response.data["resources"] if resource["name"] == "port-9080")
+    routes = listener["filterChains"][0]["filters"][0]["typedConfig"]["routeConfig"]["virtualHosts"][0]["routes"]
+    api_redirects = [route for route in routes if route["match"] == {"path": "/api"}]
+
+    assert len(api_redirects) == 1
+
+
 def test_xds_listener_discover_service_routes(unauthenticated_api_client, full_service_hierarchy_controller):
     """Verify that configured service routes are included in the listener."""
     url = reverse("lds")

--- a/aap_gateway_api/tests/views/api/envoy/test_xds.py
+++ b/aap_gateway_api/tests/views/api/envoy/test_xds.py
@@ -18,6 +18,22 @@ def test_xds_listener_discover_service_httpport_count(unauthenticated_api_client
     assert len(response.data['resources']) == HTTPPort.objects.all().count()
 
 
+def test_xds_api_port_redirects_bare_api_to_api_slash(admin_api_client, http_api_port_factory):
+    http_api_port_factory()
+
+    response = admin_api_client.post(reverse("lds"), data={})
+    assert response.status_code == 200
+
+    listener = next(resource for resource in response.data["resources"] if resource["name"] == "port-9080")
+    routes = listener["filterChains"][0]["filters"][0]["typedConfig"]["routeConfig"]["virtualHosts"][0]["routes"]
+    redirect = next(route for route in routes if route["match"] == {"path": "/api"})
+
+    assert redirect["redirect"]["pathRedirect"] == "/api/"
+    # Envoy omits MOVED_PERMANENTLY because it is the protobuf default.
+    assert redirect["redirect"].get("responseCode", "MOVED_PERMANENTLY") == "MOVED_PERMANENTLY"
+    assert redirect["typedPerFilterConfig"]["envoy.filters.http.ext_authz"]["disabled"] is True
+
+
 def test_xds_listener_discover_service_routes(unauthenticated_api_client, full_service_hierarchy_controller):
     url = reverse("lds")
     response = unauthenticated_api_client.post(url, data={})

--- a/aap_gateway_api/tests/views/api/envoy/test_xds.py
+++ b/aap_gateway_api/tests/views/api/envoy/test_xds.py
@@ -3,6 +3,8 @@ from django.urls import reverse
 
 from aap_gateway_api.models import AdditionalRoute, HTTPPort, ServiceAPIRoute, ServiceNode
 
+API_PORT_NAME = "port-9080"
+
 
 def test_xds_listener_discover_service_httpport_count(unauthenticated_api_client):
     """
@@ -30,7 +32,7 @@ def test_xds_api_port_redirects_bare_paths_to_slash(admin_api_client, service_ap
     response = admin_api_client.post(reverse("lds"), data={})
     assert response.status_code == 200
 
-    listener = next(resource for resource in response.data["resources"] if resource["name"] == "port-9080")
+    listener = next(resource for resource in response.data["resources"] if resource["name"] == API_PORT_NAME)
     routes = listener["filterChains"][0]["filters"][0]["typedConfig"]["routeConfig"]["virtualHosts"][0]["routes"]
     redirect = next(route for route in routes if route["match"] == {"path": bare_path})
 
@@ -57,7 +59,7 @@ def test_xds_service_route_without_trailing_slash_no_redirect(admin_api_client, 
     service_api_route_controller.save()
 
     response = admin_api_client.post(reverse("lds"), data={})
-    listener = next(resource for resource in response.data["resources"] if resource["name"] == "port-9080")
+    listener = next(resource for resource in response.data["resources"] if resource["name"] == API_PORT_NAME)
     routes = listener["filterChains"][0]["filters"][0]["typedConfig"]["routeConfig"]["virtualHosts"][0]["routes"]
     redirects = [route for route in routes if "redirect" in route and route["match"].get("path") == "/api/custom"]
 
@@ -67,7 +69,7 @@ def test_xds_service_route_without_trailing_slash_no_redirect(admin_api_client, 
 def test_xds_api_port_redirects_each_service_route(admin_api_client, service_api_route_controller, service_api_route_hub):
     """Each service route should get its own trailing-slash redirect."""
     response = admin_api_client.post(reverse("lds"), data={})
-    listener = next(resource for resource in response.data["resources"] if resource["name"] == "port-9080")
+    listener = next(resource for resource in response.data["resources"] if resource["name"] == API_PORT_NAME)
     routes = listener["filterChains"][0]["filters"][0]["typedConfig"]["routeConfig"]["virtualHosts"][0]["routes"]
     redirects = {route["match"]["path"]: route["redirect"]["pathRedirect"] for route in routes if "redirect" in route}
 
@@ -82,7 +84,7 @@ def test_xds_api_port_deduplicates_api_redirect(admin_api_client, service_api_ro
     response = admin_api_client.post(reverse("lds"), data={})
     assert response.status_code == 200
 
-    listener = next(resource for resource in response.data["resources"] if resource["name"] == "port-9080")
+    listener = next(resource for resource in response.data["resources"] if resource["name"] == API_PORT_NAME)
     routes = listener["filterChains"][0]["filters"][0]["typedConfig"]["routeConfig"]["virtualHosts"][0]["routes"]
     api_redirects = [route for route in routes if route["match"] == {"path": "/api"}]
 
@@ -96,7 +98,7 @@ def test_xds_listener_discover_service_routes(unauthenticated_api_client, full_s
     assert response.status_code == 200
 
     listener_routes = response.data['resources'][0]['filterChains'][0]['filters'][0]['typedConfig']['routeConfig']['virtualHosts'][0]['routes']
-    listener_routes = [route for route in listener_routes if route["match"] != {"prefix": "/up"} and "redirect" not in route]
+    listener_routes = [route for route in listener_routes if "directResponse" not in route and "redirect" not in route]
     sc_routes = full_service_hierarchy_controller.service_cluster.routes.all()
     assert sc_routes.count() > 0
     assert len(listener_routes) == sc_routes.count()
@@ -405,8 +407,7 @@ def get_lds_routes(admin_api_client):
     assert response.status_code == 200
     filter = response.data['resources'][0]["filterChains"][0]["filters"][0]
     for route in filter["typedConfig"]["routeConfig"]["virtualHosts"][0]["routes"]:
-        if route["match"]["prefix"] == "/up":
-            # Avoid envoy self-hosted /up route
+        if "directResponse" in route or "redirect" in route:
             continue
         routes[route["match"]["prefix"]] = route["route"]["cluster"]
     return routes

--- a/aap_gateway_api/tests/views/api/envoy/test_xds.py
+++ b/aap_gateway_api/tests/views/api/envoy/test_xds.py
@@ -18,32 +18,22 @@ def test_xds_listener_discover_service_httpport_count(unauthenticated_api_client
     assert len(response.data['resources']) == HTTPPort.objects.all().count()
 
 
-def test_xds_api_port_redirects_bare_api_to_api_slash(admin_api_client, http_api_port_factory):
-    http_api_port_factory()
+@pytest.mark.parametrize("redirect_type", ["api", "service"])
+def test_xds_api_port_redirects_bare_paths_to_slash(admin_api_client, service_api_route_controller, redirect_type):
+    if redirect_type == "api":
+        bare_path, redirect_path = "/api", "/api/"
+    else:
+        redirect_path = service_api_route_controller.gateway_path
+        bare_path = redirect_path.rstrip("/")
 
     response = admin_api_client.post(reverse("lds"), data={})
     assert response.status_code == 200
 
     listener = next(resource for resource in response.data["resources"] if resource["name"] == "port-9080")
     routes = listener["filterChains"][0]["filters"][0]["typedConfig"]["routeConfig"]["virtualHosts"][0]["routes"]
-    redirect = next(route for route in routes if route["match"] == {"path": "/api"})
-
-    assert redirect["redirect"]["pathRedirect"] == "/api/"
-    # Envoy omits MOVED_PERMANENTLY because it is the protobuf default.
-    assert redirect["redirect"].get("responseCode", "MOVED_PERMANENTLY") == "MOVED_PERMANENTLY"
-    assert redirect["typedPerFilterConfig"]["envoy.filters.http.ext_authz"]["disabled"] is True
-
-
-def test_xds_api_port_redirects_bare_service_prefixes_to_slash(admin_api_client, service_api_route_controller):
-    response = admin_api_client.post(reverse("lds"), data={})
-    assert response.status_code == 200
-
-    listener = next(resource for resource in response.data["resources"] if resource["name"] == "port-9080")
-    routes = listener["filterChains"][0]["filters"][0]["typedConfig"]["routeConfig"]["virtualHosts"][0]["routes"]
-    bare_path = service_api_route_controller.gateway_path.rstrip("/")
     redirect = next(route for route in routes if route["match"] == {"path": bare_path})
 
-    assert redirect["redirect"]["pathRedirect"] == service_api_route_controller.gateway_path
+    assert redirect["redirect"]["pathRedirect"] == redirect_path
     # Envoy omits MOVED_PERMANENTLY because it is the protobuf default.
     assert redirect["redirect"].get("responseCode", "MOVED_PERMANENTLY") == "MOVED_PERMANENTLY"
     assert redirect["typedPerFilterConfig"]["envoy.filters.http.ext_authz"]["disabled"] is True

--- a/aap_gateway_api/utils/xds_configs.py
+++ b/aap_gateway_api/utils/xds_configs.py
@@ -53,6 +53,10 @@ def http_router_filter():
 def redirect_route(path, redirect_path):
     """Build an unauthenticated permanent Envoy path redirect.
 
+    Redirects bypass external authentication to normalize request paths before
+    authentication and routing. This follows the same pattern as the /up health
+    check route.
+
     Args:
         path: Request path to match.
         redirect_path: Destination path for the redirect.

--- a/aap_gateway_api/utils/xds_configs.py
+++ b/aap_gateway_api/utils/xds_configs.py
@@ -2,6 +2,8 @@ from django.conf import settings
 
 from aap_gateway_api.common.envoy import (
     DOWNSTREAM_TLS_CONTEXT,
+    EXT_AUTH_FILTER,
+    EXT_AUTH_PER_ROUTE,
     EXT_AUTHZ_FILTER,
     HTTP_CONNECTION_MANAGER,
     HTTP_ROUTER,
@@ -46,6 +48,14 @@ def external_auth_filter():
 
 def http_router_filter():
     return {"name": "envoy.filters.http.router", "typed_config": {"@type": HTTP_ROUTER}}
+
+
+def redirect_route(path, redirect_path):
+    return {
+        "match": {"path": path},
+        "redirect": {"path_redirect": redirect_path, "response_code": "MOVED_PERMANENTLY"},
+        "typed_per_filter_config": {EXT_AUTH_FILTER: {"@type": EXT_AUTH_PER_ROUTE, "disabled": True}},
+    }
 
 
 def network_manager_filter(http_filters=[], routes=[]):

--- a/aap_gateway_api/utils/xds_configs.py
+++ b/aap_gateway_api/utils/xds_configs.py
@@ -51,6 +51,12 @@ def http_router_filter():
 
 
 def redirect_route(path, redirect_path):
+    """Build an unauthenticated permanent Envoy path redirect.
+
+    Args:
+        path: Request path to match.
+        redirect_path: Destination path for the redirect.
+    """
     return {
         "match": {"path": path},
         "redirect": {"path_redirect": redirect_path, "response_code": "MOVED_PERMANENTLY"},


### PR DESCRIPTION
## Description

This pull request updates Envoy route generation so requests to bare API paths are redirected to their canonical trailing-slash paths.

- Adds a permanent redirect from `/api` to `/api/` on API ports.
- Adds permanent redirects from bare service API paths (for example, `/api/controller`) to their configured slash-terminated paths (for example, `/api/controller/`).
- Disables gateway external authentication for these redirect routes so clients can be normalized before authentication and proxy handling.
- Adds parameterized xDS coverage for API and service-path redirects and updates existing route-count assertions to ignore generated utility and redirect routes.

This prevents bare API and service URLs from bypassing the route shape expected by Envoy and downstream services, while keeping the redirect behavior consistent with the configured route paths.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites

- A working Python 3.12 tox environment.
- A PostgreSQL instance available using the repository's test settings. The test runner expects PostgreSQL on `localhost:5432` with the configured test credentials.

### Steps to Test

1. Start PostgreSQL and ensure it is reachable using the repository's normal test configuration.
2. From the repository root, run:
   ```bash
   GATEWAY_TEST_DIRS="" tox -e py312 -- aap_gateway_api/tests/views/api/envoy/test_xds.py -k "redirects_bare_paths_to_slash or listener_discover_service_routes" -v
   ```
3. Inspect the generated xDS listener routes, or run the full Envoy xDS test file if broader coverage is desired.

### Expected Results

- The parameterized redirect test passes for both `/api` and a configured service route.
- Each redirect uses Envoy's `MOVED_PERMANENTLY` response code, points to the trailing-slash path, and disables external authentication for the redirect.
- Existing service route discovery tests continue to pass after excluding the generated `/up` and redirect routes from route-count assertions.

The targeted test command was attempted locally but could not complete because PostgreSQL was not running on `localhost:5432`.

## Additional Context

The implementation sorts configured routes once, emits the API-base redirect and service-route redirects before the configured route definitions, and leaves the existing `/up` route behavior unchanged.

### Required Actions

- [ ] Requires documentation updates
- [ ] Requires downstream repository changes
- [ ] Requires infrastructure/deployment changes
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: #XXX

### Screenshots/Logs

Not applicable; this change affects generated Envoy xDS configuration rather than a user interface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added permanent redirects from `/api` to `/api/`.
  * Added redirects from API paths without trailing slashes to their slash-suffixed equivalents.
  * Redirect responses bypass external authorization checks to normalize paths before authentication and routing.

* **Bug Fixes**
  * Improved route handling so redirects are applied consistently while preserving existing service routes.
  * Limited trailing-slash redirects to API ports and applicable service paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->